### PR TITLE
Expand unit test coverage: cycle tracker + battery receivers (#15)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_25
         targetCompatibility JavaVersion.VERSION_25
     }
+
+    testOptions {
+        unitTests {
+            // Give Robolectric access to the app's merged resources (string keys, etc.)
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
@@ -1,0 +1,156 @@
+package com.almothafar.simplebatterynotifier.receiver;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.almothafar.simplebatterynotifier.service.NotificationService;
+import com.almothafar.simplebatterynotifier.service.SystemService;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+/**
+ * Robolectric + Mockito tests for {@link BatteryLevelReceiver}'s threshold and de-duplication logic.
+ * <p>
+ * The receiver reads the sticky {@code ACTION_BATTERY_CHANGED} intent and delegates the actual
+ * notification to {@link NotificationService}, whose static methods are mocked so we can assert
+ * <em>which</em> alert (if any) it decides to send without doing real Android notification work.
+ * {@link SystemService} is left real so it builds a {@code BatteryDO} from the sticky intent we set.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class BatteryLevelReceiverTest {
+
+	private Context context;
+
+	@Before
+	public void setUp() {
+		context = ApplicationProvider.getApplicationContext();
+		// Clear the static de-dup state between tests so ordering can't leak through
+		setStatic("prevLevel", 0);
+		setStatic("prevType", 0);
+		setStatic("fullNotificationCalled", false);
+		setStatic("temperatureAlertSent", false);
+	}
+
+	@Test
+	public void discharging_belowCritical_sendsCriticalAlert() {
+		publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 15, 100, 0);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.CRITICAL_TYPE)));
+		}
+	}
+
+	@Test
+	public void discharging_betweenCriticalAndWarning_sendsWarningAlert() {
+		publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 35, 100, 0);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.WARNING_TYPE)));
+		}
+	}
+
+	@Test
+	public void discharging_aboveWarning_sendsNoAlert() {
+		publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 80, 100, 0);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.WARNING_TYPE)), never());
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.CRITICAL_TYPE)), never());
+		}
+	}
+
+	@Test
+	public void discharging_warningNotRepeatedWhileStillInWarningBand() {
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 38, 100, 0);
+			receive();
+			// Still in the warning band, different level -> must not re-alert
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 35, 100, 0);
+			receive();
+
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.WARNING_TYPE)), times(1));
+		}
+	}
+
+	@Test
+	public void discharging_alertEveryTick_repeatsCriticalAlert() {
+		enableAlertEveryTick();
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 15, 100, 0);
+			receive();
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 14, 100, 0);
+			receive();
+
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.CRITICAL_TYPE)), times(2));
+		}
+	}
+
+	@Test
+	public void full_whileCharging_sendsFullAlertOnce() {
+		// Simulate the battery already sitting at 100% (unchanged) so the charging/full branch runs
+		setStatic("prevLevel", 100);
+		publishBattery(BatteryManager.BATTERY_STATUS_FULL, 100, 100, BatteryManager.BATTERY_PLUGGED_AC);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			receive(); // second identical tick must not re-send
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.FULL_LEVEL_TYPE)), times(1));
+		}
+	}
+
+	// --- helpers -------------------------------------------------------------
+
+	private void receive() {
+		new BatteryLevelReceiver().onReceive(context, new Intent(Intent.ACTION_BATTERY_CHANGED));
+	}
+
+	@SuppressWarnings("deprecation")
+	private void publishBattery(final int status, final int level, final int scale, final int plugged) {
+		final Intent battery = new Intent(Intent.ACTION_BATTERY_CHANGED);
+		battery.putExtra(BatteryManager.EXTRA_STATUS, status);
+		battery.putExtra(BatteryManager.EXTRA_LEVEL, level);
+		battery.putExtra(BatteryManager.EXTRA_SCALE, scale);
+		battery.putExtra(BatteryManager.EXTRA_PLUGGED, plugged);
+		battery.putExtra(BatteryManager.EXTRA_PRESENT, true);
+		battery.putExtra(BatteryManager.EXTRA_TEMPERATURE, 250); // 25.0 °C, well below the alert threshold
+		context.sendStickyBroadcast(battery);
+	}
+
+	private void enableAlertEveryTick() {
+		androidx.preference.PreferenceManager.getDefaultSharedPreferences(context)
+				.edit()
+				.putBoolean(context.getString(com.almothafar.simplebatterynotifier.R.string._pref_key_notify_every_tick), true)
+				.commit();
+	}
+
+	private static void setStatic(final String fieldName, final Object value) {
+		try {
+			final Field field = BatteryLevelReceiver.class.getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(null, value);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException("Unable to reset " + fieldName, e);
+		}
+	}
+}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiverTest.java
@@ -1,0 +1,114 @@
+package com.almothafar.simplebatterynotifier.receiver;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.almothafar.simplebatterynotifier.R;
+import com.almothafar.simplebatterynotifier.service.NotificationService;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+/**
+ * Robolectric + Mockito tests for {@link PowerConnectionReceiver}: charger-type detection, the
+ * healthy-charge flag, plugged-state de-duplication, and the disconnect cleanup path. The
+ * {@link NotificationService} static methods are mocked so we can assert what the receiver decides
+ * to do from the sticky {@code ACTION_BATTERY_CHANGED} intent.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class PowerConnectionReceiverTest {
+
+	private Context context;
+
+	@Before
+	public void setUp() {
+		context = ApplicationProvider.getApplicationContext();
+		// Reset the static plugged-state so each test starts from "unknown"
+		PowerConnectionReceiver.setCurrentState(-1);
+	}
+
+	@Test
+	public void connectedAc_sendsChargeNotificationWithAcSource() {
+		publishBattery(BatteryManager.BATTERY_PLUGGED_AC, 50, 100);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.sendChargeNotification(any(Context.class),
+					eq(context.getString(R.string.charger_ac))));
+			ns.verify(() -> NotificationService.setIsHealthy(false));
+		}
+	}
+
+	@Test
+	public void connectedWireless_sendsChargeNotificationWithWirelessSource() {
+		publishBattery(BatteryManager.BATTERY_PLUGGED_WIRELESS, 60, 100);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.sendChargeNotification(any(Context.class),
+					eq(context.getString(R.string.charger_wireless))));
+		}
+	}
+
+	@Test
+	public void connectedAtLowBattery_marksChargeHealthy() {
+		publishBattery(BatteryManager.BATTERY_PLUGGED_USB, 10, 100);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.setIsHealthy(true));
+		}
+	}
+
+	@Test
+	public void samePluggedState_sendsNoNotification() {
+		PowerConnectionReceiver.setCurrentState(BatteryManager.BATTERY_PLUGGED_AC);
+		publishBattery(BatteryManager.BATTERY_PLUGGED_AC, 50, 100);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.sendChargeNotification(any(Context.class), any(String.class)), never());
+		}
+	}
+
+	@Test
+	public void disconnected_clearsNotifications() {
+		PowerConnectionReceiver.setCurrentState(BatteryManager.BATTERY_PLUGGED_AC);
+		publishBattery(0, 50, 100); // unplugged
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.clearNotifications(any(Context.class)));
+			ns.verify(() -> NotificationService.sendChargeNotification(any(Context.class), any(String.class)), never());
+		}
+	}
+
+	// --- helpers -------------------------------------------------------------
+
+	private void receive() {
+		new PowerConnectionReceiver().onReceive(context, new Intent(Intent.ACTION_POWER_CONNECTED));
+	}
+
+	@SuppressWarnings("deprecation")
+	private void publishBattery(final int plugged, final int level, final int scale) {
+		final Intent battery = new Intent(Intent.ACTION_BATTERY_CHANGED);
+		battery.putExtra(BatteryManager.EXTRA_PLUGGED, plugged);
+		battery.putExtra(BatteryManager.EXTRA_LEVEL, level);
+		battery.putExtra(BatteryManager.EXTRA_SCALE, scale);
+		battery.putExtra(BatteryManager.EXTRA_PRESENT, true);
+		context.sendStickyBroadcast(battery);
+	}
+}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerStateTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerStateTest.java
@@ -1,0 +1,127 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.Context;
+import android.os.BatteryManager;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Robolectric tests for the stateful, SharedPreferences-backed parts of {@link BatteryHealthTracker}:
+ * the charge-cycle state machine and the user-entered design-capacity persistence. Each test gets a
+ * fresh application (and therefore empty default SharedPreferences), so no manual reset is needed.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class BatteryHealthTrackerStateTest {
+
+	private Context context;
+
+	@Before
+	public void setUp() {
+		context = ApplicationProvider.getApplicationContext();
+	}
+
+	@Test
+	public void chargeCycle_completesWhenLowThenChargedToFull() {
+		// Drop to the low threshold -> a cycle begins but isn't counted yet
+		BatteryHealthTracker.recordBatteryState(context, 15, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		assertEquals(0, BatteryHealthTracker.getChargeCycles(context));
+
+		// Charge back up past the full threshold -> the cycle completes
+		BatteryHealthTracker.recordBatteryState(context, 96, BatteryManager.BATTERY_STATUS_CHARGING);
+		assertEquals(1, BatteryHealthTracker.getChargeCycles(context));
+	}
+
+	@Test
+	public void chargeCycle_accumulatesAcrossPartialCharges() {
+		// A mid-range reading between low and full must not start or complete a cycle
+		BatteryHealthTracker.recordBatteryState(context, 15, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 50, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		assertEquals(0, BatteryHealthTracker.getChargeCycles(context));
+
+		BatteryHealthTracker.recordBatteryState(context, 96, BatteryManager.BATTERY_STATUS_FULL);
+		assertEquals(1, BatteryHealthTracker.getChargeCycles(context));
+	}
+
+	@Test
+	public void chargeCycle_notCountedWhenReachingFullWithoutCharging() {
+		BatteryHealthTracker.recordBatteryState(context, 15, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		// Back above full while NOT charging -> tracking resets without counting a cycle
+		BatteryHealthTracker.recordBatteryState(context, 98, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		assertEquals(0, BatteryHealthTracker.getChargeCycles(context));
+
+		// And a fresh low->full charge after the reset still counts exactly one cycle
+		BatteryHealthTracker.recordBatteryState(context, 18, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 97, BatteryManager.BATTERY_STATUS_CHARGING);
+		assertEquals(1, BatteryHealthTracker.getChargeCycles(context));
+	}
+
+	@Test
+	public void firstUseDate_isInitializedOnFirstRecord() {
+		assertEquals(0, BatteryHealthTracker.getFirstUseDate(context));
+		BatteryHealthTracker.recordBatteryState(context, 55, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		assertTrue(BatteryHealthTracker.getFirstUseDate(context) > 0);
+		assertTrue(BatteryHealthTracker.getDaysSinceFirstUse(context) >= 0);
+	}
+
+	@Test
+	public void effectiveCycleCount_fallsBackToTrackedEstimate() {
+		// No OS EXTRA_CYCLE_COUNT is available under test, so the effective count is the tracked one
+		BatteryHealthTracker.recordBatteryState(context, 12, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 99, BatteryManager.BATTERY_STATUS_CHARGING);
+		assertEquals(1, BatteryHealthTracker.getEffectiveCycleCount(context));
+	}
+
+	@Test
+	public void designCapacity_persistsAndClears() {
+		assertFalse(BatteryHealthTracker.hasDesignCapacity(context));
+		assertEquals(0, BatteryHealthTracker.getDesignCapacity(context));
+
+		BatteryHealthTracker.setDesignCapacity(context, 4000);
+		assertTrue(BatteryHealthTracker.hasDesignCapacity(context));
+		assertEquals(4000, BatteryHealthTracker.getDesignCapacity(context));
+
+		// A non-positive value clears the stored capacity
+		BatteryHealthTracker.setDesignCapacity(context, 0);
+		assertFalse(BatteryHealthTracker.hasDesignCapacity(context));
+		assertEquals(0, BatteryHealthTracker.getDesignCapacity(context));
+	}
+
+	@Test
+	public void measuredHealth_requiresDesignCapacity() {
+		// Without a design capacity there's nothing to measure against
+		assertEquals(-1, BatteryHealthTracker.getMeasuredHealthPercentage(context));
+	}
+
+	@Test
+	public void resetHealthData_clearsCyclesAndFirstUse() {
+		BatteryHealthTracker.recordBatteryState(context, 10, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 96, BatteryManager.BATTERY_STATUS_CHARGING);
+		assertEquals(1, BatteryHealthTracker.getChargeCycles(context));
+
+		BatteryHealthTracker.resetHealthData(context);
+		assertEquals(0, BatteryHealthTracker.getChargeCycles(context));
+		assertEquals(0, BatteryHealthTracker.getFirstUseDate(context));
+	}
+
+	@Test
+	public void gradeAndDescription_stayConsistentForNewBattery() {
+		// A brand-new battery (0 cycles) grades Excellent with the matching description
+		final BatteryHealthGrade grade = BatteryHealthTracker.getHealthGrade(context);
+		assertEquals(BatteryHealthGrade.EXCELLENT, grade);
+		assertEquals(BatteryHealthTracker.describeHealthGrade(grade),
+				BatteryHealthTracker.getHealthDescription(context));
+	}
+}


### PR DESCRIPTION
Addresses #15. **Stacked on #32** (`feature/32-design-capacity`) because the tracker tests exercise the design-capacity / `BatteryHealthGrade` APIs added there — retarget to `master` once #32 merges.

## Why
Coverage was limited to `BatteryDO` arithmetic and a few pure helpers; the stateful components behind the reported bugs (cycle tracker, receivers) had none. Robolectric + Mockito were already on the test classpath but unused.

## What changed
- **`BatteryHealthTrackerStateTest`** (Robolectric) — the charge-cycle state machine: starts at the low threshold, completes on charge to full, resets when reaching full **without** charging, accumulates across partial charges; plus first-use-date init, effective-cycle-count fallback, design-capacity persistence/clear, measured-health-requires-design-capacity, and grade/description consistency.
- **`BatteryLevelReceiverTest`** (Robolectric + Mockito) — critical/warning/full threshold selection and de-dup logic (no repeat while in-band; `alertEveryTick` repeats), driven through a sticky `ACTION_BATTERY_CHANGED` intent with `NotificationService` mocked to assert *which* alert is chosen.
- **`PowerConnectionReceiverTest`** (Robolectric + Mockito) — charger-type detection (AC/wireless), healthy-charge flag at low battery, same-state de-dup, and disconnect cleanup.
- **`build.gradle`** — `testOptions.unitTests.includeAndroidResources = true` so Robolectric can resolve the app's string keys.

Quiet-hours logic is already covered by the existing `NotificationServiceTest` (`isWithinTimeRange`).

## Testing
`./gradlew :app:testDebugUnitTest` — **54 tests, 0 failures** (21 new). These are JVM/Robolectric tests, no device needed.

## Acceptance criteria (#15)
- [x] Cycle/health state machine covered.
- [x] Receiver threshold + de-dup logic covered.
- [x] Quiet-hours covered (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)