### PR TITLE
Gate measured battery health to near-full charge (#37)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -56,6 +56,12 @@ public class BatteryHealthTracker {
 	private static final int GOOD_HEALTH_PERCENT = 80;
 	private static final int FAIR_HEALTH_PERCENT = 70;
 
+	// Minimum battery level (%) at which the measured health figure is trustworthy. The current
+	// full-capacity estimate is charge-counter (µAh) ÷ CAPACITY (integer %), so at low charge the
+	// integer rounding of CAPACITY dominates and the figure becomes jumpy. Below this level we
+	// withhold the measured figure and fall back to the cycle-based estimate. See issue #37.
+	static final int MEASURED_HEALTH_MIN_BATTERY_LEVEL = 80;
+
 	/**
 	 * Records battery state and updates charge cycle count if appropriate.
 	 *
@@ -230,30 +236,45 @@ public class BatteryHealthTracker {
 	 * <p>
 	 * {@code health % = current full capacity (measured) / design capacity (user-entered) * 100}.
 	 * This is the accurate figure requested in #32; it only applies when the user has entered a
-	 * design capacity <em>and</em> the device reports the live charge counter used to estimate the
-	 * current full capacity.
+	 * design capacity, the device reports the live charge counter used to estimate the current full
+	 * capacity, <em>and</em> the battery is charged to at least {@link #MEASURED_HEALTH_MIN_BATTERY_LEVEL}%
+	 * (below which the estimate is too noisy — see issue #37).
 	 *
 	 * @param context Application context
 	 *
-	 * @return Measured health percentage (1-100), or -1 when it cannot be determined
+	 * @return Measured health percentage (1-100), or -1 when it cannot be determined or the battery is
+	 * too low for a stable reading
 	 */
 	public static int getMeasuredHealthPercentage(final Context context) {
 		if (isNull(context)) {
 			return -1;
 		}
-		return computeMeasuredHealth(SystemService.getBatteryCapacity(context), getDesignCapacity(context));
+		return computeMeasuredHealth(
+				SystemService.getBatteryCapacity(context),
+				getDesignCapacity(context),
+				SystemService.getBatteryLevelPercent(context));
 	}
 
 	/**
 	 * Pure helper for the measured health percentage, unit-testable with no Android dependencies.
+	 * <p>
+	 * The measured figure is withheld (returns -1) below {@link #MEASURED_HEALTH_MIN_BATTERY_LEVEL}%
+	 * charge, where the charge-counter estimate is dominated by the integer CAPACITY rounding and
+	 * would otherwise show a jumpy value (issue #37). Callers then fall back to the cycle-based estimate.
 	 *
-	 * @param currentFullMah measured current full capacity in mAh (0 when unknown)
-	 * @param designMah      user-entered design capacity in mAh (0 when unset)
+	 * @param currentFullMah     measured current full capacity in mAh (0 when unknown)
+	 * @param designMah          user-entered design capacity in mAh (0 when unset)
+	 * @param batteryLevelPercent current battery level 1-100 (-1 when unknown)
 	 *
-	 * @return health percentage clamped to 1-100, or -1 when either input is unusable
+	 * @return health percentage clamped to 1-100, or -1 when any input is unusable or the battery is
+	 * below the near-full threshold
 	 */
-	static int computeMeasuredHealth(final int currentFullMah, final int designMah) {
+	static int computeMeasuredHealth(final int currentFullMah, final int designMah, final int batteryLevelPercent) {
 		if (currentFullMah <= 0 || designMah <= 0) {
+			return -1;
+		}
+		// Too low (or unknown) to trust the charge-counter estimate: defer to the cycle-based figure.
+		if (batteryLevelPercent < MEASURED_HEALTH_MIN_BATTERY_LEVEL) {
 			return -1;
 		}
 		final int percent = Math.round(currentFullMah * 100f / designMah);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -253,6 +253,28 @@ public final class SystemService {
 	}
 
 	/**
+	 * Read the current battery charge level as a percentage via the public
+	 * {@link BatteryManager#BATTERY_PROPERTY_CAPACITY} property.
+	 * <p>
+	 * Used to gate the measured health figure: the charge-counter-based full-capacity estimate is
+	 * only stable near full charge (see issue #37 and {@code BatteryHealthTracker}).
+	 *
+	 * @param context The application context
+	 *
+	 * @return current battery level (1-100), or -1 when it cannot be determined
+	 */
+	public static int getBatteryLevelPercent(final Context context) {
+		final BatteryManager batteryManager = (BatteryManager) context.getSystemService(Context.BATTERY_SERVICE);
+		if (isNull(batteryManager)) {
+			Log.w(TAG, "BatteryManager service unavailable");
+			return -1;
+		}
+		final int capacityPercent = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
+		// getIntProperty returns Integer.MIN_VALUE for unsupported properties; keep only a valid 1-100.
+		return (capacityPercent >= 1 && capacityPercent <= 100) ? capacityPercent : -1;
+	}
+
+	/**
 	 * Read the OS-reported charge cycle count, where available.
 	 * <p>
 	 * Exposed to apps via the public {@link BatteryManager#EXTRA_CYCLE_COUNT} extra on

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
@@ -13,29 +13,45 @@ import static org.junit.Assert.assertTrue;
  */
 public class BatteryHealthTrackerTest {
 
+	// A near-full battery level, at/above the threshold, so these cases exercise the math (not the gate).
+	private static final int FULL = 95;
+
 	@Test
 	public void computeMeasuredHealth_typicalReadings() {
 		// 3800 mAh measured against a 4000 mAh design capacity -> 95%
-		assertEquals(95, BatteryHealthTracker.computeMeasuredHealth(3800, 4000));
+		assertEquals(95, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, FULL));
 		// A healthy battery measuring at its rated capacity -> 100%
-		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4000, 4000));
+		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4000, 4000, FULL));
 		// Worn battery: 3000 of 5000 -> 60%
