### PR TITLE
docs: refresh README + guidelines; split human vs AI-agent docs

### DIFF
--- a/.claude/guidelines.md
+++ b/.claude/guidelines.md
@@ -1,12 +1,14 @@
 # SimpleBatteryNotifier Development Guidelines
 
+> **Audience:** this is the machine-facing rulebook for the AI code-review agent. The human-facing companion is [`../CODE_REVIEW_GUIDELINES.md`](../CODE_REVIEW_GUIDELINES.md); keep the two in sync when a standard changes.
+
 ## Project Overview
 SimpleBatteryNotifier is an Android application that monitors battery status and provides notifications for power events. The app displays battery information with a circular progress bar and supports customizable alerts.
 
 ## Code Style
 
 ### Java Language Features
-- **Use Java 21+ features** where appropriate
+- **Use modern Java (JDK 25) features** where appropriate
   - Switch expressions with `yield` keyword
   - Pattern matching (when available)
   - Records for simple data carriers
@@ -45,16 +47,18 @@ SimpleBatteryNotifier is an Android application that monitors battery status and
 
 ### Error Handling
 - Check for null before accessing system services or intent extras
-- Use graceful degradation for non-critical features (e.g., battery capacity via reflection)
+- Use graceful degradation for non-critical features (e.g., battery-capacity estimate returning 0 when unsupported)
 - Log warnings (not errors) for expected failures
 - Add clear comments explaining why certain failures are acceptable
+- **Never swallow exceptions silently and never `catch (Exception)` broadly.** A catch must take real recovery action or log. Catch the narrowest type.
+- **Don't use exceptions for expected validation.** Unchecked exceptions like `NumberFormatException` can be avoided by validating first (e.g. `s.matches("\\d{1,5}")`) and then parsing without a `try`. A catch that shows the user feedback (e.g. `ActivityNotFoundException` → Toast) is fine.
 
 ## Android Specifics
 
 ### API Level Support
 - **Minimum SDK**: API 26 (Android 8.0 Oreo)
-- **Target SDK**: API 35 (Android 15)
-- **Compile SDK**: API 35
+- **Target SDK**: API 36
+- **Compile SDK**: API 36
 - Use modern APIs with fallbacks for older versions when needed
 
 ### API Version Handling
@@ -80,35 +84,9 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
 - **Document workarounds**: If using deprecated API, explain the necessity in code comments
 
 ### Reflection Usage
