### PR TITLE
Guard getBatteryPercentage() against invalid scale (#10)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/model/BatteryDO.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/model/BatteryDO.java
@@ -25,6 +25,12 @@ public final class BatteryDO {
 	 * @return Battery percentage (0-100)
 	 */
 	public float getBatteryPercentage() {
+		// Guard against a missing/invalid scale. BatteryManager defaults scale to -1 when
+		// unavailable; dividing by 0 or a negative scale would yield Infinity/NaN, which then
+		// becomes Integer.MAX_VALUE once callers cast to int and breaks threshold comparisons.
+		if (scale <= 0) {
+			return 0f;
+		}
 		return (level / (float) scale) * 100;
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/model/BatteryDOTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/model/BatteryDOTest.java
@@ -45,14 +45,21 @@ public class BatteryDOTest {
 	}
 
 	/**
-	 * CRITICAL EDGE CASE: Division by zero
-	 * This tests actual error condition that could happen with malformed battery data
+	 * CRITICAL EDGE CASE: Division by zero / invalid scale
+	 * A zero (or negative) scale is malformed battery data. It must be guarded so it never
+	 * produces Infinity/NaN, which would become Integer.MAX_VALUE when cast to int downstream.
 	 */
 	@Test
-	public void getBatteryPercentage_scaleZero_returnsInfinity() {
+	public void getBatteryPercentage_scaleZero_returnsZero() {
 		battery.setLevel(50).setScale(0);
 		final float result = battery.getBatteryPercentage();
-		assertTrue("Division by zero should produce infinity", Float.isInfinite(result));
+		assertEquals("Invalid scale must be guarded, not produce Infinity", 0.0f, result, 0.01f);
+	}
+
+	@Test
+	public void getBatteryPercentage_negativeScale_returnsZero() {
+		battery.setLevel(50).setScale(-1);
+		assertEquals("Negative scale must be guarded", 0.0f, battery.getBatteryPercentage(), 0.01f);
 	}
 
 	/**


### PR DESCRIPTION
Closes #10. Guards `scale <= 0` so it can't return Infinity/NaN (which became Integer.MAX_VALUE when cast to int). Independent (off master). Build + unit tests green.