### PR TITLE
Localize hardcoded strings + complete Arabic (values-ar) + lint gate (#42)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,13 @@ android {
             includeAndroidResources = true
         }
     }
+
+    lint {
+        // Fail the build if any user-facing string is missing an Arabic translation, so future
+        // localization gaps are caught at build time rather than shipping English fallbacks.
+        // Internal identifiers/defaults are marked translatable="false" so they're exempt.
+        error 'MissingTranslation'
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/model/BatteryHealthGrade.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/model/BatteryHealthGrade.java
@@ -8,23 +8,14 @@ package com.almothafar.simplebatterynotifier.model;
  * cycle-count- or capacity-derived quality bucket shown on the Battery Insights screen. Using an
  * enum (instead of the previous "Excellent"/"Good"/... strings) keeps producers and consumers in
  * sync via exhaustive switches and removes the risk of a silent typo falling through to a default.
+ * <p>
+ * The user-facing label and description are localized string resources resolved in the
+ * presentation layer (see {@code BatteryHealthTracker.labelResId} / {@code describeHealthGrade}),
+ * so this model carries no display copy.
  */
 public enum BatteryHealthGrade {
-	EXCELLENT("Excellent"),
-	GOOD("Good"),
-	FAIR("Fair"),
-	POOR("Poor");
-
-	private final String label;
-
-	BatteryHealthGrade(final String label) {
-		this.label = label;
-	}
-
-	/**
-	 * @return the human-readable label shown to the user
-	 */
-	public String getLabel() {
-		return label;
-	}
+	EXCELLENT,
+	GOOD,
+	FAIR,
+	POOR
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.BatteryManager;
 import android.util.Log;
+import androidx.annotation.StringRes;
 import androidx.preference.PreferenceManager;
 
+import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
 
 import static java.util.Objects.isNull;
@@ -400,25 +402,46 @@ public class BatteryHealthTracker {
 	 * @return Detailed health description
 	 */
 	public static String getHealthDescription(final Context context) {
-		return describeHealthGrade(getHealthGrade(context));
+		return describeHealthGrade(context, getHealthGrade(context));
 	}
 
 	/**
-	 * Gets a detailed health description for a wear grade.
+	 * Resolves the localized label for a wear grade (e.g. "Excellent").
 	 * <p>
-	 * Shared by the cycle-based and measured health paths so the wording stays consistent.
+	 * Kept as a resource id (not on the enum) so the model stays free of Android/resource coupling,
+	 * mirroring {@code SystemService.getHealthString}. Callers pass it to {@code setText}/{@code getString}.
 	 *
 	 * @param grade the battery wear grade
 	 *
-	 * @return Detailed health description
+	 * @return the string resource id for the grade's label
 	 */
-	public static String describeHealthGrade(final BatteryHealthGrade grade) {
+	@StringRes
+	public static int labelResId(final BatteryHealthGrade grade) {
 		return switch (grade) {
-			case EXCELLENT -> "Your battery is in excellent condition. Continue with normal usage patterns.";
-			case GOOD -> "Your battery is in good condition with minimal degradation. Normal usage expected.";
-			case FAIR -> "Your battery shows moderate wear. You may notice slightly reduced battery life.";
-			case POOR -> "Your battery has significant wear. Consider battery replacement if experiencing poor performance.";
+			case EXCELLENT -> R.string.battery_health_grade_excellent;
+			case GOOD -> R.string.battery_health_grade_good;
+			case FAIR -> R.string.battery_health_grade_fair;
+			case POOR -> R.string.battery_health_grade_poor;
 		};
+	}
+
+	/**
+	 * Gets a localized, detailed health description for a wear grade.
+	 * <p>
+	 * Shared by the cycle-based and measured health paths so the wording stays consistent.
+	 *
+	 * @param context Application context (for resource resolution)
+	 * @param grade   the battery wear grade
+	 *
+	 * @return Detailed, localized health description
+	 */
+	public static String describeHealthGrade(final Context context, final BatteryHealthGrade grade) {
+		return context.getString(switch (grade) {
+			case EXCELLENT -> R.string.battery_health_desc_excellent;
+			case GOOD -> R.string.battery_health_desc_good;
+			case FAIR -> R.string.battery_health_desc_fair;
+			case POOR -> R.string.battery_health_desc_poor;
+		});
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -89,7 +89,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 		final BatteryHealthGrade grade = measured
 		                                 ? BatteryHealthTracker.gradeForPercentage(measuredHealth)
 		                                 : BatteryHealthTracker.getHealthGrade(this);
-		final String healthDescription = BatteryHealthTracker.describeHealthGrade(grade);
+		final String healthDescription = BatteryHealthTracker.describeHealthGrade(this, grade);
 		final int chargeCycles = BatteryHealthTracker.getEffectiveCycleCount(this);
 		final int daysInUse = BatteryHealthTracker.getDaysSinceFirstUse(this);
 
@@ -98,7 +98,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 		healthPercentageText.setTextColor(getHealthColor(grade));
 
 		// Update health status text
-		healthStatusText.setText(grade.getLabel());
+		healthStatusText.setText(BatteryHealthTracker.labelResId(grade));
 		healthStatusText.setTextColor(getHealthColor(grade));
 
 		// Tell the user whether the figure is measured (honest) or a cycle-based estimate

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -122,7 +122,7 @@ public class MainActivity extends BaseActivity {
 				isGranted -> {
 					if (isGranted) {
 						Log.d(TAG, "Notification permission granted");
-						Toast.makeText(this, "Thank you! Notifications are now enabled.", Toast.LENGTH_SHORT).show();
+						Toast.makeText(this, R.string.notifications_enabled_toast, Toast.LENGTH_SHORT).show();
 					} else {
 						Log.w(TAG, "Notification permission denied");
 						showPermissionDeniedSnackbar();

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -32,8 +32,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingLeft="16dp"
-                android:paddingRight="16dp"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
                 android:paddingTop="16dp"
                 android:paddingBottom="@dimen/content_navigation_bar_padding">
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -56,8 +56,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
         android:paddingTop="16dp"
         android:paddingBottom="@dimen/content_navigation_bar_padding"
         android:background="@android:color/white">

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">منبه البطارية البسيط</string>
     <string name="action_settings">الإعدادات</string>
     <string name="title_activity_settings">الإعدادات</string>
@@ -107,4 +107,64 @@
     <!-- Accessibility -->
     <string name="battery_progress_description">البطارية عند %1$d بالمئة</string>
     <string name="battery_details_separator">:</string>
+
+    <!-- ==== Added for localization pass #42 (drafted by Claude — pending maintainer review) ==== -->
+
+    <!-- Persistent foreground-service status notification -->
+    <string name="notification_status_channel_name">حالة البطارية</string>
+    <string name="notification_status_channel_description">حالة البطارية المستمرة أثناء تفعيل المراقبة</string>
+    <string name="notification_status_content">%1$d%% · %2$s · %3$s</string>
+
+    <!-- High temperature alert -->
+    <string name="notify_high_temperature">تنبيه ارتفاع الحرارة</string>
+    <string name="notify_high_temperature_summary_on">ينبهك عندما ترتفع حرارة البطارية كثيراً (استخدام مكثف، شحن، بيئة حارة)</string>
+    <string name="notify_high_temperature_summary_off">تنبيهات ارتفاع الحرارة معطلة</string>
+    <string name="high_temperature_threshold">التنبيه عند تجاوز الحرارة</string>
+    <string name="notification_temperature_channel_name">حرارة البطارية</string>
+    <string name="notification_temperature_channel_description">تنبيهات عندما تصبح حرارة البطارية غير آمنة</string>
+    <string name="notification_temperature_ticker">البطارية حارة</string>
+    <string name="notification_temperature_title">حرارة البطارية مرتفعة</string>
+    <string name="notification_temperature_content">حرارة البطارية %1$s. قلّل الاستخدام ودعها تبرد.</string>
+    <string name="notification_temperature_content_big">حرارة بطاريتك %1$s، وهي أعلى من النطاق الآمن. الحرارة العالية تسرّع تلف البطارية وقد تكون خطرة. أوقف الشحن أو الاستخدام المكثف (الألعاب، الملاحة، الكاميرا) ودع الهاتف يبرد.</string>
+
+    <!-- Battery Insights screen -->
+    <string name="battery_insights_title">تحليلات البطارية</string>
+    <string name="battery_insights_menu">تحليلات البطارية</string>
+    <string name="view_battery_insights">عرض تحليلات البطارية</string>
+    <string name="battery_health">صحة البطارية</string>
+    <string name="charge_cycles">دورات الشحن</string>
+    <string name="days_in_use">أيام الاستخدام</string>
+    <string name="about_battery_health">عن بطاريتك</string>
+    <string name="battery_health_description_placeholder">ستظهر معلومات صحة بطاريتك هنا.</string>
+    <string name="design_capacity">السعة التصميمية</string>
+    <string name="design_capacity_value">%1$d mAh</string>
+    <string name="set_design_capacity_action">أدخل السعة المقدّرة لحساب صحة أدق</string>
+    <string name="design_capacity_dialog_title">السعة التصميمية للبطارية</string>
+    <string name="design_capacity_dialog_message">أدخل السعة المقدّرة لبطاريتك بوحدة mAh من مواصفات الشركة المصنّعة. لقد عبّأنا تقديراً مقاساً — أكّده أو صحّحه للحصول على قيمة صحة دقيقة.</string>
+    <string name="design_capacity_hint">السعة (mAh)</string>
+    <string name="look_up_my_model">ابحث عن طرازي</string>
+    <string name="no_browser_found">لا يوجد متصفح لفتح البحث</string>
+    <string name="save">حفظ</string>
+    <string name="clear">مسح</string>
+    <string name="error_design_capacity_range">أدخل سعة بين %1$d و %2$d mAh</string>
+    <string name="health_basis_measured">مقاسة من السعة المقدّرة</string>
+    <string name="health_basis_estimated">مقدّرة من دورات الشحن</string>
+    <string name="how_it_works">كيف يعمل</string>
+    <string name="how_battery_health_works" formatted="false" tools:ignore="TypographyDashes">تُقدَّر صحة البطارية بناءً على دورات الشحن. تُحتسب دورة شحن عندما تُشحن بطاريتك من 20% أو أقل إلى 95% أو أكثر. يبدأ هذا التتبع عند أول استخدام لهذا التطبيق.\n\nتقديرات الصحة:\n• 0–300 دورة: ممتازة (95–100%)\n• 300-500 دورة: جيدة (85-95%)\n• 500-800 دورة: مقبولة (70-85%)\n• 800+ دورة: ضعيفة (&lt;70%)</string>
+    <string name="developed_by">طوّره</string>
+    <!-- Proper name — transliteration; maintainer to confirm or keep Latin -->
+    <string name="developer_name">المظفّر الحسن</string>
+
+    <!-- Battery health wear grades and their descriptions -->
+    <string name="battery_health_grade_excellent">ممتازة</string>
+    <string name="battery_health_grade_good">جيدة</string>
+    <string name="battery_health_grade_fair">مقبولة</string>
+    <string name="battery_health_grade_poor">ضعيفة</string>
+    <string name="battery_health_desc_excellent">بطاريتك في حالة ممتازة. تابع استخدامك الطبيعي.</string>
+    <string name="battery_health_desc_good">بطاريتك في حالة جيدة مع تدهور طفيف. الاستخدام الطبيعي متوقع.</string>
+    <string name="battery_health_desc_fair">تُظهر بطاريتك تآكلاً متوسطاً. قد تلاحظ انخفاضاً طفيفاً في عمر البطارية.</string>
+    <string name="battery_health_desc_poor">بطاريتك متآكلة بشكل كبير. فكّر في استبدال البطارية إذا لاحظت أداءً ضعيفاً.</string>
+
+    <!-- Notification permission granted -->
+    <string name="notifications_enabled_toast">شكراً! تم تفعيل التنبيهات الآن.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,47 +140,62 @@
     <string name="error_design_capacity_range">Enter a capacity between %1$d and %2$d mAh</string>
     <string name="health_basis_measured">Measured from rated capacity</string>
     <string name="health_basis_estimated">Estimated from charge cycles</string>
+
+    <!-- Battery health wear grades (shown as the health status) and their descriptions -->
+    <string name="battery_health_grade_excellent">Excellent</string>
+    <string name="battery_health_grade_good">Good</string>
+    <string name="battery_health_grade_fair">Fair</string>
+    <string name="battery_health_grade_poor">Poor</string>
+    <string name="battery_health_desc_excellent">Your battery is in excellent condition. Continue with normal usage patterns.</string>
+    <string name="battery_health_desc_good">Your battery is in good condition with minimal degradation. Normal usage expected.</string>
+    <string name="battery_health_desc_fair">Your battery shows moderate wear. You may notice slightly reduced battery life.</string>
+    <string name="battery_health_desc_poor">Your battery has significant wear. Consider battery replacement if experiencing poor performance.</string>
     <string name="how_it_works">How It Works</string>
     <string name="how_battery_health_works" formatted="false" tools:ignore="TypographyDashes">Battery health is estimated based on charge cycles. A charge cycle counts when your battery charges from 20% or below to 95% or above. This tracking starts when you first use this app.\n\nHealth estimates:\n• 0–300 cycles: Excellent (95–100%)\n• 300-500 cycles: Good (85-95%)\n• 500-800 cycles: Fair (70-85%)\n• 800+ cycles: Poor (&lt;70%)</string>
     <string name="developed_by">Developed by</string>
     <string name="developer_name">Al-Mothafar Al-Hasan</string>
-    <string name="developer_link">github.com/almothafar</string>
+    <string name="developer_link" translatable="false">github.com/almothafar</string>
 
-    <!-- Below this line to the end of file is for coding not for labeling -->
-    <string name="extra_category">category</string>
-    <string name="pref_category_general">pref_category_general</string>
-    <string name="pref_category_notifications">pref_category_notifications</string>
-    <string name="pref_category_time_settings">pref_category_time_settings</string>
+    <!-- Shown after the user grants the notification permission -->
+    <string name="notifications_enabled_toast">Thank you! Notifications are now enabled.</string>
 
-    <string name="_pref_key_warn_battery_level">key_warn_battery_level</string>
-    <string name="_pref_key_critical_battery_level">key_critical_battery_level</string>
-    <string name="_pref_key_notifications_sticky">key_notifications_sticky</string>
-    <string name="_pref_key_temperatures_unit">key_temperatures_unit</string>
-    <string name="_pref_key_notifications_vibrate">key_notifications_vibrate</string>
-    <string name="_pref_key_notifications_alert_sound_ringtone">key_notifications_alert_sound_ringtone</string>
-    <string name="_pref_key_notify_for_full_level">key_notify_for_full_level</string>
-    <string name="_pref_key_notifications_full_sound_ringtone">key_notifications_full_sound_ringtone</string>
-    <string name="_pref_key_notify_for_warning_level">key_notify_for_warning_level</string>
-    <string name="_pref_key_notifications_warning_sound_ringtone">key_notifications_warning_sound_ringtone</string>
-    <string name="_pref_key_notifications_time_range">key_notifications_time_range</string>
-    <string name="_pref_key_notifications_time_range_start">key_notifications_time_range_start</string>
-    <string name="_pref_key_notifications_time_range_end">key_notifications_time_range_end</string>
-    <string name="_pref_key_notifications_apply_silent_mode">key_notifications_apply_silent_mode</string>
-    <string name="_pref_key_notify_every_tick">key_notify_every_tick</string>
-    <string name="_pref_key_notify_high_temperature">key_notify_high_temperature</string>
-    <string name="_pref_key_high_temperature_threshold">key_high_temperature_threshold</string>
+    <!-- Below this line to the end of file is for coding not for labeling.
+         These are internal identifiers/defaults, not user copy: marked translatable="false"
+         so the MissingTranslation lint gate does not expect them in values-ar. -->
+    <string name="extra_category" translatable="false">category</string>
+    <string name="pref_category_general" translatable="false">pref_category_general</string>
+    <string name="pref_category_notifications" translatable="false">pref_category_notifications</string>
+    <string name="pref_category_time_settings" translatable="false">pref_category_time_settings</string>
 
-    <string name="_pref_value_temperatures_unit_c">celsius</string>
-    <string name="_pref_value_temperatures_unit_f">fahrenheit</string>
-    <string name="_pref_value_notifications_time_range_end">23:00</string>
-    <string name="_pref_value_notifications_time_range_start">08:00</string>
+    <string name="_pref_key_warn_battery_level" translatable="false">key_warn_battery_level</string>
+    <string name="_pref_key_critical_battery_level" translatable="false">key_critical_battery_level</string>
+    <string name="_pref_key_notifications_sticky" translatable="false">key_notifications_sticky</string>
+    <string name="_pref_key_temperatures_unit" translatable="false">key_temperatures_unit</string>
+    <string name="_pref_key_notifications_vibrate" translatable="false">key_notifications_vibrate</string>
+    <string name="_pref_key_notifications_alert_sound_ringtone" translatable="false">key_notifications_alert_sound_ringtone</string>
+    <string name="_pref_key_notify_for_full_level" translatable="false">key_notify_for_full_level</string>
+    <string name="_pref_key_notifications_full_sound_ringtone" translatable="false">key_notifications_full_sound_ringtone</string>
+    <string name="_pref_key_notify_for_warning_level" translatable="false">key_notify_for_warning_level</string>
+    <string name="_pref_key_notifications_warning_sound_ringtone" translatable="false">key_notifications_warning_sound_ringtone</string>
+    <string name="_pref_key_notifications_time_range" translatable="false">key_notifications_time_range</string>
+    <string name="_pref_key_notifications_time_range_start" translatable="false">key_notifications_time_range_start</string>
+    <string name="_pref_key_notifications_time_range_end" translatable="false">key_notifications_time_range_end</string>
+    <string name="_pref_key_notifications_apply_silent_mode" translatable="false">key_notifications_apply_silent_mode</string>
+    <string name="_pref_key_notify_every_tick" translatable="false">key_notify_every_tick</string>
+    <string name="_pref_key_notify_high_temperature" translatable="false">key_notify_high_temperature</string>
+    <string name="_pref_key_high_temperature_threshold" translatable="false">key_high_temperature_threshold</string>
+
+    <string name="_pref_value_temperatures_unit_c" translatable="false">celsius</string>
+    <string name="_pref_value_temperatures_unit_f" translatable="false">fahrenheit</string>
+    <string name="_pref_value_notifications_time_range_end" translatable="false">23:00</string>
+    <string name="_pref_value_notifications_time_range_start" translatable="false">08:00</string>
 
     <!-- Validation error messages -->
     <string name="error_warning_level_too_low">Warning level must be higher than critical level (%d%%)</string>
     <string name="error_critical_level_too_high">Critical level must be lower than warning level (%d%%)</string>
 
     <!-- Notification service -->
-    <string name="_default_notification_sound_uri">content://settings/system/notification_sound</string>
+    <string name="_default_notification_sound_uri" translatable="false">content://settings/system/notification_sound</string>
 
     <!-- Accessibility -->
     <string name="battery_progress_description">Battery at %1$d percent</string>

--- a/app/src/main/res/values/strings_activity_settings.xml
+++ b/app/src/main/res/values/strings_activity_settings.xml
@@ -1,5 +1,6 @@
 <resources>
-    <string name="preference_title_temperature">@string/temperature_unit</string>
+    <!-- Alias to an already-translated string; not copy itself -->
+    <string name="preference_title_temperature" translatable="false">@string/temperature_unit</string>
     <string-array name="preference_list_temperatures">
         <item>@string/celsius</item>
         <item>@string/fahrenheit</item>

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerStateTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerStateTest.java
@@ -121,7 +121,7 @@ public class BatteryHealthTrackerStateTest {
 		// A brand-new battery (0 cycles) grades Excellent with the matching description
 		final BatteryHealthGrade grade = BatteryHealthTracker.getHealthGrade(context);
 		assertEquals(BatteryHealthGrade.EXCELLENT, grade);
-		assertEquals(BatteryHealthTracker.describeHealthGrade(grade),
+		assertEquals(BatteryHealthTracker.describeHealthGrade(context, grade),
 				BatteryHealthTracker.getHealthDescription(context));
 	}
 }


### PR DESCRIPTION
Closes #42.

⚠️ **Needs a native-speaker review of the Arabic** before merge (per the agreed workflow: Claude drafts, maintainer reviews). All strings compile and lint passes; the review is about wording, not correctness.

## A. Hardcoded Java literals → resources
- **`BatteryHealthGrade`** — removed the hardcoded English `label`; the enum is now pure. Label + description are resolved as string resources in the presentation layer via `BatteryHealthTracker.labelResId(grade)` and `describeHealthGrade(Context, grade)`, mirroring `SystemService.getHealthString`. Call sites in `BatteryInsightsActivity` updated; the state test updated to the new signature.
- **`MainActivity`** — the "notifications enabled" toast now uses `R.string.notifications_enabled_toast`.
- Debug-menu literals left in English (explicitly exempt in #42).

## B. `values-ar` completeness
- Added Arabic for all **37** previously English-only user-facing strings (Battery Insights, high-temperature alert #18, persistent status notification #5, design-capacity #32) plus the **9** newly-extracted grade labels/descriptions and the toast.
- **144 / 144** translatable strings now have Arabic parity (verified by name diff).

## Hardening
- Internal identifiers/defaults (`_pref_key_*`, `_pref_value_*`, `pref_category_*`, `extra_category`, `_default_notification_sound_uri`, the `developer_link` URL, and the settings-title alias) marked `translatable="false"`.
- **`lint { error 'MissingTranslation' }`** — future gaps now fail `./gradlew lint`.
- **RTL:** `supportsRtl="true"` was already set and the audit found layouts + Java gravity otherwise RTL-clean; converted the only two `paddingLeft/Right` (symmetric) to `paddingStart/End`.

## Please review these Arabic choices
| Key | English | Arabic draft | Note |
|---|---|---|---|
| `developer_name` | Al-Mothafar Al-Hasan | المظفّر الحسن | Proper name — keep Latin instead? |
| `battery_insights_title` | Battery Insights | تحليلات البطارية | vs. رؤى / إحصاءات? |
| grades | Excellent/Good/Fair/Poor | ممتازة/جيدة/مقبولة/ضعيفة | |
| `design_capacity_value` / hint / range | … mAh | kept **mAh** in Latin | transliterate the unit? |
| `health_basis_measured/estimated` | Measured / Estimated | مقاسة / مقدّرة | |

## Tests
`:app:assembleDebug`, `:app:testDebugUnitTest`, and `:app:lintDebug` all green.

> Follow-up (separate issue, per your call): the in-app **System / Arabic / English** language picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)