### PR TITLE
Audit try/catch: log or validate instead of swallowing (#43)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
@@ -8,6 +8,7 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -45,6 +46,8 @@ import static java.util.Objects.nonNull;
  */
 public class GenericPreferenceFragment extends PreferenceFragmentCompat
 		implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+	private static final String TAG = "GenericPreferenceFrag";
 
 	// Default battery level values (from pref_general.xml)
 	private static final int DEFAULT_WARNING_BATTERY_LEVEL = 40;
@@ -358,8 +361,10 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 				if (nonNull(ringtone)) {
 					ringtonePref.setSummary(ringtone.getTitle(ringtonePref.getContext()));
 				}
-			} catch (Exception e) {
-				// If ringtone not found, just show URI
+			} catch (RuntimeException e) {
+				// Resolving the ringtone can fail (e.g. SecurityException on a revoked media URI):
+				// fall back to showing the raw URI, but don't swallow it silently.
+				Log.w(TAG, "Could not resolve ringtone title for " + uri + "; showing URI", e);
 				ringtonePref.setSummary(uri);
 			}
 		}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/SignatureFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/SignatureFragment.java
@@ -1,5 +1,6 @@
 package com.almothafar.simplebatterynotifier.ui.fragment;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -55,8 +56,9 @@ public class SignatureFragment extends Fragment {
 			}
 			final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(link));
 			startActivity(browserIntent);
-		} catch (final Exception e) {
-			Log.e(TAG, "Error opening developer link", e);
+		} catch (final ActivityNotFoundException e) {
+			// The only expected failure: no app can handle the link (e.g. no browser installed).
+			Log.e(TAG, "No app available to open the developer link", e);
 		}
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/RingtonePreference.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/RingtonePreference.java
@@ -198,11 +198,9 @@ public class RingtonePreference extends Preference {
 					setSummary(ringtone.getTitle(getContext()));
 					return;
 				}
-			} catch (Exception e) {
-				final String errorMsg = e.getMessage();
-				if (nonNull(errorMsg)) {
-					Log.e(TAG, "Error loading ringtone: " + errorMsg);
-				}
+			} catch (RuntimeException e) {
+				// Resolving the ringtone can fail (e.g. SecurityException on a revoked media URI).
+				Log.e(TAG, "Error loading ringtone for " + currentRingtoneUri, e);
 			}
 		}
 		// Empty or null URI means no ringtone selected (silent/none)

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreference.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreference.java
@@ -3,6 +3,7 @@ package com.almothafar.simplebatterynotifier.ui.preference;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
+import android.util.Log;
 import androidx.preference.DialogPreference;
 
 import static java.util.Objects.isNull;
@@ -12,6 +13,8 @@ import static java.util.Objects.nonNull;
  * Custom TimePickerPreference for AndroidX preferences
  */
 public class TimePickerPreference extends DialogPreference {
+	private static final String TAG = "TimePickerPreference";
+
 	private int hour = 0;
 	private int minute = 0;
 
@@ -50,20 +53,37 @@ public class TimePickerPreference extends DialogPreference {
 			time = "00:00";
 		}
 
+		// The value is our own persisted "HH:MM", so anything that doesn't validate is unexpected
+		// corruption — validate the parts (no exception-as-control-flow) and log if we have to reset.
 		final String[] parts = time.split(":");
-		if (parts.length == 2) {
-			try {
-				hour = Integer.parseInt(parts[0]);
-				minute = Integer.parseInt(parts[1]);
-			} catch (NumberFormatException e) {
-				hour = 0;
-				minute = 0;
-			}
+		if (parts.length == 2 && isTimePart(parts[0], 23) && isTimePart(parts[1], 59)) {
+			hour = Integer.parseInt(parts[0]);   // safe: isTimePart matched \d{1,2}
+			minute = Integer.parseInt(parts[1]);
+		} else {
+			Log.w(TAG, "Malformed persisted time \"" + time + "\"; defaulting to 00:00");
+			hour = 0;
+			minute = 0;
 		}
 
 		final String timeStr = String.format("%02d:%02d", hour, minute);
 		persistString(timeStr);
 		setSummary(timeStr);
+	}
+
+	/**
+	 * Whether {@code part} is a 1-2 digit number within {@code 0..max}. Pre-validates so the
+	 * subsequent {@link Integer#parseInt} can't throw or overflow — no catch needed.
+	 *
+	 * @param part candidate hour/minute component
+	 * @param max  inclusive upper bound (23 for hours, 59 for minutes)
+	 *
+	 * @return true when {@code part} is a valid time component
+	 */
+	private static boolean isTimePart(final String part, final int max) {
+		if (!part.matches("\\d{1,2}")) {
+			return false;
+		}
+		return Integer.parseInt(part) <= max; // safe: matched \d{1,2}, fits in an int
 	}
 
 	public int getHour() {


### PR DESCRIPTION
Closes #43.

Brings the code in line with the exception-handling standard already documented in [`CODE_REVIEW_GUIDELINES.md`](CODE_REVIEW_GUIDELINES.md) and [`.claude/guidelines.md`](.claude/guidelines.md) (both added in #44): *catch the narrowest type, never swallow silently, and validate expected input rather than using exceptions as control flow.*

## Should-fix (silent and/or broad) — fixed
- **`TimePickerPreference.setTime`** — the value is our own persisted `HH:MM`, so malformed input is *unexpected corruption*, not normal validation. Replaced `try { parseInt } catch { hour=minute=0 }` (no log) with a `validate-then-parse` helper (`\d{1,2}` + range check) and a `Log.w` when it must reset — same pattern as the design-capacity fix from #36.
- **`GenericPreferenceFragment.updateRingtonePreferenceSummary`** — `catch (Exception)` with an empty body that silently fell back to the URI. Narrowed to `RuntimeException` and added a `Log.w` (still falls back to the raw URI).

## Consider-narrowing (broad but logged) — narrowed
- **`SignatureFragment.openDeveloperLink`** — `catch (Exception)` → `ActivityNotFoundException`, the only expected failure (no browser). Keeps the existing `Log.e`.
- **`RingtonePreference.updateSummary`** — `catch (Exception)` → `RuntimeException`; now logs the offending URI + full stack trace instead of only `e.getMessage()`.

## Left as-is (accepted idioms per #43)
`PowerConnectionService.unregisterReceiver` (`IllegalArgumentException` when already unregistered), `NotificationService.isInDoNotDisturbMode` (`SettingNotFoundException` → default), `NotificationService.shutdown` (`InterruptedException` → `shutdownNow()` + re-interrupt) — all correct and documented.

## Notes
- The standard itself was already documented in #44, so **no doc changes needed** — this PR is the code catching up.
- The hardcoded `"None"` fallback in `RingtonePreference` is untouched here; it's tracked under localization #42.
- No user-facing behaviour change — failures are now diagnosable in logcat.

## Tests
- Build + full unit suite green (`:app:assembleDebug :app:testDebugUnitTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