-- **Avoid reflection** except when absolutely necessary (e.g., accessing internal Android APIs)
-- **Always document reflection usage**:
-  - Add `@SuppressLint("DiscouragedPrivateApi")` annotation
-  - Add comprehensive JavaDoc explaining:
-    - Why reflection is necessary
-    - What could go wrong
-    - How failures are handled gracefully
-    - That it's acceptable for the feature to fail
-
-Example:
-```java
-/**
- * Get battery capacity using reflection (internal API)
- * <p>
- * WARNING: This method accesses internal Android APIs via reflection.
- * Android does not provide a public API to retrieve battery capacity (mAh).
- * This implementation may not work on all devices or future Android versions.
- * <p>
- * The method gracefully handles failures and returns 0 if capacity cannot be determined.
- * This is acceptable as capacity is informational only and not critical for app functionality.
- *
- * @param context The application context
- * @return Battery capacity in mAh, or 0 if unavailable or unsupported
- */
-@SuppressLint("DiscouragedPrivateApi")
-public static synchronized int getBatteryCapacity(final Context context) {
-    // Implementation with try-catch for graceful failure
-}
-```
+- **Avoid reflection.** Prefer public APIs; reflection into internal/private Android APIs is blocked by non-SDK restrictions on modern Android and should not be used.
+  - Historical note: battery capacity was once read by reflecting into the internal `PowerProfile`. That was **removed** — `SystemService.getBatteryCapacity` now estimates full capacity from public `BatteryManager` properties (`BATTERY_PROPERTY_CHARGE_COUNTER ÷ BATTERY_PROPERTY_CAPACITY`), returning 0 when unsupported.
+- If reflection is ever truly unavoidable, document it thoroughly (why it's needed, what can fail, how failure degrades gracefully) and keep the pure/computational part unit-testable.
 
 ### UI Components
 - **Edge-to-Edge Display**: Enabled via `WindowCompat.setDecorFitsSystemWindows(getWindow(), false)`
@@ -151,22 +129,21 @@ public static synchronized int getBatteryCapacity(final Context context) {
 - **API Level notes**: Document API compatibility decisions
   - Example: `// BATTERY_PLUGGED_WIRELESS added in API 17`
 
-## Testing Strategy (Future)
+## Testing Strategy
 
-### Unit Tests
-- Test all business logic in service classes
-- Test data transformations and calculations
-- Mock Android framework dependencies
+The project uses **JUnit 4** for pure logic, with **Robolectric** and **Mockito** available for framework-dependent tests. `build.gradle` sets `testOptions.unitTests.includeAndroidResources = true` so Robolectric can resolve app resources.
 
-### Integration Tests
-- Test fragment lifecycle
-- Test service interactions
-- Test preference persistence
+### Unit Tests (JUnit) — prefer these
+- Extract pure, Android-free helpers and test them directly (e.g. `SystemService.estimateFullCapacityMah`, `NotificationService.isWithinTimeRange`, `TemperatureUtils`, `BatteryDO.getBatteryPercentage`).
+- Cover edge cases: division by zero, boundaries, unsupported/`MIN_VALUE` readings.
 
-### UI Tests
-- Test critical user flows
-- Test settings changes
-- Test battery status updates
+### Framework Tests (Robolectric + Mockito)
+- Use `@RunWith(RobolectricTestRunner.class) @Config(sdk = 34)` — targetSdk 36 is beyond Robolectric's supported range.
+- SharedPreferences-backed state (cycle tracker, design capacity) via a real `ApplicationProvider` context.
+- Receivers: drive `onReceive` with a sticky `ACTION_BATTERY_CHANGED` intent and `mockStatic(NotificationService.class)` to assert which alert is chosen; reset static de-dup state between tests.
+
+### Add tests with new logic
+- New business logic (thresholds, state machines, parsing) should ship with tests that would fail on regression.
 
 ## Code Quality
 
@@ -246,12 +223,17 @@ public static synchronized int getBatteryCapacity(final Context context) {
 ## Internationalization
 
 ### String Resources
-- All user-facing text must be in string resources
-- Use format strings for dynamic content
-- Example: `<string name="battery_percentage">%d%%</string>`
+- **All user-facing text must be in string resources — never a hardcoded Java literal** (no `setText("Excellent")`, no `Toast` string literals). Map values/enums to a `@StringRes` in a UI/service layer.
+- Use positional format args for dynamic content: `<string name="notification_status_content">%1$d%% · %2$s · %3$s</string>`.
+
+### Arabic (`values-ar/`) Parity
+- The app ships an Arabic translation. Every new user-facing string in `values/strings.xml` needs a matching entry in `values-ar/strings.xml`.
+- Quick check: diff the `<string name=…>` lists of the two files.
+- Consider the `MissingTranslation` lint check as a build gate.
+- Arabic wording is drafted by the AI agent and reviewed by the maintainer (native speaker) before merge.
 
 ### Resource Naming
-- Prefix internal keys with underscore: `_pref_key_*`
+- Prefix internal keys with underscore: `_pref_key_*`. Internal identifiers (`_pref_key_*`, `_pref_value_*`, `pref_category_*`, `extra_category`, URIs) are **not** translated — leave them out of `values-ar/`.
 - Use descriptive names: `battery_health_good`, not `bh_g`
 
 ## Common Patterns in This Codebase

--- a/CODE_REVIEW_GUIDELINES.md
+++ b/CODE_REVIEW_GUIDELINES.md
@@ -2,6 +2,8 @@
 
 These are the coding standards and best practices for the SimpleBatteryNotifier Android project.
 
+> **Audience:** this is the human-facing standard for contributors and reviewers. The AI code-review agent has a machine-facing companion at [`.claude/guidelines.md`](.claude/guidelines.md); keep the two in sync when a standard changes.
+
 ---
 
 ## 📋 Table of Contents
@@ -9,9 +11,11 @@ These are the coding standards and best practices for the SimpleBatteryNotifier 
 - [Build Configuration](#build-configuration)
 - [Code Style](#code-style)
 - [Null Safety](#null-safety)
+- [Exception Handling](#exception-handling)
 - [Variables](#variables)
 - [Code Organization](#code-organization)
 - [Android Best Practices](#android-best-practices)
+- [Localization](#localization)
 - [Performance](#performance)
 - [Comments & Documentation](#comments--documentation)
 
@@ -165,6 +169,60 @@ if(nonNull(bitmap)) {
 	imageView.setImageBitmap(bitmap);
 }
 ```
+
+---
+
+## 🧯 Exception Handling
+
+### 1. Never Swallow Exceptions Silently
+
+**A `catch` block must either take real recovery action or log — never both empty and silent.**
+
+```java
+// ❌ BAD - swallowed, no log, and overly broad
+try {
+	value = Integer.parseInt(input);
+} catch (Exception e) {
+	value = -1;
+}
+
+// ✅ GOOD - if a catch is unavoidable, catch the narrowest type and log it
+try {
+	return Settings.Global.getInt(resolver, ZEN_MODE) == ZEN_MODE_IMPORTANT_INTERRUPTIONS;
+} catch (Settings.SettingNotFoundException e) {
+	return false; // setting genuinely absent on this device — expected default
+}
+```
+
+**Why?** An empty/sentinel catch with no log hides real bugs and conflates unexpected failures with expected ones.
+
+### 2. Don't Use Exceptions for Expected Validation
+
+**If something is "normal to fail" (user/persisted input), handle it with an ordinary branch — not `try/catch`.**
+
+`NumberFormatException` and friends are *unchecked*, so you can validate first and skip the catch entirely:
+
+```java
+// ❌ BAD - exception as the validation path
+try {
+	value = Integer.parseInt(trimmed);
+} catch (NumberFormatException e) {
+	value = -1; // "invalid" signalled via exception
+}
+
+// ✅ GOOD - validate, then parse (provably can't throw)
+if (!trimmed.matches("\\d{1,5}")) {
+	showRangeError();
+	return false;
+}
+final int value = Integer.parseInt(trimmed); // safe: matched \d{1,5}
+```
+
+### 3. Catch the Narrowest Type
+
+- Prefer `ActivityNotFoundException` over `Exception` around `startActivity`.
+- A catch that gives the user feedback (e.g. a Toast) is fine and is **not** "silent".
+- Accepted idioms (document why): `unregisterReceiver` throwing `IllegalArgumentException` when already unregistered; `Settings.SettingNotFoundException` → default.
 
 ---
 
@@ -360,6 +418,42 @@ new Thread(() ->{
 private static final ExecutorService executor = Executors.newSingleThreadExecutor();
 executor.execute(() -> doBackgroundWork());
 ```
+
+---
+
+## 🌍 Localization
+
+**The app ships an Arabic translation (`res/values-ar/`), so every user-facing string must be localizable.**
+
+### 1. No Hardcoded User-Facing Strings
+
+```java
+// ❌ BAD - hardcoded English, can never be translated
+healthStatusText.setText("Excellent");
+Toast.makeText(this, "Health data reset", Toast.LENGTH_SHORT).show();
+
+// ✅ GOOD - string resource
+healthStatusText.setText(R.string.health_grade_excellent);
+```
+
+Keep the mapping from a value/enum to its string resource in a UI/service layer (mirroring `SystemService.getHealthString`), not as inline literals.
+
+### 2. Keep `values-ar/` in Parity
+
+- Every new user-facing string in `values/strings.xml` needs a matching entry in `values-ar/strings.xml`.
+- Quick check: diff the `<string name=…>` lists of the two files.
+- Consider enabling the `MissingTranslation` lint check as a build gate.
+
+### 3. Don't Translate Internal Keys
+
+Identifiers are **not** copy — leave them out of `values-ar/`:
+
+- `_pref_key_*`, `_pref_value_*`, `pref_category_*`, `extra_category`, URIs, and URLs.
+
+### 4. Format Strings & RTL
+
+- Use positional format args for dynamic content: `<string name="notification_status_content">%1$d%% · %2$s · %3$s</string>`.
+- Use `start`/`end` (not `left`/`right`) in layouts and test with an RTL language.
 
 ---
 
@@ -559,6 +653,8 @@ When reviewing code, check:
 - [ ] No code duplication (DRY)
 - [ ] Methods ≤ 50 lines
 - [ ] All null checks in place
+- [ ] No silent/broad `catch`; expected failures validated, not caught
+- [ ] No hardcoded user-facing strings; `values-ar/` kept in parity
 - [ ] Permissions checked (Android 13+)
 - [ ] Modern APIs used (no deprecated)
 - [ ] Thread-safe for static fields
@@ -589,4 +685,4 @@ When reviewing code, check:
 
 ---
 
-*Last updated: 2025-12-07*
+*Last updated: 2026-07-02*

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ No surprises. No clutter. Just simple battery notifications.
 - 🔋 **Battery Alerts**
     - Get notified at *Critical* and *Warning* levels
     - Receive an alert when charging is complete
+    - **High-temperature safety alert** when the battery gets too hot
 
 - ⏰ **Customizable Notifications**
     - Choose *when* to get notified (e.g., no alerts while you’re sleeping)
@@ -34,7 +35,8 @@ No surprises. No clutter. Just simple battery notifications.
     - Helpful if you charge your phone in **Airplane Mode** for faster charging — you’ll get reminded not to forget it there
 
 - 📊 **Battery Insights**
-    - Extra details like **temperature**, **health**, and more
+    - Estimated **battery health %**, **charge cycles**, temperature, voltage, and more
+    - Enter your battery’s **design capacity** for a measured health estimate
 
 - 📌 **Persistent & Repeated Alerts**
     - Keep a permanent battery status notification if you tend to forget things
@@ -50,7 +52,7 @@ No surprises. No clutter. Just simple battery notifications.
 ---
 
 ## 📥 Installation
-(Add installation instructions here, e.g., link to Google Play or APK download)
+A packaged release (Google Play / F-Droid / APK) is not published yet. For now, build it yourself — see [Building from Source](#building-from-source) below.
 
 ---
 
@@ -79,11 +81,11 @@ cd SimpleBatteryNotifier
 - **Gradle 9.2+**
 
 ### Testing
-The project includes **11 focused unit tests** covering critical business logic:
-- **BatteryDO calculation logic** - Percentage calculation with edge cases
-- **Division by zero handling** - Tests defensive programming
-- **Negative values and boundary conditions** - Real-world edge cases
-- **Builder pattern validation** - Method chaining correctness
+The project has a focused unit-test suite (JUnit; Robolectric and Mockito are available for framework-dependent tests) covering the logic most likely to regress:
+- **Battery math** — percentage calculation, division-by-zero and boundary handling (`BatteryDO`)
+- **Quiet-hours window** — inclusive/exclusive and overnight ranges (`NotificationService`)
+- **Temperature** — °C/°F conversion and threshold/hysteresis (`TemperatureUtils`)
+- **Capacity estimate** — full-capacity math from public `BatteryManager` readings (`SystemService`)
 
 Run tests with:
 ```bash
@@ -111,9 +113,11 @@ Pull requests and suggestions are welcome!
 
 Before submitting:
 1. Ensure all tests pass: `./gradlew test`
-2. Follow the coding guidelines in `.claude/guidelines.md`
+2. Follow the coding standards in [`CODE_REVIEW_GUIDELINES.md`](CODE_REVIEW_GUIDELINES.md)
 3. Add tests for new features
 4. Update documentation as needed
+
+> The repo keeps two guideline docs: [`CODE_REVIEW_GUIDELINES.md`](CODE_REVIEW_GUIDELINES.md) is the human-facing standard for contributors; [`.claude/guidelines.md`](.claude/guidelines.md) is the machine-facing rulebook for the AI code-review agent. Keep them in sync when standards change.
 
 ---
 
@@ -124,7 +128,7 @@ Licensed under the Apache License, Version 2.0 - see the [LICENSE](LICENSE) file
 
 ## 🏆 Code Quality
 
-- ✅ **Focused unit tests** (11 tests, 100% pass rate)
+- ✅ **Focused unit-test suite** (JUnit + Robolectric, 100% pass rate)
 - ✅ **Zero critical bugs**
 - ✅ **Full accessibility support** (TalkBack compatible)
 - ✅ **Modern Java 25** features (switch expressions, pattern matching, records)


### PR DESCRIPTION
Refreshes the docs that had drifted from the recent feature work, and formalizes the two guideline files by audience (per maintainer's call):
- **`CODE_REVIEW_GUIDELINES.md`** → human contributors/reviewers.
- **`.claude/guidelines.md`** → the AI code-review agent.

README now links contributors to the human doc and cross-references both.

## README.md
- **Fix the stale "11 unit tests" claim** (and its `BatteryDO`-only description) — master actually has 29 tests across 4 files; rewrote to describe the covered areas without a brittle exact count.
- **Features**: added the high-temperature safety alert (#18) and the expanded Battery Insights (health %, charge cycles, user-entered design capacity → measured health; #7/#12/#32).
- Replaced the empty **Installation** placeholder with a build-from-source pointer.
- Contributor guidance now points at `CODE_REVIEW_GUIDELINES.md` (was `.claude/guidelines.md`).

## CODE_REVIEW_GUIDELINES.md (human)
- New **Exception Handling** section — no silent/broad `catch`; validate expected input instead of catching (from #43).
- New **Localization** section — string resources + `values-ar` parity; internal keys not translated (from #42).
- Updated the review checklist and the "last updated" date; added an audience note.

## .claude/guidelines.md (agent)
- **Fixed stale facts**: target/compile SDK `35 → 36`, Java `21+ → 25`.
- **Removed obsolete reflection guidance** — battery capacity no longer uses reflection into `PowerProfile`; it's estimated from public `BatteryManager` properties (#12/#31). Updated the example accordingly.
- **"Testing Strategy (Future)" → real strategy**: JUnit + Robolectric + Mockito, `includeAndroidResources`, and the receiver/tracker test patterns.
- Added the exception-handling and `values-ar` parity standards so the agent enforces them.

Docs-only; no code changes. Relates to #42 and #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)