### PR TITLE
Use the OS-reported charge cycle count where available (part of #7)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -111,6 +111,24 @@ public class BatteryHealthTracker {
 	}
 
 	/**
+	 * Gets the best-available charge cycle count: the OS-reported value where the device exposes it
+	 * (Android 14+ {@code EXTRA_CYCLE_COUNT}), otherwise this app's own tracked estimate.
+	 * <p>
+	 * Used for both the displayed cycle count and the health estimate so the two stay consistent.
+	 *
+	 * @param context Application context
+	 *
+	 * @return Charge cycle count (OS-reported if available, else the tracked estimate)
+	 */
+	public static int getEffectiveCycleCount(final Context context) {
+		if (isNull(context)) {
+			return 0;
+		}
+		final int osCycleCount = SystemService.getChargeCycleCount(context);
+		return osCycleCount > 0 ? osCycleCount : getChargeCycles(context);
+	}
+
+	/**
 	 * Gets the date when health tracking was first initialized.
 	 *
 	 * @param context Application context
@@ -154,7 +172,7 @@ public class BatteryHealthTracker {
 	 * @return Estimated battery health percentage (0-100)
 	 */
 	public static int getEstimatedHealthPercentage(final Context context) {
-		final int cycles = getChargeCycles(context);
+		final int cycles = getEffectiveCycleCount(context);
 
 		// Excellent health: 0-300 cycles (100% to 95%)
 		if (cycles < EXCELLENT_THRESHOLD) {
@@ -189,7 +207,7 @@ public class BatteryHealthTracker {
 	 * @return Health status: "Excellent", "Good", "Fair", or "Poor"
 	 */
 	public static String getHealthStatus(final Context context) {
-		final int cycles = getChargeCycles(context);
+		final int cycles = getEffectiveCycleCount(context);
 
 		if (cycles < EXCELLENT_THRESHOLD) {
 			return "Excellent";
@@ -210,7 +228,7 @@ public class BatteryHealthTracker {
 	 * @return Detailed health description
 	 */
 	public static String getHealthDescription(final Context context) {
-		final int cycles = getChargeCycles(context);
+		final int cycles = getEffectiveCycleCount(context);
 
 		if (cycles < EXCELLENT_THRESHOLD) {
 			return "Your battery is in excellent condition. Continue with normal usage patterns.";

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -253,6 +253,28 @@ public final class SystemService {
 	}
 
 	/**
+	 * Read the OS-reported charge cycle count, where available.
+	 * <p>
+	 * Exposed to apps via the public {@link BatteryManager#EXTRA_CYCLE_COUNT} extra on
+	 * {@code ACTION_BATTERY_CHANGED} (Android 14 / API 34+, populated on devices whose battery
+	 * fuel gauge reports it). Returns -1 when unavailable, so callers can fall back to the
+	 * app's own estimate. Note: the per-app battery State-of-Health <em>percentage</em> is a
+	 * privileged/system API and is not available here.
+	 *
+	 * @param context The application context
+	 *
+	 * @return Charge cycle count, or -1 if the device doesn't report it
+	 */
+	public static int getChargeCycleCount(final Context context) {
+		final Intent batteryStatus = context.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+		if (isNull(batteryStatus)) {
+			return -1;
+		}
+		final int cycles = batteryStatus.getIntExtra(BatteryManager.EXTRA_CYCLE_COUNT, -1);
+		return cycles > 0 ? cycles : -1;
+	}
+
+	/**
 	 * Vibrate the phone with a predefined pattern
 	 *
 	 * @param context The application context

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -58,7 +58,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 		// Get health metrics
 		final int healthPercentage = BatteryHealthTracker.getEstimatedHealthPercentage(this);
 		final String healthStatus = BatteryHealthTracker.getHealthStatus(this);
-		final int chargeCycles = BatteryHealthTracker.getChargeCycles(this);
+		final int chargeCycles = BatteryHealthTracker.getEffectiveCycleCount(this);
 		final int daysInUse = BatteryHealthTracker.getDaysSinceFirstUse(this);
 		final String healthDescription = BatteryHealthTracker.getHealthDescription(this);
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -218,7 +218,7 @@ public class BatteryDetailsFragment extends Fragment {
 		valuesMap.put(getResources().getString(R.string.capacity), capacityText);
 
 		// Add charge cycles from the battery health tracker - positioned right after capacity
-		final int chargeCycles = BatteryHealthTracker.getChargeCycles(view.getContext());
+		final int chargeCycles = BatteryHealthTracker.getEffectiveCycleCount(view.getContext());
 		valuesMap.put(getResources().getString(R.string.charge_cycles), String.valueOf(chargeCycles));
 
 		valuesMap.put(getResources().getString(R.string.voltage), batteryDO.getVoltage() + " mV");


### PR DESCRIPTION
Part of #7. Apps can read the **real charge cycle count** on Android 14+ via the public `ACTION_BATTERY_CHANGED` `EXTRA_CYCLE_COUNT` extra. So "Charge Cycles" is real on modern devices (no longer stuck at 0), and the health estimate now derives from it for consistency — **no user input or extra permission**.

**Correction worth noting:** the battery State-of-Health *percentage* is a privileged/system API, **not** available to normal apps. So a real *measured* health % still requires the design-capacity input (#32); this PR improves the cycle-based estimate using real cycles.

**Stacked on #31** (base: `pr/12-battery-capacity`), because it builds on that branch's SystemService changes. Build + unit tests green.