### PR TITLE
Let the user enter battery design capacity for measured health (#32)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/model/BatteryHealthGrade.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/model/BatteryHealthGrade.java
@@ -1,0 +1,30 @@
+package com.almothafar.simplebatterynotifier.model;
+
+/**
+ * Wear grade for the app's estimated/measured battery health, in descending order of condition.
+ * <p>
+ * This is distinct from {@link BatteryHealthStatus}, which mirrors the OS {@code BATTERY_HEALTH_*}
+ * constants (GOOD/WARNING/CRITICAL/UNKNOWN). {@code BatteryHealthGrade} is the app's own
+ * cycle-count- or capacity-derived quality bucket shown on the Battery Insights screen. Using an
+ * enum (instead of the previous "Excellent"/"Good"/... strings) keeps producers and consumers in
+ * sync via exhaustive switches and removes the risk of a silent typo falling through to a default.
+ */
+public enum BatteryHealthGrade {
+	EXCELLENT("Excellent"),
+	GOOD("Good"),
+	FAIR("Fair"),
+	POOR("Poor");
+
+	private final String label;
+
+	BatteryHealthGrade(final String label) {
+		this.label = label;
+	}
+
+	/**
+	 * @return the human-readable label shown to the user
+	 */
+	public String getLabel() {
+		return label;
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -6,6 +6,8 @@ import android.os.BatteryManager;
 import android.util.Log;
 import androidx.preference.PreferenceManager;
 
+import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
+
 import static java.util.Objects.isNull;
 
 /**
@@ -237,21 +239,21 @@ public class BatteryHealthTracker {
 	}
 
 	/**
-	 * Maps a health percentage to a status label consistent with the cycle-based buckets.
+	 * Maps a health percentage to a wear grade, consistent with the cycle-based buckets.
 	 *
 	 * @param healthPercentage Health percentage (0-100)
 	 *
-	 * @return Health status: "Excellent", "Good", "Fair", or "Poor"
+	 * @return the matching {@link BatteryHealthGrade}
 	 */
-	public static String statusForPercentage(final int healthPercentage) {
+	public static BatteryHealthGrade gradeForPercentage(final int healthPercentage) {
 		if (healthPercentage >= EXCELLENT_HEALTH_PERCENT) {
-			return "Excellent";
+			return BatteryHealthGrade.EXCELLENT;
 		} else if (healthPercentage >= GOOD_HEALTH_PERCENT) {
-			return "Good";
+			return BatteryHealthGrade.GOOD;
 		} else if (healthPercentage >= FAIR_HEALTH_PERCENT) {
-			return "Fair";
+			return BatteryHealthGrade.FAIR;
 		} else {
-			return "Poor";
+			return BatteryHealthGrade.POOR;
 		}
 	}
 
@@ -327,52 +329,52 @@ public class BatteryHealthTracker {
 	}
 
 	/**
-	 * Gets a human-readable health status description.
+	 * Gets the cycle-based battery wear grade.
 	 *
 	 * @param context Application context
 	 *
-	 * @return Health status: "Excellent", "Good", "Fair", or "Poor"
+	 * @return the matching {@link BatteryHealthGrade}
 	 */
-	public static String getHealthStatus(final Context context) {
+	public static BatteryHealthGrade getHealthGrade(final Context context) {
 		final int cycles = getEffectiveCycleCount(context);
 
 		if (cycles < EXCELLENT_THRESHOLD) {
-			return "Excellent";
+			return BatteryHealthGrade.EXCELLENT;
 		} else if (cycles < GOOD_THRESHOLD) {
-			return "Good";
+			return BatteryHealthGrade.GOOD;
 		} else if (cycles < FAIR_THRESHOLD) {
-			return "Fair";
+			return BatteryHealthGrade.FAIR;
 		} else {
-			return "Poor";
+			return BatteryHealthGrade.POOR;
 		}
 	}
 
 	/**
-	 * Gets a detailed health description with recommendations.
+	 * Gets a detailed health description with recommendations for the cycle-based grade.
 	 *
 	 * @param context Application context
 	 *
 	 * @return Detailed health description
 	 */
 	public static String getHealthDescription(final Context context) {
-		return describeHealthStatus(getHealthStatus(context));
+		return describeHealthGrade(getHealthGrade(context));
 	}
 
 	/**
-	 * Gets a detailed health description for a status label.
+	 * Gets a detailed health description for a wear grade.
 	 * <p>
 	 * Shared by the cycle-based and measured health paths so the wording stays consistent.
 	 *
-	 * @param status Health status ("Excellent", "Good", "Fair", or "Poor")
+	 * @param grade the battery wear grade
 	 *
 	 * @return Detailed health description
 	 */
-	public static String describeHealthStatus(final String status) {
-		return switch (status) {
-			case "Excellent" -> "Your battery is in excellent condition. Continue with normal usage patterns.";
-			case "Good" -> "Your battery is in good condition with minimal degradation. Normal usage expected.";
-			case "Fair" -> "Your battery shows moderate wear. You may notice slightly reduced battery life.";
-			default -> "Your battery has significant wear. Consider battery replacement if experiencing poor performance.";
+	public static String describeHealthGrade(final BatteryHealthGrade grade) {
+		return switch (grade) {
+			case EXCELLENT -> "Your battery is in excellent condition. Continue with normal usage patterns.";
+			case GOOD -> "Your battery is in good condition with minimal degradation. Normal usage expected.";
+			case FAIR -> "Your battery shows moderate wear. You may notice slightly reduced battery life.";
+			case POOR -> "Your battery has significant wear. Consider battery replacement if experiencing poor performance.";
 		};
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -31,15 +31,25 @@ public class BatteryHealthTracker {
 	private static final String PREF_FIRST_USE_DATE = "_battery_health_first_use_date";
 	private static final String PREF_LAST_LOW_BATTERY = "_battery_health_last_low_battery";
 	private static final String PREF_CYCLE_IN_PROGRESS = "_battery_health_cycle_in_progress";
+	private static final String PREF_DESIGN_CAPACITY = "key_battery_design_capacity";
 
 	// Battery thresholds for cycle tracking
 	private static final int LOW_BATTERY_THRESHOLD = 20;
 	private static final int FULL_BATTERY_THRESHOLD = 95;
 
-	// Health estimation thresholds
+	// Health estimation thresholds (cycle-based)
 	private static final int EXCELLENT_THRESHOLD = 300;
 	private static final int GOOD_THRESHOLD = 500;
 	private static final int FAIR_THRESHOLD = 800;
+
+	// Accepted range for a user-entered design (rated) capacity, in mAh
+	public static final int MIN_DESIGN_CAPACITY_MAH = 500;
+	public static final int MAX_DESIGN_CAPACITY_MAH = 15000;
+
+	// Health-percentage thresholds for the measured (design-capacity-based) health figure
+	private static final int EXCELLENT_HEALTH_PERCENT = 90;
+	private static final int GOOD_HEALTH_PERCENT = 80;
+	private static final int FAIR_HEALTH_PERCENT = 70;
 
 	/**
 	 * Records battery state and updates charge cycle count if appropriate.
@@ -126,6 +136,123 @@ public class BatteryHealthTracker {
 		}
 		final int osCycleCount = SystemService.getChargeCycleCount(context);
 		return osCycleCount > 0 ? osCycleCount : getChargeCycles(context);
+	}
+
+	/**
+	 * Gets the user-entered battery design (rated) capacity in mAh.
+	 * <p>
+	 * Android exposes no public API for the design capacity, so the user supplies it (from the
+	 * manufacturer's specs) to enable a measured health figure. See {@link #getMeasuredHealthPercentage}.
+	 *
+	 * @param context Application context
+	 *
+	 * @return Design capacity in mAh, or 0 when unset
+	 */
+	public static int getDesignCapacity(final Context context) {
+		if (isNull(context)) {
+			return 0;
+		}
+		return PreferenceManager.getDefaultSharedPreferences(context).getInt(PREF_DESIGN_CAPACITY, 0);
+	}
+
+	/**
+	 * Whether a design capacity has been set.
+	 *
+	 * @param context Application context
+	 *
+	 * @return true when the user has entered a design capacity
+	 */
+	public static boolean hasDesignCapacity(final Context context) {
+		return getDesignCapacity(context) > 0;
+	}
+
+	/**
+	 * Whether the given value is a plausible battery design capacity (within {@link #MIN_DESIGN_CAPACITY_MAH}
+	 * to {@link #MAX_DESIGN_CAPACITY_MAH}).
+	 *
+	 * @param mAh Candidate capacity in mAh
+	 *
+	 * @return true when the value is within the accepted range
+	 */
+	public static boolean isValidDesignCapacity(final int mAh) {
+		return mAh >= MIN_DESIGN_CAPACITY_MAH && mAh <= MAX_DESIGN_CAPACITY_MAH;
+	}
+
+	/**
+	 * Stores (or clears) the user-entered design capacity.
+	 * <p>
+	 * A non-positive value clears the preference and reverts to the cycle-based health estimate.
+	 *
+	 * @param context Application context
+	 * @param mAh     Design capacity in mAh, or {@code <= 0} to clear
+	 */
+	public static void setDesignCapacity(final Context context, final int mAh) {
+		if (isNull(context)) {
+			return;
+		}
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		if (mAh <= 0) {
+			prefs.edit().remove(PREF_DESIGN_CAPACITY).apply();
+			Log.i(TAG, "Design capacity cleared");
+		} else {
+			prefs.edit().putInt(PREF_DESIGN_CAPACITY, mAh).apply();
+			Log.i(TAG, "Design capacity set to " + mAh + " mAh");
+		}
+	}
+
+	/**
+	 * Computes a measured battery-health percentage from the measured current full capacity and the
+	 * user-entered design capacity.
+	 * <p>
+	 * {@code health % = current full capacity (measured) / design capacity (user-entered) * 100}.
+	 * This is the accurate figure requested in #32; it only applies when the user has entered a
+	 * design capacity <em>and</em> the device reports the live charge counter used to estimate the
+	 * current full capacity.
+	 *
+	 * @param context Application context
+	 *
+	 * @return Measured health percentage (1-100), or -1 when it cannot be determined
+	 */
+	public static int getMeasuredHealthPercentage(final Context context) {
+		if (isNull(context)) {
+			return -1;
+		}
+		return computeMeasuredHealth(SystemService.getBatteryCapacity(context), getDesignCapacity(context));
+	}
+
+	/**
+	 * Pure helper for the measured health percentage, unit-testable with no Android dependencies.
+	 *
+	 * @param currentFullMah measured current full capacity in mAh (0 when unknown)
+	 * @param designMah      user-entered design capacity in mAh (0 when unset)
+	 *
+	 * @return health percentage clamped to 1-100, or -1 when either input is unusable
+	 */
+	static int computeMeasuredHealth(final int currentFullMah, final int designMah) {
+		if (currentFullMah <= 0 || designMah <= 0) {
+			return -1;
+		}
+		final int percent = Math.round(currentFullMah * 100f / designMah);
+		return Math.max(1, Math.min(100, percent));
+	}
+
+	/**
+	 * Maps a health percentage to a status label consistent with the cycle-based buckets.
+	 *
+	 * @param healthPercentage Health percentage (0-100)
+	 *
+	 * @return Health status: "Excellent", "Good", "Fair", or "Poor"
+	 */
+	public static String statusForPercentage(final int healthPercentage) {
+		if (healthPercentage >= EXCELLENT_HEALTH_PERCENT) {
+			return "Excellent";
+		} else if (healthPercentage >= GOOD_HEALTH_PERCENT) {
+			return "Good";
+		} else if (healthPercentage >= FAIR_HEALTH_PERCENT) {
+			return "Fair";
+		} else {
+			return "Poor";
+		}
 	}
 
 	/**
@@ -228,17 +355,25 @@ public class BatteryHealthTracker {
 	 * @return Detailed health description
 	 */
 	public static String getHealthDescription(final Context context) {
-		final int cycles = getEffectiveCycleCount(context);
+		return describeHealthStatus(getHealthStatus(context));
+	}
 
-		if (cycles < EXCELLENT_THRESHOLD) {
-			return "Your battery is in excellent condition. Continue with normal usage patterns.";
-		} else if (cycles < GOOD_THRESHOLD) {
-			return "Your battery is in good condition with minimal degradation. Normal usage expected.";
-		} else if (cycles < FAIR_THRESHOLD) {
-			return "Your battery shows moderate wear. You may notice slightly reduced battery life.";
-		} else {
-			return "Your battery has significant wear. Consider battery replacement if experiencing poor performance.";
-		}
+	/**
+	 * Gets a detailed health description for a status label.
+	 * <p>
+	 * Shared by the cycle-based and measured health paths so the wording stays consistent.
+	 *
+	 * @param status Health status ("Excellent", "Good", "Fair", or "Poor")
+	 *
+	 * @return Detailed health description
+	 */
+	public static String describeHealthStatus(final String status) {
+		return switch (status) {
+			case "Excellent" -> "Your battery is in excellent condition. Continue with normal usage patterns.";
+			case "Good" -> "Your battery is in good condition with minimal degradation. Normal usage expected.";
+			case "Fair" -> "Your battery shows moderate wear. You may notice slightly reduced battery life.";
+			default -> "Your battery has significant wear. Consider battery replacement if experiencing poor performance.";
+		};
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -1,13 +1,23 @@
 package com.almothafar.simplebatterynotifier.ui;
 
 import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
 import android.content.pm.ApplicationInfo;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.widget.Toolbar;
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
+import com.almothafar.simplebatterynotifier.service.SystemService;
 
 /**
  * Activity displaying battery health insights including charge cycles and estimated health.
@@ -16,9 +26,11 @@ public class BatteryInsightsActivity extends BaseActivity {
 
 	private TextView healthPercentageText;
 	private TextView healthStatusText;
+	private TextView healthBasisText;
 	private TextView chargeCyclesText;
 	private TextView daysInUseText;
 	private TextView healthDescriptionText;
+	private TextView designCapacityText;
 
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {
@@ -33,9 +45,14 @@ public class BatteryInsightsActivity extends BaseActivity {
 		// Initialize views
 		healthPercentageText = findViewById(R.id.healthPercentageText);
 		healthStatusText = findViewById(R.id.healthStatusText);
+		healthBasisText = findViewById(R.id.healthBasisText);
 		chargeCyclesText = findViewById(R.id.chargeCyclesText);
 		daysInUseText = findViewById(R.id.daysInUseText);
 		healthDescriptionText = findViewById(R.id.healthDescriptionText);
+		designCapacityText = findViewById(R.id.designCapacityText);
+
+		// Tap the design-capacity card to set/edit the rated capacity
+		findViewById(R.id.designCapacityCard).setOnClickListener(v -> showDesignCapacityDialog());
 
 		// Add debug menu (long-press on health percentage)
 		setupDebugMenu();
@@ -55,12 +72,22 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 * Updates all health data displays with current values from BatteryHealthTracker.
 	 */
 	private void updateHealthData() {
-		// Get health metrics
-		final int healthPercentage = BatteryHealthTracker.getEstimatedHealthPercentage(this);
-		final String healthStatus = BatteryHealthTracker.getHealthStatus(this);
+		// Prefer the measured health figure (current capacity vs. user-entered design capacity) when
+		// available; otherwise fall back to the cycle-based estimate. See issue #32 / #7.
+		final int measuredHealth = BatteryHealthTracker.getMeasuredHealthPercentage(this);
+		final boolean measured = measuredHealth >= 0;
+
+		final int healthPercentage = measured
+		                             ? measuredHealth
+		                             : BatteryHealthTracker.getEstimatedHealthPercentage(this);
+		final String healthStatus = measured
+		                            ? BatteryHealthTracker.statusForPercentage(measuredHealth)
+		                            : BatteryHealthTracker.getHealthStatus(this);
+		final String healthDescription = measured
+		                                 ? BatteryHealthTracker.describeHealthStatus(healthStatus)
+		                                 : BatteryHealthTracker.getHealthDescription(this);
 		final int chargeCycles = BatteryHealthTracker.getEffectiveCycleCount(this);
 		final int daysInUse = BatteryHealthTracker.getDaysSinceFirstUse(this);
-		final String healthDescription = BatteryHealthTracker.getHealthDescription(this);
 
 		// Update health percentage and color it based on status
 		healthPercentageText.setText(healthPercentage + "%");
@@ -70,12 +97,21 @@ public class BatteryInsightsActivity extends BaseActivity {
 		healthStatusText.setText(healthStatus);
 		healthStatusText.setTextColor(getHealthColor(healthStatus));
 
+		// Tell the user whether the figure is measured (honest) or a cycle-based estimate
+		healthBasisText.setText(measured ? R.string.health_basis_measured : R.string.health_basis_estimated);
+
 		// Update metrics
 		chargeCyclesText.setText(String.valueOf(chargeCycles));
 		daysInUseText.setText(String.valueOf(daysInUse));
 
 		// Update description
 		healthDescriptionText.setText(healthDescription);
+
+		// Update the design-capacity row (value when set, call-to-action when unset)
+		final int designCapacity = BatteryHealthTracker.getDesignCapacity(this);
+		designCapacityText.setText(designCapacity > 0
+		                           ? getString(R.string.design_capacity_value, designCapacity)
+		                           : getString(R.string.set_design_capacity_action));
 	}
 
 	/**
@@ -158,6 +194,107 @@ public class BatteryInsightsActivity extends BaseActivity {
 		BatteryHealthTracker.addTestChargeCycles(this, cycles);
 		updateHealthData();
 		Toast.makeText(this, "Added " + cycles + " test cycles", Toast.LENGTH_SHORT).show();
+	}
+
+	/**
+	 * Shows the dialog for setting, editing, or clearing the battery design (rated) capacity.
+	 * <p>
+	 * The input is prefilled with the current stored value, or — when unset — with the measured
+	 * current full-capacity estimate, so the user only has to confirm or correct it. A "look up my
+	 * model" action opens a web search for the device's rated capacity. Saving an empty field clears
+	 * the value and reverts to the cycle-based estimate.
+	 */
+	private void showDesignCapacityDialog() {
+		final EditText input = new EditText(this);
+		input.setInputType(InputType.TYPE_CLASS_NUMBER);
+		input.setHint(R.string.design_capacity_hint);
+
+		final int stored = BatteryHealthTracker.getDesignCapacity(this);
+		final int prefill = stored > 0 ? stored : SystemService.getBatteryCapacity(this);
+		if (prefill > 0) {
+			input.setText(String.valueOf(prefill));
+			input.setSelection(input.getText().length());
+		}
+
+		// Indent the field to match the dialog's message padding
+		final int padding = (int) (24 * getResources().getDisplayMetrics().density);
+		final FrameLayout container = new FrameLayout(this);
+		final FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+				FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);
+		params.leftMargin = padding;
+		params.rightMargin = padding;
+		container.addView(input, params);
+		input.setGravity(Gravity.START);
+
+		final AlertDialog dialog = new AlertDialog.Builder(this)
+				.setTitle(R.string.design_capacity_dialog_title)
+				.setMessage(R.string.design_capacity_dialog_message)
+				.setView(container)
+				.setPositiveButton(R.string.save, null) // overridden below to validate without dismissing
+				.setNeutralButton(R.string.look_up_my_model, null)
+				.setNegativeButton(android.R.string.cancel, null)
+				.create();
+
+		dialog.show();
+
+		// Override click handlers so invalid input (Save) and the lookup action (Neutral) don't dismiss.
+		dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+			if (saveDesignCapacity(input.getText().toString())) {
+				dialog.dismiss();
+			}
+		});
+		dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(v -> lookUpBatteryModel());
+	}
+
+	/**
+	 * Validates and stores the entered design capacity.
+	 *
+	 * @param rawInput The raw text from the input field
+	 *
+	 * @return true when the value was saved (or cleared) and the dialog may close; false when the
+	 * input was invalid and the dialog should stay open
+	 */
+	private boolean saveDesignCapacity(final String rawInput) {
+		final String trimmed = rawInput.trim();
+
+		// Empty input clears the design capacity and reverts to the cycle-based estimate
+		if (TextUtils.isEmpty(trimmed)) {
+			BatteryHealthTracker.setDesignCapacity(this, 0);
+			updateHealthData();
+			return true;
+		}
+
+		int value;
+		try {
+			value = Integer.parseInt(trimmed);
+		} catch (NumberFormatException e) {
+			value = -1;
+		}
+
+		if (!BatteryHealthTracker.isValidDesignCapacity(value)) {
+			Toast.makeText(this, getString(R.string.error_design_capacity_range,
+					BatteryHealthTracker.MIN_DESIGN_CAPACITY_MAH,
+					BatteryHealthTracker.MAX_DESIGN_CAPACITY_MAH), Toast.LENGTH_LONG).show();
+			return false;
+		}
+
+		BatteryHealthTracker.setDesignCapacity(this, value);
+		updateHealthData();
+		return true;
+	}
+
+	/**
+	 * Opens a web search for the current device's battery capacity so the user can find their rated
+	 * (design) capacity.
+	 */
+	private void lookUpBatteryModel() {
+		final String query = (Build.MANUFACTURER + " " + Build.MODEL + " battery capacity mAh").trim();
+		final Uri uri = Uri.parse("https://www.google.com/search?q=" + Uri.encode(query));
+		try {
+			startActivity(new Intent(Intent.ACTION_VIEW, uri));
+		} catch (ActivityNotFoundException e) {
+			Toast.makeText(this, R.string.no_browser_found, Toast.LENGTH_SHORT).show();
+		}
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -7,6 +7,7 @@ import android.content.pm.ApplicationInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.InputFilter;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.Gravity;
@@ -24,6 +25,10 @@ import com.almothafar.simplebatterynotifier.service.SystemService;
  * Activity displaying battery health insights including charge cycles and estimated health.
  */
 public class BatteryInsightsActivity extends BaseActivity {
+
+	// Digit cap for the design-capacity field; MAX_DESIGN_CAPACITY_MAH (15000) is 5 digits, so this
+	// bounds the input and guarantees Integer.parseInt can't overflow.
+	private static final int MAX_DESIGN_CAPACITY_DIGITS = 5;
 
 	private TextView healthPercentageText;
 	private TextView healthStatusText;
@@ -205,6 +210,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 	private void showDesignCapacityDialog() {
 		final EditText input = new EditText(this);
 		input.setInputType(InputType.TYPE_CLASS_NUMBER);
+		// Max valid capacity is 15000 (5 digits); cap the length so the field can't overflow an int.
+		input.setFilters(new InputFilter[]{new InputFilter.LengthFilter(MAX_DESIGN_CAPACITY_DIGITS)});
 		input.setHint(R.string.design_capacity_hint);
 
 		final int stored = BatteryHealthTracker.getDesignCapacity(this);
@@ -262,23 +269,31 @@ public class BatteryInsightsActivity extends BaseActivity {
 			return true;
 		}
 
-		int value;
-		try {
-			value = Integer.parseInt(trimmed);
-		} catch (NumberFormatException e) {
-			value = -1;
+		// Reject non-numeric / oversized input as a normal validation branch. Bounding it to 1–5
+		// digits here means the parse below provably can't overflow, so no exception handling needed.
+		if (!trimmed.matches("\\d{1," + MAX_DESIGN_CAPACITY_DIGITS + "}")) {
+			showCapacityRangeError();
+			return false;
 		}
 
+		final int value = Integer.parseInt(trimmed); // safe: matched \d{1,5}, fits in an int
 		if (!BatteryHealthTracker.isValidDesignCapacity(value)) {
-			Toast.makeText(this, getString(R.string.error_design_capacity_range,
-					BatteryHealthTracker.MIN_DESIGN_CAPACITY_MAH,
-					BatteryHealthTracker.MAX_DESIGN_CAPACITY_MAH), Toast.LENGTH_LONG).show();
+			showCapacityRangeError();
 			return false;
 		}
 
 		BatteryHealthTracker.setDesignCapacity(this, value);
 		updateHealthData();
 		return true;
+	}
+
+	/**
+	 * Shows the accepted design-capacity range as a Toast.
+	 */
+	private void showCapacityRangeError() {
+		Toast.makeText(this, getString(R.string.error_design_capacity_range,
+				BatteryHealthTracker.MIN_DESIGN_CAPACITY_MAH,
+				BatteryHealthTracker.MAX_DESIGN_CAPACITY_MAH), Toast.LENGTH_LONG).show();
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.widget.Toolbar;
 import com.almothafar.simplebatterynotifier.R;
+import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 
@@ -80,22 +81,20 @@ public class BatteryInsightsActivity extends BaseActivity {
 		final int healthPercentage = measured
 		                             ? measuredHealth
 		                             : BatteryHealthTracker.getEstimatedHealthPercentage(this);
-		final String healthStatus = measured
-		                            ? BatteryHealthTracker.statusForPercentage(measuredHealth)
-		                            : BatteryHealthTracker.getHealthStatus(this);
-		final String healthDescription = measured
-		                                 ? BatteryHealthTracker.describeHealthStatus(healthStatus)
-		                                 : BatteryHealthTracker.getHealthDescription(this);
+		final BatteryHealthGrade grade = measured
+		                                 ? BatteryHealthTracker.gradeForPercentage(measuredHealth)
+		                                 : BatteryHealthTracker.getHealthGrade(this);
+		final String healthDescription = BatteryHealthTracker.describeHealthGrade(grade);
 		final int chargeCycles = BatteryHealthTracker.getEffectiveCycleCount(this);
 		final int daysInUse = BatteryHealthTracker.getDaysSinceFirstUse(this);
 
-		// Update health percentage and color it based on status
+		// Update health percentage and color it based on grade
 		healthPercentageText.setText(healthPercentage + "%");
-		healthPercentageText.setTextColor(getHealthColor(healthStatus));
+		healthPercentageText.setTextColor(getHealthColor(grade));
 
 		// Update health status text
-		healthStatusText.setText(healthStatus);
-		healthStatusText.setTextColor(getHealthColor(healthStatus));
+		healthStatusText.setText(grade.getLabel());
+		healthStatusText.setTextColor(getHealthColor(grade));
 
 		// Tell the user whether the figure is measured (honest) or a cycle-based estimate
 		healthBasisText.setText(measured ? R.string.health_basis_measured : R.string.health_basis_estimated);
@@ -115,19 +114,18 @@ public class BatteryInsightsActivity extends BaseActivity {
 	}
 
 	/**
-	 * Gets the appropriate color for the health status.
+	 * Gets the appropriate color for a battery wear grade.
 	 *
-	 * @param healthStatus The health status string (Excellent, Good, Fair, Poor)
+	 * @param grade The battery wear grade
 	 *
-	 * @return Color integer for the status
+	 * @return Color integer for the grade
 	 */
-	private int getHealthColor(final String healthStatus) {
-		return switch (healthStatus) {
-			case "Excellent" -> getColor(R.color.top_background_color); // Green
-			case "Good" -> getColor(R.color.title_bar_background_color); // Blue
-			case "Fair" -> getColor(R.color.circular_progress_default_progress_warning); // Orange
-			case "Poor" -> getColor(R.color.circular_progress_default_progress_alert); // Red
-			default -> getColor(R.color.default_text_color); // Default
+	private int getHealthColor(final BatteryHealthGrade grade) {
+		return switch (grade) {
+			case EXCELLENT -> getColor(R.color.top_background_color); // Green
+			case GOOD -> getColor(R.color.title_bar_background_color); // Blue
+			case FAIR -> getColor(R.color.circular_progress_default_progress_warning); // Orange
+			case POOR -> getColor(R.color.circular_progress_default_progress_alert); // Red
 		};
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -217,6 +217,13 @@ public class BatteryDetailsFragment extends Fragment {
 		                            : getResources().getString(R.string.unknown);
 		valuesMap.put(getResources().getString(R.string.capacity), capacityText);
 
+		// Show the user-entered design (rated) capacity when set (issue #32)
+		final int designCapacity = BatteryHealthTracker.getDesignCapacity(view.getContext());
+		if (designCapacity > 0) {
+			valuesMap.put(getResources().getString(R.string.design_capacity),
+					getResources().getString(R.string.design_capacity_value, designCapacity));
+		}
+
 		// Add charge cycles from the battery health tracker - positioned right after capacity
 		final int chargeCycles = BatteryHealthTracker.getEffectiveCycleCount(view.getContext());
 		valuesMap.put(getResources().getString(R.string.charge_cycles), String.valueOf(chargeCycles));

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -79,6 +79,53 @@
                             android:textStyle="bold"
                             android:textColor="@color/title_bar_background_color"/>
 
+                    <TextView
+                            android:id="@+id/healthBasisText"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/health_basis_estimated"
+                            android:textSize="12sp"
+                            android:textColor="@color/battery_details_label_color"
+                            android:layout_marginTop="4dp"/>
+
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
+            <!-- Design Capacity Card (tap to set/edit the rated capacity) -->
+            <androidx.cardview.widget.CardView
+                    android:id="@+id/designCapacityCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="16dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground"
+                    app:cardCornerRadius="8dp"
+                    app:cardElevation="4dp"
+                    app:contentPadding="16dp">
+
+                <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                    <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/design_capacity"
+                            android:textSize="14sp"
+                            android:textColor="@color/battery_details_label_color"
+                            android:layout_marginBottom="8dp"/>
+
+                    <TextView
+                            android:id="@+id/designCapacityText"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/set_design_capacity_action"
+                            android:textSize="18sp"
+                            android:textStyle="bold"
+                            android:textColor="@color/battery_details_value_color"/>
+
                 </LinearLayout>
             </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,19 @@
     <string name="days_in_use">Days in Use</string>
     <string name="about_battery_health">About Your Battery</string>
     <string name="battery_health_description_placeholder">Your battery health information will appear here.</string>
+    <string name="design_capacity">Design Capacity</string>
+    <string name="design_capacity_value">%1$d mAh</string>
+    <string name="set_design_capacity_action">Set rated capacity for accurate health</string>
+    <string name="design_capacity_dialog_title">Battery design capacity</string>
+    <string name="design_capacity_dialog_message">Enter your battery\'s rated capacity in mAh from the manufacturer\'s specs. We\'ve prefilled a measured estimate — confirm or correct it for an accurate health figure.</string>
+    <string name="design_capacity_hint">Capacity (mAh)</string>
+    <string name="look_up_my_model">Look up my model</string>
+    <string name="no_browser_found">No browser available to open the search</string>
+    <string name="save">Save</string>
+    <string name="clear">Clear</string>
+    <string name="error_design_capacity_range">Enter a capacity between %1$d and %2$d mAh</string>
+    <string name="health_basis_measured">Measured from rated capacity</string>
+    <string name="health_basis_estimated">Estimated from charge cycles</string>
     <string name="how_it_works">How It Works</string>
     <string name="how_battery_health_works" formatted="false" tools:ignore="TypographyDashes">Battery health is estimated based on charge cycles. A charge cycle counts when your battery charges from 20% or below to 95% or above. This tracking starts when you first use this app.\n\nHealth estimates:\n• 0–300 cycles: Excellent (95–100%)\n• 300-500 cycles: Good (85-95%)\n• 500-800 cycles: Fair (70-85%)\n• 800+ cycles: Poor (&lt;70%)</string>
     <string name="developed_by">Developed by</string>

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
@@ -1,0 +1,61 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the pure, Android-free helpers in {@link BatteryHealthTracker}.
+ */
+public class BatteryHealthTrackerTest {
+
+	@Test
+	public void computeMeasuredHealth_typicalReadings() {
+		// 3800 mAh measured against a 4000 mAh design capacity -> 95%
+		assertEquals(95, BatteryHealthTracker.computeMeasuredHealth(3800, 4000));
+		// A healthy battery measuring at its rated capacity -> 100%
+		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4000, 4000));
+		// Worn battery: 3000 of 5000 -> 60%
+		assertEquals(60, BatteryHealthTracker.computeMeasuredHealth(3000, 5000));
+	}
+
+	@Test
+	public void computeMeasuredHealth_clampsToRange() {
+		// Measured above rated (fresh cell / rounding) is clamped to 100
+		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4200, 4000));
+		// Never reports 0; the smallest positive result is 1
+		assertEquals(1, BatteryHealthTracker.computeMeasuredHealth(1, 15000));
+	}
+
+	@Test
+	public void computeMeasuredHealth_unusableInputs_returnsMinusOne() {
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(0, 4000));
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 0));
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(-5, 4000));
+	}
+
+	@Test
+	public void isValidDesignCapacity_enforcesRange() {
+		assertTrue(BatteryHealthTracker.isValidDesignCapacity(BatteryHealthTracker.MIN_DESIGN_CAPACITY_MAH));
+		assertTrue(BatteryHealthTracker.isValidDesignCapacity(BatteryHealthTracker.MAX_DESIGN_CAPACITY_MAH));
+		assertTrue(BatteryHealthTracker.isValidDesignCapacity(4000));
+		assertFalse(BatteryHealthTracker.isValidDesignCapacity(BatteryHealthTracker.MIN_DESIGN_CAPACITY_MAH - 1));
+		assertFalse(BatteryHealthTracker.isValidDesignCapacity(BatteryHealthTracker.MAX_DESIGN_CAPACITY_MAH + 1));
+		assertFalse(BatteryHealthTracker.isValidDesignCapacity(0));
+		assertFalse(BatteryHealthTracker.isValidDesignCapacity(-1));
+	}
+
+	@Test
+	public void statusForPercentage_bucketsMatchLabels() {
+		assertEquals("Excellent", BatteryHealthTracker.statusForPercentage(100));
+		assertEquals("Excellent", BatteryHealthTracker.statusForPercentage(90));
+		assertEquals("Good", BatteryHealthTracker.statusForPercentage(89));
+		assertEquals("Good", BatteryHealthTracker.statusForPercentage(80));
+		assertEquals("Fair", BatteryHealthTracker.statusForPercentage(79));
+		assertEquals("Fair", BatteryHealthTracker.statusForPercentage(70));
+		assertEquals("Poor", BatteryHealthTracker.statusForPercentage(69));
+		assertEquals("Poor", BatteryHealthTracker.statusForPercentage(0));
+	}
+}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
@@ -1,5 +1,7 @@
 package com.almothafar.simplebatterynotifier.service;
 
+import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -48,14 +50,14 @@ public class BatteryHealthTrackerTest {
 	}
 
 	@Test
-	public void statusForPercentage_bucketsMatchLabels() {
-		assertEquals("Excellent", BatteryHealthTracker.statusForPercentage(100));
-		assertEquals("Excellent", BatteryHealthTracker.statusForPercentage(90));
-		assertEquals("Good", BatteryHealthTracker.statusForPercentage(89));
-		assertEquals("Good", BatteryHealthTracker.statusForPercentage(80));
-		assertEquals("Fair", BatteryHealthTracker.statusForPercentage(79));
-		assertEquals("Fair", BatteryHealthTracker.statusForPercentage(70));
-		assertEquals("Poor", BatteryHealthTracker.statusForPercentage(69));
-		assertEquals("Poor", BatteryHealthTracker.statusForPercentage(0));
+	public void gradeForPercentage_bucketsMatchGrades() {
+		assertEquals(BatteryHealthGrade.EXCELLENT, BatteryHealthTracker.gradeForPercentage(100));
+		assertEquals(BatteryHealthGrade.EXCELLENT, BatteryHealthTracker.gradeForPercentage(90));
+		assertEquals(BatteryHealthGrade.GOOD, BatteryHealthTracker.gradeForPercentage(89));
+		assertEquals(BatteryHealthGrade.GOOD, BatteryHealthTracker.gradeForPercentage(80));
+		assertEquals(BatteryHealthGrade.FAIR, BatteryHealthTracker.gradeForPercentage(79));
+		assertEquals(BatteryHealthGrade.FAIR, BatteryHealthTracker.gradeForPercentage(70));
+		assertEquals(BatteryHealthGrade.POOR, BatteryHealthTracker.gradeForPercentage(69));
+		assertEquals(BatteryHealthGrade.POOR, BatteryHealthTracker.gradeForPercentage(0));
 	}
 }


### PR DESCRIPTION
Closes #32. Concrete, accurate path for the remaining part of #7 (measured health), building on #12/#31 (public-API current-capacity estimate).

## Why
Android exposes **no public API for design capacity**, so the existing health figure was only a cycle-count guess. With a user-provided rated capacity we can compute an honest, measured health %:

```
health % ≈ measured current full capacity ÷ user-entered design capacity × 100
```

## What changed
- **`BatteryHealthTracker`**: store/validate a design capacity (500–15000 mAh), compute measured health clamped to 1–100, and map a percentage to the existing Excellent/Good/Fair/Poor labels. `getHealthDescription` refactored to share wording via `describeHealthStatus`. Pure helpers (`computeMeasuredHealth`, `isValidDesignCapacity`, `statusForPercentage`) are unit-tested.
- **Battery Insights**: a "Design Capacity" card surfaces a *"Set rated capacity for accurate health"* call-to-action when unset. Tapping opens a dialog **prefilled with the measured estimate**, with a **"Look up my model"** web search and range validation (bad/out-of-range input rejected, dialog stays open). Empty input clears the value.
- When a design capacity is set, the big health figure switches to the **measured** value, labelled *"Measured from rated capacity"* vs. the cycle-based *"Estimated from charge cycles"*. Unset → no regression.
- **Battery details table** shows the design capacity when set.

## Acceptance criteria
- [x] Set/edit/clear a design capacity with validation; bad input rejected with feedback.
- [x] When set, insights shows rated capacity and a health % derived from measured vs. rated capacity.
- [x] When unset, no regression vs. current behaviour.

## Testing
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` — build + unit tests pass (added `BatteryHealthTrackerTest`).
- ⚠️ Not yet device-verified (dialog UX, browser lookup intent, measured figure on a device that reports the charge counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)