### PR TITLE
Debug menu: read-only info in release, gate mutating actions (#30)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -97,15 +97,12 @@ public class BatteryInsightsActivity extends BaseActivity {
 
 	/**
 	 * Sets up the hidden debug menu (long-press on health percentage).
-	 * DEBUG feature for testing battery health tracking.
+	 * <p>
+	 * The long-press entry point is always registered: in release builds it surfaces only the
+	 * read-only "Show Debug Info" dump (harmless, useful for diagnosing user reports), while the
+	 * data-mutating actions are gated to debuggable builds by {@link #showDebugMenu}.
 	 */
 	private void setupDebugMenu() {
-		// Debug tools (inject/reset cycles) must not be reachable in release builds, where a
-		// long-press could let a user silently corrupt their tracked health data.
-		final boolean debuggable = (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
-		if (!debuggable) {
-			return;
-		}
 		healthPercentageText.setOnLongClickListener(v -> {
 			showDebugMenu();
 			return true;
@@ -113,9 +110,19 @@ public class BatteryInsightsActivity extends BaseActivity {
 	}
 
 	/**
-	 * Shows debug menu with options to test battery health tracking.
+	 * Shows the debug menu. Read-only "Show Debug Info" is always available; the data-mutating
+	 * actions (inject/reset cycles) are only offered in debuggable builds, where a long-press can't
+	 * let a normal user silently corrupt their tracked health data.
 	 */
 	private void showDebugMenu() {
+		final boolean debuggable = (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+
+		if (!debuggable) {
+			// Release: read-only tracking dump only
+			showDebugInfo();
+			return;
+		}
+
 		final String[] options = {
 				"Show Debug Info",
 				"Add 50 Test Cycles",


### PR DESCRIPTION
Closes #30. **Stacked on #29** (`feature/29-debug-reset-scope`) — retarget to `master` once #39 merges. Follow-up from the debug-menu review (#14 / #21).

## Change
#21 gated the *entire* battery-health debug menu (long-press on the health %) behind debuggable builds. The read-only **"Show Debug Info"** dump is harmless and useful for diagnosing user reports, so split the menu into two tiers:
- **Always available (incl. release):** long-press surfaces the read-only tracking dump.
- **Debug builds only:** add test cycles, reset debug data, reset ALL.

The long-press entry point stays unobtrusive so normal users won't stumble into it, and no data-mutating action is reachable in release.

## Acceptance criteria
- [x] In a release build, long-press surfaces only the read-only debug info; add/reset actions are not reachable.

## Testing
`./gradlew :app:assembleDebug` passes. Release gating is a build-config branch (`FLAG_DEBUGGABLE`); not device-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)