### PR TITLE
Run battery monitoring in a foreground service + persistent notification (#5)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
     <uses-permission
             android:name="android.permission.POST_NOTIFICATIONS"
             tools:targetApi="33"/>
+    <!-- Foreground service keeps battery monitoring alive when the app is closed -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission
+            android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
+            tools:targetApi="34"/>
 
     <application
             android:allowBackup="true"
@@ -28,11 +33,16 @@
             </intent-filter>
         </activity>
 
-        <!-- Service kept internal -->
+        <!-- Foreground service: keeps battery monitoring alive in the background -->
         <service
                 android:name=".service.PowerConnectionService"
                 android:enabled="true"
-                android:exported="false"/>
+                android:exported="false"
+                android:foregroundServiceType="specialUse">
+            <property
+                    android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                    android:value="Continuous battery-level monitoring to deliver low, critical and full-charge alerts while the app is closed."/>
+        </service>
 
         <!-- Boot receiver: exported so system can deliver the broadcast on 12+ -->
         <receiver

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -56,6 +56,9 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		final BatteryDO batteryDO = SystemService.getBatteryInfo(context);
 		final int percentage = batteryDO == null ? 100 : (int) batteryDO.getBatteryPercentage();
 
+		// Keep the persistent foreground-service status notification live with the latest reading
+		NotificationService.updateOngoingNotification(context, batteryDO);
+
 		// Track battery health and charge cycles
 		BatteryHealthTracker.recordBatteryState(context, percentage, status);
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -14,12 +14,14 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.media.AudioManager;
 import android.net.Uri;
+import android.os.BatteryManager;
 import android.os.Build;
 import android.provider.Settings;
 import android.util.Log;
 import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceManager;
 import com.almothafar.simplebatterynotifier.R;
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.ui.MainActivity;
 import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 
@@ -59,10 +61,13 @@ public final class NotificationService {
 	private static final String CHANNEL_ID_CRITICAL = "battery_critical";
 	private static final String CHANNEL_ID_WARNING = "battery_warning";
 	private static final String CHANNEL_ID_FULL = "battery_full";
+	private static final String CHANNEL_ID_STATUS = "battery_status";
 
 	// Notification settings
 	private static final long[] VIBRATION_PATTERN = {0, 500, 250, 500, 250};
 	private static final int NOTIFICATION_ID = 1641987;
+	// Separate ID for the persistent foreground-service status notification
+	private static final int ONGOING_NOTIFICATION_ID = 1641988;
 
 	// Do Not Disturb mode constants
 	private static final String ZEN_MODE = "zen_mode";
@@ -179,6 +184,60 @@ public final class NotificationService {
 	}
 
 	/**
+	 * ID of the persistent status notification (used by the foreground service).
+	 *
+	 * @return The ongoing notification ID
+	 */
+	public static int getOngoingNotificationId() {
+		return ONGOING_NOTIFICATION_ID;
+	}
+
+	/**
+	 * Build the persistent (ongoing) battery-status notification shown by the foreground service.
+	 * <p>
+	 * This is a low-importance, silent, non-dismissible notification that displays the live
+	 * battery percentage, charging state and temperature (AccuBattery-style). It keeps the
+	 * monitoring service alive so alerts are delivered even when the app is closed.
+	 *
+	 * @param context   The application context
+	 * @param batteryDO Current battery snapshot, or null if unavailable
+	 * @return The built ongoing notification
+	 */
+	public static Notification buildOngoingNotification(final Context context, final BatteryDO batteryDO) {
+		createNotificationChannels(context);
+
+		return new Notification.Builder(context, CHANNEL_ID_STATUS)
+				.setSmallIcon(ongoingIconRes(batteryDO))
+				.setContentTitle(context.getString(R.string.app_name))
+				.setContentText(statusText(context, batteryDO))
+				.setContentIntent(createMainActivityIntent(context))
+				.setOnlyAlertOnce(true)
+				.setOngoing(true)
+				.setVisibility(Notification.VISIBILITY_PUBLIC)
+				.setCategory(Notification.CATEGORY_STATUS)
+				.build();
+	}
+
+	/**
+	 * Refresh the persistent status notification with the latest battery data.
+	 * <p>
+	 * Called whenever the battery state changes so the ongoing notification stays live.
+	 * Uses the same notification ID as the foreground service, so it updates in place.
+	 *
+	 * @param context   The application context
+	 * @param batteryDO Current battery snapshot, or null if unavailable
+	 */
+	public static void updateOngoingNotification(final Context context, final BatteryDO batteryDO) {
+		if (lacksNotificationPermission(context)) {
+			return;
+		}
+		final NotificationManager manager = getNotificationManager(context);
+		if (nonNull(manager)) {
+			manager.notify(ONGOING_NOTIFICATION_ID, buildOngoingNotification(context, batteryDO));
+		}
+	}
+
+	/**
 	 * Set healthy charge mode
 	 * <p>
 	 * Thread-safe setter for the healthy charge state flag.
@@ -254,6 +313,34 @@ public final class NotificationService {
 		createChannelIfNotExists(manager, CHANNEL_ID_CRITICAL, "Battery Critical Alerts", "Critical battery level alerts", Color.RED);
 		createChannelIfNotExists(manager, CHANNEL_ID_WARNING, "Battery Warnings", "Battery warning notifications", Color.rgb(0xff, 0x66, 0x00));
 		createChannelIfNotExists(manager, CHANNEL_ID_FULL, "Battery Full", "Battery fully charged notifications", Color.GREEN);
+		createStatusChannelIfNotExists(manager,
+				context.getString(R.string.notification_status_channel_name),
+				context.getString(R.string.notification_status_channel_description));
+	}
+
+	/**
+	 * Create the low-importance channel used by the persistent status notification.
+	 * <p>
+	 * Unlike the alert channels, this channel is silent (no sound, vibration, lights or badge)
+	 * so the ongoing battery-status notification stays unobtrusive.
+	 *
+	 * @param manager     The NotificationManager
+	 * @param name        The channel name
+	 * @param description The channel description
+	 */
+	private static void createStatusChannelIfNotExists(final NotificationManager manager, final String name,
+	                                                   final String description) {
+		if (nonNull(manager.getNotificationChannel(CHANNEL_ID_STATUS))) {
+			return;
+		}
+
+		final NotificationChannel channel = new NotificationChannel(CHANNEL_ID_STATUS, name, NotificationManager.IMPORTANCE_LOW);
+		channel.setDescription(description);
+		channel.enableLights(false);
+		channel.enableVibration(false);
+		channel.setSound(null, null);
+		channel.setShowBadge(false);
+		manager.createNotificationChannel(channel);
 	}
 
 	/**
@@ -352,11 +439,25 @@ public final class NotificationService {
 	 * @param config  The notification configuration
 	 */
 	private static void playSoundIfNeeded(final Context context, final NotificationConfig config) {
-		if (!config.withinTime) {
+		playAlarm(context, config.alarmSound, config.withinTime, config.ignoreSilent);
+	}
+
+	/**
+	 * Play the alert sound (and vibrate) when the phone is silenced but the user opted to
+	 * override silent mode. In normal ringer mode the notification channel plays its own sound.
+	 *
+	 * @param context      The application context
+	 * @param soundUriStr  The alarm sound URI string
+	 * @param withinTime   Whether the current time is inside the allowed notification window
+	 * @param ignoreSilent Whether the user opted to override silent/DND mode
+	 */
+	private static void playAlarm(final Context context, final String soundUriStr,
+	                              final boolean withinTime, final boolean ignoreSilent) {
+		if (!withinTime) {
 			return;
 		}
 
-		final Uri soundUri = Uri.parse(config.alarmSound);
+		final Uri soundUri = Uri.parse(soundUriStr);
 		final AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
 		if (isNull(audioManager)) {
 			return;
@@ -364,12 +465,42 @@ public final class NotificationService {
 
 		final boolean isNotNormalRingerMode = audioManager.getRingerMode() != AudioManager.RINGER_MODE_NORMAL || isInDoNotDisturbMode(context);
 
-		if (config.ignoreSilent && isNotNormalRingerMode) {
+		if (ignoreSilent && isNotNormalRingerMode) {
 			soundExecutor.execute(() -> {
 				SystemService.playSound(context, soundUri);
 				SystemService.vibratePhone(context);
 			});
 		}
+	}
+
+	/**
+	 * Whether the current time falls inside the user's allowed notification window
+	 * (always true when the time-range limit is disabled).
+	 *
+	 * @param context The application context
+	 * @param prefs   SharedPreferences containing user settings
+	 * @return true if alerts are allowed at the current time
+	 */
+	private static boolean isWithinNotificationWindow(final Context context, final SharedPreferences prefs) {
+		final boolean limitedTime = prefs.getBoolean(context.getString(R.string._pref_key_notifications_time_range), false);
+		final String startTime = prefs.getString(
+				context.getString(R.string._pref_key_notifications_time_range_start),
+				context.getString(R.string._pref_value_notifications_time_range_start));
+		final String endTime = prefs.getString(
+				context.getString(R.string._pref_key_notifications_time_range_end),
+				context.getString(R.string._pref_value_notifications_time_range_end));
+		return isWithinTime(startTime, endTime) || !limitedTime;
+	}
+
+	/**
+	 * Whether the user opted to override silent/DND mode for alerts.
+	 *
+	 * @param context The application context
+	 * @param prefs   SharedPreferences containing user settings
+	 * @return true if silent mode should be overridden
+	 */
+	private static boolean shouldIgnoreSilentMode(final Context context, final SharedPreferences prefs) {
+		return !prefs.getBoolean(context.getString(R.string._pref_key_notifications_apply_silent_mode), false);
 	}
 
 	/**
@@ -465,6 +596,78 @@ public final class NotificationService {
 	}
 
 	/**
+	 * Build the content line of the ongoing status notification, e.g. "85% · Discharging · 32.0 °C".
+	 *
+	 * @param context   The application context
+	 * @param batteryDO Current battery snapshot, or null if unavailable
+	 * @return Formatted status text
+	 */
+	private static String statusText(final Context context, final BatteryDO batteryDO) {
+		final int percentage = isNull(batteryDO) ? 0 : Math.round(batteryDO.getBatteryPercentage());
+		final String statusLabel = statusLabel(context, isNull(batteryDO) ? -1 : batteryDO.getStatus());
+		final String temperature = isNull(batteryDO) ? "" : formatTemperature(context, batteryDO.getTemperature());
+		return context.getString(R.string.notification_status_content, percentage, statusLabel, temperature);
+	}
+
+	/**
+	 * Map a BatteryManager status constant to a localized label.
+	 *
+	 * @param context The application context
+	 * @param status  BatteryManager status constant
+	 * @return Localized status label
+	 */
+	private static String statusLabel(final Context context, final int status) {
+		return switch (status) {
+			case BatteryManager.BATTERY_STATUS_FULL -> context.getString(R.string.charged);
+			case BatteryManager.BATTERY_STATUS_CHARGING -> context.getString(R.string.charging);
+			case BatteryManager.BATTERY_STATUS_NOT_CHARGING -> context.getString(R.string.not_charging);
+			case BatteryManager.BATTERY_STATUS_DISCHARGING -> context.getString(R.string.discharging);
+			default -> context.getString(R.string.unknown);
+		};
+	}
+
+	/**
+	 * Format the battery temperature respecting the user's unit preference (°C/°F).
+	 *
+	 * @param context     The application context
+	 * @param rawTenthsC  Temperature in tenths of a degree Celsius (as reported by BatteryManager)
+	 * @return Formatted temperature with unit suffix
+	 */
+	private static String formatTemperature(final Context context, final int rawTenthsC) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		final String unit = prefs.getString(
+				context.getString(R.string._pref_key_temperatures_unit),
+				context.getString(R.string._pref_value_temperatures_unit_c));
+
+		float temperature = rawTenthsC / 10f;
+		String suffix = context.getString(R.string.celsius_short);
+		if (unit.equalsIgnoreCase(context.getString(R.string._pref_value_temperatures_unit_f))) {
+			temperature = GeneralHelper.fromCtoF(temperature);
+			suffix = context.getString(R.string.fahrenheit_short);
+		}
+		return temperature + " " + suffix;
+	}
+
+	/**
+	 * Choose a small icon for the ongoing notification based on charging state and level.
+	 *
+	 * @param batteryDO Current battery snapshot, or null if unavailable
+	 * @return Drawable resource id
+	 */
+	private static int ongoingIconRes(final BatteryDO batteryDO) {
+		if (isNull(batteryDO)) {
+			return R.drawable.ic_stat_device_battery_charging_50;
+		}
+		final int status = batteryDO.getStatus();
+		if (status == BatteryManager.BATTERY_STATUS_FULL || status == BatteryManager.BATTERY_STATUS_CHARGING) {
+			return R.drawable.ic_stat_device_battery_charging_full;
+		}
+		return Math.round(batteryDO.getBatteryPercentage()) <= 50
+		       ? R.drawable.ic_stat_device_battery_charging_20
+		       : R.drawable.ic_stat_device_battery_charging_50;
+	}
+
+	/**
 	 * Configuration object for notification creation (reduces parameter count)
 	 * <p>
 	 * This class encapsulates all configuration needed to build a notification,
@@ -496,19 +699,10 @@ public final class NotificationService {
 			// Load common preferences
 			final int warningLevel = prefs.getInt(context.getString(R.string._pref_key_warn_battery_level), 40);
 			final int criticalLevel = prefs.getInt(context.getString(R.string._pref_key_critical_battery_level), 20);
-			final boolean limitedTime = prefs.getBoolean(context.getString(R.string._pref_key_notifications_time_range), false);
-			final String startTime = prefs.getString(
-					context.getString(R.string._pref_key_notifications_time_range_start),
-					context.getString(R.string._pref_value_notifications_time_range_start)
-			);
-			final String endTime = prefs.getString(
-					context.getString(R.string._pref_key_notifications_time_range_end),
-					context.getString(R.string._pref_value_notifications_time_range_end)
-			);
 
 			this.stickyNotification = prefs.getBoolean(context.getString(R.string._pref_key_notifications_sticky), false);
-			this.withinTime = isWithinTime(startTime, endTime) || !limitedTime;
-			this.ignoreSilent = !prefs.getBoolean(context.getString(R.string._pref_key_notifications_apply_silent_mode), false);
+			this.withinTime = isWithinNotificationWindow(context, prefs);
+			this.ignoreSilent = shouldIgnoreSilentMode(context, prefs);
 
 			final String defaultSound = context.getString(R.string._default_notification_sound_uri);
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/PowerConnectionService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/PowerConnectionService.java
@@ -1,14 +1,18 @@
 package com.almothafar.simplebatterynotifier.service;
 
+import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.ServiceInfo;
 import android.os.BatteryManager;
+import android.os.Build;
 import android.os.IBinder;
+import androidx.core.app.ServiceCompat;
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver;
 import com.almothafar.simplebatterynotifier.receiver.PowerConnectionReceiver;
 
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 /**
@@ -27,6 +31,9 @@ public class PowerConnectionService extends Service {
 
 	@Override
 	public void onCreate() {
+		super.onCreate();
+		// Promote to foreground first so the OS keeps the process (and our receivers) alive on Android 8+.
+		startForegroundWithStatus();
 		registerPowerConnectionReceiver();
 	}
 
@@ -38,7 +45,28 @@ public class PowerConnectionService extends Service {
 
 	@Override
 	public int onStartCommand(final Intent intent, final int flags, final int startId) {
+		// Re-assert the foreground notification (e.g. after a START_STICKY restart delivers a null intent).
+		startForegroundWithStatus();
 		return START_STICKY;
+	}
+
+	/**
+	 * Promote this service to the foreground with the persistent battery-status notification.
+	 * <p>
+	 * Required on Android 8+: a plain background service (and its runtime-registered battery
+	 * receivers) is reaped shortly after the app leaves the foreground. The ongoing notification
+	 * keeps monitoring alive so alerts are delivered while the app is closed.
+	 */
+	private void startForegroundWithStatus() {
+		final BatteryDO batteryDO = SystemService.getBatteryInfo(this);
+		final Notification notification = NotificationService.buildOngoingNotification(this, batteryDO);
+
+		// The specialUse FGS type only exists from Android 14 (API 34); pass 0 on older versions.
+		final int serviceType = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+		                        ? ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+		                        : 0;
+
+		ServiceCompat.startForeground(this, NotificationService.getOngoingNotificationId(), notification, serviceType);
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -139,8 +139,9 @@ public class MainActivity extends BaseActivity {
 		// Set up button click listeners
 		batteryInsightsButton.setOnClickListener(v -> openBatteryInsights());
 
-		// Start the power connection service
-		startService(new Intent(this, PowerConnectionService.class));
+		// Start the power connection service as a foreground service so monitoring
+		// survives the app being closed (required on Android 8+).
+		ContextCompat.startForegroundService(this, new Intent(this, PowerConnectionService.class));
 	}
 
 	/**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,12 @@
     <string name="notification_charge_started_title_regular">Regular charging started</string>
     <string name="notification_charge_started_content">Battery charging with %1$s </string>
 
+    <!-- Persistent foreground-service status notification -->
+    <string name="notification_status_channel_name">Battery Status</string>
+    <string name="notification_status_channel_description">Ongoing battery status while monitoring is active</string>
+    <!-- e.g. "85% · Discharging · 32.0 °C" -->
+    <string name="notification_status_content">%1$d%% · %2$s · %3$s</string>
+
     <!-- Battery Insights Screen -->
     <string name="battery_insights_title">Battery Insights</string>
     <string name="battery_insights_menu">Battery Insights</string>


### PR DESCRIPTION
Closes #5. The critical fix: monitoring receivers were hosted by a plain background Service that Android 8+ reaps, so alerts only fired while the app was open. PowerConnectionService is now a foreground service with a low-importance, silent ongoing notification showing live `% · status · temp` (the AccuBattery-style persistent notification).

**Base of the stack** (the temp/#6/#9/#11/#13/#16 PRs build on this). Build green.