### PR TITLE
Semantic notification icons: thermometer + state-aware status (#34)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -196,7 +196,7 @@ public final class NotificationService {
 		final String temperature = TemperatureUtils.format(context, rawTenthsC);
 
 		final Notification.Builder builder = new Notification.Builder(context, CHANNEL_ID_TEMPERATURE)
-				.setSmallIcon(R.drawable.ic_stat_device_battery_charging_20)
+				.setSmallIcon(R.drawable.ic_stat_temperature_hot)
 				.setTicker(context.getString(R.string.notification_temperature_ticker))
 				.setContentTitle(context.getString(R.string.notification_temperature_title))
 				.setContentText(context.getString(R.string.notification_temperature_content, temperature))
@@ -727,22 +727,23 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Choose a small icon for the ongoing notification based on charging state and level.
+	 * Choose a small icon for the ongoing notification that reflects the actual battery state: a
+	 * charging bolt only while actively charging, otherwise a plain battery whose fill matches the
+	 * level. (A charged-but-still-plugged battery reads as full, without a bolt.)
 	 *
 	 * @param batteryDO Current battery snapshot, or null if unavailable
 	 * @return Drawable resource id
 	 */
 	private static int ongoingIconRes(final BatteryDO batteryDO) {
 		if (isNull(batteryDO)) {
-			return R.drawable.ic_stat_device_battery_charging_50;
+			return R.drawable.ic_stat_battery_full;
 		}
-		final int status = batteryDO.getStatus();
-		if (status == BatteryManager.BATTERY_STATUS_FULL || status == BatteryManager.BATTERY_STATUS_CHARGING) {
-			return R.drawable.ic_stat_device_battery_charging_full;
+		if (batteryDO.getStatus() == BatteryManager.BATTERY_STATUS_CHARGING) {
+			return R.drawable.ic_stat_battery_charging;
 		}
 		return Math.round(batteryDO.getBatteryPercentage()) <= 50
-		       ? R.drawable.ic_stat_device_battery_charging_20
-		       : R.drawable.ic_stat_device_battery_charging_50;
+		       ? R.drawable.ic_stat_battery_low
+		       : R.drawable.ic_stat_battery_full;
 	}
 
 	/**

--- a/app/src/main/res/drawable/ic_stat_battery_charging.xml
+++ b/app/src/main/res/drawable/ic_stat_battery_charging.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Battery outline with a charging bolt, shown only while actively charging (white-on-transparent). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Outline: outer silhouette with the body hollowed out (even-odd) -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M10,4 L14,4 L14,6 L17,6 L17,22 L7,22 L7,6 L10,6 Z M8.5,7.5 L15.5,7.5 L15.5,20.5 L8.5,20.5 Z" />
+    <!-- Lightning bolt inside the body -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12.8,8 L9.5,14.2 L11.7,14.2 L11.2,20 L14.5,13.2 L12.3,13.2 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_stat_battery_full.xml
+++ b/app/src/main/res/drawable/ic_stat_battery_full.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Solid battery for a high/known level while discharging (white-on-transparent status icon). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10,4 L14,4 L14,6 L17,6 L17,22 L7,22 L7,6 L10,6 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_stat_battery_low.xml
+++ b/app/src/main/res/drawable/ic_stat_battery_low.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Battery outline with a low fill, for <=50% while discharging (white-on-transparent). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Outline: outer silhouette with the body hollowed out (even-odd) -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M10,4 L14,4 L14,6 L17,6 L17,22 L7,22 L7,6 L10,6 Z M8.5,7.5 L15.5,7.5 L15.5,20.5 L8.5,20.5 Z" />
+    <!-- Low charge: bottom quarter filled -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8.5,16 L15.5,16 L15.5,20.5 L8.5,20.5 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_stat_temperature_hot.xml
+++ b/app/src/main/res/drawable/ic_stat_temperature_hot.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Thermometer glyph for the high-temperature alert (white-on-transparent status icon). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M15,13V5c0,-1.66 -1.34,-3 -3,-3S9,3.34 9,5v8c-1.21,0.91 -2,2.37 -2,4c0,2.76 2.24,5 5,5s5,-2.24 5,-5C17,15.37 16.21,13.91 15,13zM12,4c0.55,0 1,0.45 1,1h-1v1h1v2h-1v1h1v2h-2V5C11,4.45 11.45,4 12,4z" />
+</vector>


### PR DESCRIPTION
Closes #34. Cosmetic polish from #5 (persistent notification) and #18 (temperature alert), which reused the "battery charging" glyphs as placeholders.

## Problem
- The **temperature alert** showed `ic_stat_device_battery_charging_20` — a charging icon for a *heat* alert.
- The **persistent status notification** picked a *charging* glyph by level, so it could show a charging bolt even while **discharging**.

## Change
Added a small monochrome, white-on-transparent **vector** icon set (status-bar icons render as an alpha mask):
- `ic_stat_temperature_hot` — thermometer, for the high-temperature alert.
- `ic_stat_battery_full` / `ic_stat_battery_low` / `ic_stat_battery_charging` — the ongoing status icon now shows a **bolt only while actively charging**, otherwise a plain battery whose fill reflects the level. A charged-but-still-plugged battery (`BATTERY_STATUS_FULL`) reads as a full battery, no bolt.

The pre-existing critical/warning/full **alert** icons are intentionally left as-is (out of scope per the issue); the old charging PNGs remain in use there.

## Acceptance criteria
- [x] The temperature alert shows a heat/thermometer icon, not a charging glyph.
- [x] The persistent notification's icon reflects charging vs. discharging correctly.

## Testing
`./gradlew :app:assembleDebug` — vectors compile, build passes. A rendered preview of the four icons is attached in the PR discussion / was shared for review. **Not device-verified** — worth a glance in the real status bar (small-icon masking) on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)