### PR TITLE
Debug menu: reset only debug-injected cycles, not real tracking (#29)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -31,6 +31,9 @@ public class BatteryHealthTracker {
 	private static final String PREF_FIRST_USE_DATE = "_battery_health_first_use_date";
 	private static final String PREF_LAST_LOW_BATTERY = "_battery_health_last_low_battery";
 	private static final String PREF_CYCLE_IN_PROGRESS = "_battery_health_cycle_in_progress";
+	// Debug-only cycle offset kept separate from real tracking so it can be cleared without
+	// destroying genuine data (see the debug menu in BatteryInsightsActivity).
+	private static final String PREF_DEBUG_CHARGE_CYCLES = "_battery_health_debug_charge_cycles";
 
 	// Battery thresholds for cycle tracking
 	private static final int LOW_BATTERY_THRESHOLD = 20;
@@ -112,20 +115,39 @@ public class BatteryHealthTracker {
 
 	/**
 	 * Gets the best-available charge cycle count: the OS-reported value where the device exposes it
-	 * (Android 14+ {@code EXTRA_CYCLE_COUNT}), otherwise this app's own tracked estimate.
+	 * (Android 14+ {@code EXTRA_CYCLE_COUNT}), otherwise this app's own tracked estimate. Any
+	 * debug-injected cycles are added on top so the debug menu still visibly affects the display and
+	 * health estimate (even on devices that report an OS cycle count).
 	 * <p>
 	 * Used for both the displayed cycle count and the health estimate so the two stay consistent.
 	 *
 	 * @param context Application context
 	 *
-	 * @return Charge cycle count (OS-reported if available, else the tracked estimate)
+	 * @return Charge cycle count (OS-reported if available, else the tracked estimate) plus any
+	 * debug-injected cycles
 	 */
 	public static int getEffectiveCycleCount(final Context context) {
 		if (isNull(context)) {
 			return 0;
 		}
 		final int osCycleCount = SystemService.getChargeCycleCount(context);
-		return osCycleCount > 0 ? osCycleCount : getChargeCycles(context);
+		final int base = osCycleCount > 0 ? osCycleCount : getChargeCycles(context);
+		return base + getDebugChargeCycles(context);
+	}
+
+	/**
+	 * Gets the number of debug-injected charge cycles (0 in normal use). Tracked separately from real
+	 * cycles so {@link #resetDebugData} can clear them without touching genuine tracking.
+	 *
+	 * @param context Application context
+	 *
+	 * @return Debug-injected cycle count
+	 */
+	public static int getDebugChargeCycles(final Context context) {
+		if (isNull(context)) {
+			return 0;
+		}
+		return PreferenceManager.getDefaultSharedPreferences(context).getInt(PREF_DEBUG_CHARGE_CYCLES, 0);
 	}
 
 	/**
@@ -242,7 +264,8 @@ public class BatteryHealthTracker {
 	}
 
 	/**
-	 * Resets all health tracking data. Use with caution!
+	 * Resets <em>all</em> health tracking data, including the first-use date and real charge cycles.
+	 * Use with caution — for undoing only debug-injected cycles, prefer {@link #resetDebugData}.
 	 *
 	 * @param context Application context
 	 */
@@ -256,12 +279,31 @@ public class BatteryHealthTracker {
 		     .remove(PREF_FIRST_USE_DATE)
 		     .remove(PREF_LAST_LOW_BATTERY)
 		     .remove(PREF_CYCLE_IN_PROGRESS)
+		     .remove(PREF_DEBUG_CHARGE_CYCLES)
 		     .apply();
 		Log.i(TAG, "Battery health data reset");
 	}
 
 	/**
-	 * Adds test charge cycles for debugging/testing purposes.
+	 * Clears only the debug-injected charge cycles, leaving the first-use date and real tracked
+	 * cycles intact. This is the reset a tester wants after injecting dummy cycles.
+	 *
+	 * @param context Application context
+	 */
+	public static void resetDebugData(final Context context) {
+		if (isNull(context)) {
+			return;
+		}
+		PreferenceManager.getDefaultSharedPreferences(context)
+		                 .edit()
+		                 .remove(PREF_DEBUG_CHARGE_CYCLES)
+		                 .apply();
+		Log.i(TAG, "Debug-injected charge cycles cleared");
+	}
+
+	/**
+	 * Adds debug-injected test charge cycles, tracked separately from real cycles so they can be
+	 * cleared via {@link #resetDebugData} without destroying genuine tracking.
 	 * DEBUG/TEST METHOD - Do not use in production!
 	 *
 	 * @param context Application context
@@ -272,11 +314,11 @@ public class BatteryHealthTracker {
 			return;
 		}
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-		final int currentCycles = prefs.getInt(PREF_CHARGE_CYCLES, 0);
+		final int currentDebugCycles = prefs.getInt(PREF_DEBUG_CHARGE_CYCLES, 0);
 		prefs.edit()
-		     .putInt(PREF_CHARGE_CYCLES, currentCycles + cyclesToAdd)
+		     .putInt(PREF_DEBUG_CHARGE_CYCLES, currentDebugCycles + cyclesToAdd)
 		     .apply();
-		Log.i(TAG, "Added " + cyclesToAdd + " test charge cycles. Total: " + (currentCycles + cyclesToAdd));
+		Log.i(TAG, "Added " + cyclesToAdd + " debug charge cycles. Debug total: " + (currentDebugCycles + cyclesToAdd));
 	}
 
 	/**
@@ -292,13 +334,16 @@ public class BatteryHealthTracker {
 		}
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 		final int cycles = prefs.getInt(PREF_CHARGE_CYCLES, 0);
+		final int debugCycles = prefs.getInt(PREF_DEBUG_CHARGE_CYCLES, 0);
 		final long firstUse = prefs.getLong(PREF_FIRST_USE_DATE, 0);
 		final boolean cycleInProgress = prefs.getBoolean(PREF_CYCLE_IN_PROGRESS, false);
 		final long lastLowBattery = prefs.getLong(PREF_LAST_LOW_BATTERY, 0);
 
 		return "Tracking Status:\n" +
 				"- First Use: " + (firstUse == 0 ? "Not initialized" : new java.util.Date(firstUse)) + "\n" +
-				"- Charge Cycles: " + cycles + "\n" +
+				"- Charge Cycles (real): " + cycles + "\n" +
+				"- Charge Cycles (debug-injected): " + debugCycles + "\n" +
+				"- Effective Cycle Count: " + getEffectiveCycleCount(context) + "\n" +
 				"- Cycle in Progress: " + cycleInProgress + "\n" +
 				"- Last Low Battery: " + (lastLowBattery == 0 ? "Never" : new java.util.Date(lastLowBattery)) + "\n" +
 				"- Days Since First Use: " + getDaysSinceFirstUse(context);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -121,7 +121,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 				"Add 50 Test Cycles",
 				"Add 300 Test Cycles",
 				"Add 600 Test Cycles",
-				"Reset All Data"
+				"Reset debug data",
+				"Reset ALL (incl. real data)"
 		};
 
 		new AlertDialog.Builder(this)
@@ -132,7 +133,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 						case 1 -> addTestCycles(50);
 						case 2 -> addTestCycles(300);
 						case 3 -> addTestCycles(600);
-						case 4 -> resetHealthData();
+						case 4 -> resetDebugData();
+						case 5 -> resetHealthData();
 					}
 				})
 				.setNegativeButton("Cancel", null)
@@ -161,16 +163,26 @@ public class BatteryInsightsActivity extends BaseActivity {
 	}
 
 	/**
-	 * Resets all health tracking data.
+	 * Clears only the debug-injected cycles, leaving the first-use date and real cycles intact.
+	 */
+	private void resetDebugData() {
+		BatteryHealthTracker.resetDebugData(this);
+		updateHealthData();
+		Toast.makeText(this, "Debug data cleared", Toast.LENGTH_SHORT).show();
+	}
+
+	/**
+	 * Resets all health tracking data, including the first-use date and real charge cycles.
 	 */
 	private void resetHealthData() {
 		new AlertDialog.Builder(this)
-				.setTitle("Reset Health Data?")
-				.setMessage("This will delete all tracked battery health data. Are you sure?")
+				.setTitle("Reset ALL health data?")
+				.setMessage("This deletes ALL tracked battery health data, including the first-use date "
+						+ "and real charge cycles. Are you sure?")
 				.setPositiveButton("Reset", (dialog, which) -> {
 					BatteryHealthTracker.resetHealthData(this);
 					updateHealthData();
-					Toast.makeText(this, "Health data reset", Toast.LENGTH_SHORT).show();
+					Toast.makeText(this, "All health data reset", Toast.LENGTH_SHORT).show();
 				})
 				.setNegativeButton("Cancel", null)
 				.show();


### PR DESCRIPTION
Closes #29. Follow-up from the debug-menu review (#14 / #21).

## Problem
The debug **"Reset All Data"** wiped *everything* — first-use date (so "Days in Use" → 0) and any **real** accumulated charge cycles. And `addTestChargeCycles` added straight into the same `PREF_CHARGE_CYCLES` counter as real cycles, so injected and real cycles were indistinguishable.

## Change
Track debug-injected cycles in a separate `PREF_DEBUG_CHARGE_CYCLES` offset:
- `addTestChargeCycles` writes to the debug offset; `getEffectiveCycleCount` adds it on top of the real/OS count, so injection still visibly affects the display and health estimate.
- New `resetDebugData()` clears **only** the injected offset — first-use date and real cycles untouched. Debug menu action: **"Reset debug data"**.
- `resetHealthData()` (menu: **"Reset ALL (incl. real data)"**) still does the full wipe, now including the debug offset.
- `getDebugInfo` reports real vs debug-injected vs effective counts.

## Acceptance criteria
- [x] After injecting dummy cycles then "Reset debug data", "Days in Use" and the real cycle count are unchanged; only injected cycles are removed.

## Testing
`./gradlew :app:assembleDebug :app:testDebugUnitTest` — build + tests pass. (An automated regression test for the debug offset wants the Robolectric infra from #38, which isn't on master yet; can add once that lands.) Not device-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)