### PR TITLE
Fix quiet-hours edge cases and add tests (#13)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -26,7 +26,7 @@ import com.almothafar.simplebatterynotifier.ui.MainActivity;
 import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 
 import java.lang.ref.WeakReference;
-import java.util.Calendar;
+import java.time.LocalTime;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -615,8 +615,8 @@ public final class NotificationService {
 	 * @return true if current time is within range
 	 */
 	private static boolean isWithinTime(final String startTime, final String endTime) {
-		final Calendar now = Calendar.getInstance();
-		final int nowMinutes = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE);
+		final LocalTime now = LocalTime.now();
+		final int nowMinutes = now.getHour() * 60 + now.getMinute();
 		final int startMinutes = GeneralHelper.getHour(startTime) * 60 + GeneralHelper.getMinute(startTime);
 		final int endMinutes = GeneralHelper.getHour(endTime) * 60 + GeneralHelper.getMinute(endTime);
 		return isWithinTimeRange(nowMinutes, startMinutes, endMinutes);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -27,7 +27,6 @@ import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 
 import java.lang.ref.WeakReference;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -616,29 +615,38 @@ public final class NotificationService {
 	 * @return true if current time is within range
 	 */
 	private static boolean isWithinTime(final String startTime, final String endTime) {
-		final int startHour = GeneralHelper.getHour(startTime);
-		final int startMinute = GeneralHelper.getMinute(startTime);
-		final int endHour = GeneralHelper.getHour(endTime);
-		final int endMinute = GeneralHelper.getMinute(endTime);
+		final Calendar now = Calendar.getInstance();
+		final int nowMinutes = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE);
+		final int startMinutes = GeneralHelper.getHour(startTime) * 60 + GeneralHelper.getMinute(startTime);
+		final int endMinutes = GeneralHelper.getHour(endTime) * 60 + GeneralHelper.getMinute(endTime);
+		return isWithinTimeRange(nowMinutes, startMinutes, endMinutes);
+	}
 
-		final Date currentTime = new Date();
-
-		final Calendar startCal = Calendar.getInstance();
-		startCal.setTime(currentTime);
-		startCal.set(Calendar.HOUR_OF_DAY, startHour);
-		startCal.set(Calendar.MINUTE, startMinute);
-
-		final Calendar endCal = Calendar.getInstance();
-		endCal.setTime(currentTime);
-		endCal.set(Calendar.HOUR_OF_DAY, endHour);
-		endCal.set(Calendar.MINUTE, endMinute);
-
-		// Handle overnight time ranges (e.g., 8:00 PM to 6:00 AM)
-		if (endHour <= startHour) {
-			endCal.add(Calendar.DATE, 1);
+	/**
+	 * Pure minute-of-day range check. Handles same-day, overnight and equal-times windows
+	 * (the previous implementation ignored minutes and mishandled overnight ranges that shared
+	 * the same hour bucket).
+	 * <ul>
+	 *   <li>start &lt; end: inside when {@code start <= now < end} (e.g. 08:00–23:00).</li>
+	 *   <li>start &gt; end: overnight window, inside when {@code now >= start || now < end} (e.g. 22:00–06:00).</li>
+	 *   <li>start == end: treated as a 24-hour window (always inside).</li>
+	 * </ul>
+	 * Start is inclusive, end is exclusive.
+	 *
+	 * @param nowMinutes   Current time as minutes since midnight
+	 * @param startMinutes Window start as minutes since midnight
+	 * @param endMinutes   Window end as minutes since midnight
+	 * @return true if now falls inside the window
+	 */
+	static boolean isWithinTimeRange(final int nowMinutes, final int startMinutes, final int endMinutes) {
+		if (startMinutes == endMinutes) {
+			return true; // Whole day
 		}
-
-		return currentTime.after(startCal.getTime()) && currentTime.before(endCal.getTime());
+		if (startMinutes < endMinutes) {
+			return nowMinutes >= startMinutes && nowMinutes < endMinutes;
+		}
+		// Overnight window wraps past midnight
+		return nowMinutes >= startMinutes || nowMinutes < endMinutes;
 	}
 
 	/**

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
@@ -1,0 +1,74 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the pure quiet-hours range logic in {@link NotificationService}.
+ * Times are expressed as minutes since midnight (hour * 60 + minute).
+ */
+public class NotificationServiceTest {
+
+	// Daytime window 08:00 (480) – 23:00 (1380)
+	private static final int DAY_START = 8 * 60;
+	private static final int DAY_END = 23 * 60;
+
+	// Overnight window 22:00 (1320) – 06:00 (360)
+	private static final int NIGHT_START = 22 * 60;
+	private static final int NIGHT_END = 6 * 60;
+
+	@Test
+	public void daytime_inside() {
+		assertTrue(NotificationService.isWithinTimeRange(10 * 60, DAY_START, DAY_END));
+	}
+
+	@Test
+	public void daytime_beforeStart_excluded() {
+		assertFalse(NotificationService.isWithinTimeRange(6 * 60 + 40, DAY_START, DAY_END));
+	}
+
+	@Test
+	public void daytime_startIsInclusive() {
+		assertTrue(NotificationService.isWithinTimeRange(DAY_START, DAY_START, DAY_END));
+	}
+
+	@Test
+	public void daytime_endIsExclusive() {
+		assertFalse(NotificationService.isWithinTimeRange(DAY_END, DAY_START, DAY_END));
+	}
+
+	@Test
+	public void overnight_lateNight_inside() {
+		assertTrue(NotificationService.isWithinTimeRange(22 * 60 + 30, NIGHT_START, NIGHT_END));
+	}
+
+	@Test
+	public void overnight_earlyMorning_inside() {
+		assertTrue(NotificationService.isWithinTimeRange(2 * 60, NIGHT_START, NIGHT_END));
+	}
+
+	@Test
+	public void overnight_midday_outside() {
+		assertFalse(NotificationService.isWithinTimeRange(12 * 60, NIGHT_START, NIGHT_END));
+	}
+
+	/**
+	 * Overnight window whose start/end share the same hour bucket, e.g. 22:30 → 22:00.
+	 * The old hour-only logic mishandled this; the minute-based logic must not.
+	 */
+	@Test
+	public void overnight_sameHourBucket() {
+		final int start = 22 * 60 + 30; // 22:30
+		final int end = 22 * 60;        // 22:00
+		assertTrue(NotificationService.isWithinTimeRange(23 * 60 + 30, start, end));  // 23:30 inside
+		assertFalse(NotificationService.isWithinTimeRange(22 * 60 + 15, start, end)); // 22:15 outside
+	}
+
+	@Test
+	public void equalTimes_meansWholeDay() {
+		assertTrue(NotificationService.isWithinTimeRange(0, 10 * 60, 10 * 60));
+		assertTrue(NotificationService.isWithinTimeRange(23 * 60 + 59, 10 * 60, 10 * 60));
+	}
+}


### PR DESCRIPTION
Closes #13. Reworked isWithinTime around minutes-of-day with a pure, unit-tested isWithinTimeRange (same-day / overnight / equal-times / boundaries).

**Stacked on #11** (base: `pr/11-receiver-null`). Build + unit tests green.