-		assertEquals(60, BatteryHealthTracker.computeMeasuredHealth(3000, 5000));
+		assertEquals(60, BatteryHealthTracker.computeMeasuredHealth(3000, 5000, FULL));
 	}
 
 	@Test
 	public void computeMeasuredHealth_clampsToRange() {
 		// Measured above rated (fresh cell / rounding) is clamped to 100
-		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4200, 4000));
+		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4200, 4000, FULL));
 		// Never reports 0; the smallest positive result is 1
-		assertEquals(1, BatteryHealthTracker.computeMeasuredHealth(1, 15000));
+		assertEquals(1, BatteryHealthTracker.computeMeasuredHealth(1, 15000, FULL));
 	}
 
 	@Test
 	public void computeMeasuredHealth_unusableInputs_returnsMinusOne() {
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(0, 4000));
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 0));
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(-5, 4000));
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(0, 4000, FULL));
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 0, FULL));
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(-5, 4000, FULL));
+	}
+
+	@Test
+	public void computeMeasuredHealth_belowNearFullThreshold_returnsMinusOne() {
+		final int threshold = BatteryHealthTracker.MEASURED_HEALTH_MIN_BATTERY_LEVEL;
+		// Just below the threshold: withheld as too noisy, so callers fall back to the cycle estimate.
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, threshold - 1));
+		// A low charge level is withheld even with otherwise-usable capacity inputs.
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, 5));
+		// Unknown level (-1) is also withheld.
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, -1));
+		// Exactly at the threshold: the measured figure is returned.
+		assertEquals(95, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, threshold));
 	}
 
 	@Test


### PR DESCRIPTION
Closes #37.

## Problem
The **measured** health figure from #32 (`current full capacity ÷ user-entered design capacity`) is derived from `CHARGE_COUNTER` (µAh) ÷ `CAPACITY` (an **integer** 0–100 %). At low charge the integer rounding of `CAPACITY` dominates the division, so the estimated full capacity — and therefore the "measured" health % — swings noticeably between visits. Since that figure is presented as the *honest* number ("Measured from rated capacity"), a jumpy value undermines exactly the accuracy #32 set out to add.

## Fix
Only trust the measured figure near full charge; below the threshold, fall back to the existing cycle-based estimate (already labelled "estimated").

- **`SystemService.getBatteryLevelPercent()`** — reads the current level via public `BATTERY_PROPERTY_CAPACITY` (returns -1 when unavailable).
- **`BatteryHealthTracker.computeMeasuredHealth()`** now takes the battery level and returns `-1` below `MEASURED_HEALTH_MIN_BATTERY_LEVEL` (**80 %**); `getMeasuredHealthPercentage()` passes the live level through.
- **UI unchanged**: `BatteryInsightsActivity.updateHealthData()` already falls back to the cycle-based estimate whenever measured health is `-1`, so a low battery now shows the estimate with no regression and **no new user-facing strings** (keeps #42 scope clean).

## Acceptance criteria
- ✅ Measured figure no longer computed/shown at low charge (withheld < 80 %).
- ✅ Below threshold shows the cycle-based estimate (no regression).
- ✅ Near-full behaviour unchanged from #32.

## Tests
- Threaded the battery level through the existing `computeMeasuredHealth` cases (near-full).
- Added `computeMeasuredHealth_belowNearFullThreshold_returnsMinusOne`: below threshold, low charge, and unknown (-1) are all withheld; exactly at the threshold returns the figure.
- Build + full unit suite green (`:app:assembleDebug :app:testDebugUnitTest`).

> Not device-verified — threshold (80 %) may want tuning during real-device testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)