### PR TITLE
Gate the battery-health debug menu to debuggable builds (#14)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -1,6 +1,7 @@
 package com.almothafar.simplebatterynotifier.ui;
 
 import android.app.AlertDialog;
+import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -99,6 +100,12 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 * DEBUG feature for testing battery health tracking.
 	 */
 	private void setupDebugMenu() {
+		// Debug tools (inject/reset cycles) must not be reachable in release builds, where a
+		// long-press could let a user silently corrupt their tracked health data.
+		final boolean debuggable = (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+		if (!debuggable) {
+			return;
+		}
 		healthPercentageText.setOnLongClickListener(v -> {
 			showDebugMenu();
 			return true;


### PR DESCRIPTION
Closes #14. The long-press debug menu (inject/reset test cycles) no longer ships in release builds, where it let users corrupt their tracked health data. Independent (off master). Build green.