### PR TITLE
Add in-app language picker: System / Arabic / English (#48)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
+            android:localeConfig="@xml/locales_config"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
 
@@ -66,6 +67,17 @@
                 android:label="@string/battery_insights_title"
                 android:theme="@style/AppTheme.NoActionBar"
                 android:parentActivityName=".ui.MainActivity"/>
+
+        <!-- Enables AndroidX per-app locale auto-storage so the in-app language choice
+             (AppCompatDelegate.setApplicationLocales) survives restarts without a manual store. -->
+        <service
+                android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+                android:enabled="false"
+                android:exported="false">
+            <meta-data
+                    android:name="autoStoreLocales"
+                    android:value="true"/>
+        </service>
 
     </application>
 </manifest>

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
@@ -8,12 +8,15 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.os.LocaleListCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
@@ -122,6 +125,7 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 			if (nonNull(category)) {
 				if (category.equals(getString(R.string.pref_category_general))) {
 					setPreferencesFromResource(R.xml.pref_general, rootKey);
+					configureLanguagePreference();
 				} else if (category.equals(getString(R.string.pref_category_notifications))) {
 					setPreferencesFromResource(R.xml.pref_notification, rootKey);
 					configureTemperatureThreshold();
@@ -130,6 +134,36 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 				}
 			}
 		}
+	}
+
+	/**
+	 * Wire up the app-language picker (System / Arabic / English).
+	 * <p>
+	 * The choice is applied and persisted by AndroidX per-app locales
+	 * ({@link AppCompatDelegate#setApplicationLocales}, stored via the {@code AppLocalesMetadataHolderService}
+	 * declared in the manifest), so the {@link ListPreference} itself is non-persistent — it only
+	 * reflects and triggers the locale. Its value is seeded from the currently applied locale so the
+	 * selection stays in sync when the screen is reopened.
+	 */
+	private void configureLanguagePreference() {
+		final ListPreference pref = findPreference(getString(R.string._pref_key_language));
+		if (isNull(pref)) {
+			return;
+		}
+
+		// Seed the selection from the currently applied app locale ("" = follow the system).
+		final LocaleListCompat current = AppCompatDelegate.getApplicationLocales();
+		pref.setValue(current.isEmpty() ? "" : current.get(0).getLanguage());
+
+		pref.setOnPreferenceChangeListener((preference, newValue) -> {
+			final String tag = (String) newValue;
+			final LocaleListCompat locales = TextUtils.isEmpty(tag)
+					? LocaleListCompat.getEmptyLocaleList()   // follow the system language
+					: LocaleListCompat.forLanguageTags(tag);
+			// Applies immediately (recreates activities); the metadata service persists it across restarts.
+			AppCompatDelegate.setApplicationLocales(locales);
+			return true;
+		});
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -167,4 +167,19 @@
 
     <!-- Notification permission granted -->
     <string name="notifications_enabled_toast">شكراً! تم تفعيل التنبيهات الآن.</string>
+
+    <!-- App language picker -->
+    <string name="pref_language_category">اللغة</string>
+    <string name="pref_title_language">لغة التطبيق</string>
+    <string name="language_system_default">إعدادات النظام</string>
+
+    <!-- Settings category titles -->
+    <string name="pref_cat_title_display">العرض</string>
+    <string name="pref_cat_title_thresholds">حدود مستوى البطارية</string>
+    <string name="pref_cat_title_other">إعدادات أخرى</string>
+    <string name="pref_cat_title_notification">إعدادات التنبيهات</string>
+    <string name="pref_cat_title_full_battery">البطارية الممتلئة</string>
+    <string name="pref_cat_title_warning">مستوى التحذير</string>
+    <string name="pref_cat_title_temperature">الحرارة</string>
+    <string name="pref_cat_title_critical">مستوى البطارية الحرج</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,18 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- App-language picker. Entry labels reference localized strings; the values are BCP-47
+         language tags (identifiers), with an empty first value meaning "follow the system".
+         tools:ignore="MissingTranslation": the arrays are locale-independent; the visible copy
+         lives in the referenced string resources, which are translated. -->
+    <string-array name="language_entries" tools:ignore="MissingTranslation">
+        <item>@string/language_system_default</item>
+        <item>@string/language_arabic</item>
+        <item>@string/language_english</item>
+    </string-array>
+    <string-array name="language_values" tools:ignore="MissingTranslation">
+        <item></item>
+        <item>ar</item>
+        <item>en</item>
+    </string-array>
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,24 @@
     <!-- Shown after the user grants the notification permission -->
     <string name="notifications_enabled_toast">Thank you! Notifications are now enabled.</string>
 
+    <!-- App language picker -->
+    <string name="pref_language_category">Language</string>
+    <string name="pref_title_language">App language</string>
+    <string name="language_system_default">System default</string>
+    <!-- Language autonyms: shown in the language's own script regardless of UI locale -->
+    <string name="language_arabic" translatable="false">العربية</string>
+    <string name="language_english" translatable="false">English</string>
+
+    <!-- Settings category titles -->
+    <string name="pref_cat_title_display">Display</string>
+    <string name="pref_cat_title_thresholds">Battery Level Thresholds</string>
+    <string name="pref_cat_title_other">Other Settings</string>
+    <string name="pref_cat_title_notification">Notification Settings</string>
+    <string name="pref_cat_title_full_battery">Full Battery</string>
+    <string name="pref_cat_title_warning">Warning Level</string>
+    <string name="pref_cat_title_temperature">Temperature</string>
+    <string name="pref_cat_title_critical">Critical Battery Level</string>
+
     <!-- Below this line to the end of file is for coding not for labeling.
          These are internal identifiers/defaults, not user copy: marked translatable="false"
          so the MissingTranslation lint gate does not expect them in values-ar. -->
@@ -184,6 +202,7 @@
     <string name="_pref_key_notify_every_tick" translatable="false">key_notify_every_tick</string>
     <string name="_pref_key_notify_high_temperature" translatable="false">key_notify_high_temperature</string>
     <string name="_pref_key_high_temperature_threshold" translatable="false">key_high_temperature_threshold</string>
+    <string name="_pref_key_language" translatable="false">key_language</string>
 
     <string name="_pref_value_temperatures_unit_c" translatable="false">celsius</string>
     <string name="_pref_value_temperatures_unit_f" translatable="false">fahrenheit</string>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Locales the app ships translations for; lets the Android 13+ system
+     "App languages" screen list them. -->
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="ar"/>
+</locale-config>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -2,7 +2,22 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
-        android:title="Display"
+        android:title="@string/pref_language_category"
+        app:iconSpaceReserved="false">
+
+        <ListPreference
+            android:key="@string/_pref_key_language"
+            android:persistent="false"
+            android:entries="@array/language_entries"
+            android:entryValues="@array/language_values"
+            android:title="@string/pref_title_language"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/pref_cat_title_display"
         app:iconSpaceReserved="false">
 
         <ListPreference
@@ -17,7 +32,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="Battery Level Thresholds"
+        android:title="@string/pref_cat_title_thresholds"
         app:iconSpaceReserved="false">
 
         <SeekBarPreference
@@ -45,7 +60,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="Other Settings"
+        android:title="@string/pref_cat_title_other"
         app:iconSpaceReserved="false">
 
         <SwitchPreference

--- a/app/src/main/res/xml/pref_notification.xml
+++ b/app/src/main/res/xml/pref_notification.xml
@@ -2,7 +2,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
-        android:title="Notification Settings"
+        android:title="@string/pref_cat_title_notification"
         app:iconSpaceReserved="false">
 
         <SwitchPreference
@@ -28,7 +28,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="Full Battery"
+        android:title="@string/pref_cat_title_full_battery"
         app:iconSpaceReserved="false">
 
         <SwitchPreference
@@ -52,7 +52,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="Warning Level"
+        android:title="@string/pref_cat_title_warning"
         app:iconSpaceReserved="false">
 
         <SwitchPreference
@@ -76,7 +76,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="Temperature"
+        android:title="@string/pref_cat_title_temperature"
         app:iconSpaceReserved="false">
 
         <SwitchPreference
@@ -104,7 +104,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="Critical Battery Level"
+        android:title="@string/pref_cat_title_critical"
         app:iconSpaceReserved="false">
 
         <com.almothafar.simplebatterynotifier.ui.preference.RingtonePreference


### PR DESCRIPTION
Closes #48. **Stacked on #47 (#42)** — it needs the completed Arabic strings, so review/merge #47 first (GitHub will retarget this to `master` once #47 lands).

## What it does
A **Language** picker at the top of Settings lets the user force the app language independently of the device locale.

- **Per-app locales (AndroidX):** on change, `AppCompatDelegate.setApplicationLocales(...)` (empty tag = follow system). Applied immediately; persisted across restarts by the `AppLocalesMetadataHolderService` (`autoStoreLocales`) added to the manifest. The `ListPreference` is **non-persistent** and seeds its value from the currently applied locale, so it stays in sync when reopened.
- **`locales_config.xml` + `android:localeConfig`** so the Android 13+ system *App languages* screen lists `en`/`ar`.
- **Arrays:** `language_entries` reference localized strings; autonyms (العربية / English) are `translatable="false"`, only **System default** is localized.

## Also (localization completeness)
Switching to Arabic exposed **8 hardcoded English category titles** in `pref_general.xml` / `pref_notification.xml` (Display, Battery Level Thresholds, Other Settings, Notification Settings, Full Battery, Warning Level, Temperature, Critical Battery Level). Extracted them to strings + added Arabic, so the whole Settings screen localizes. The #42 `MissingTranslation` gate stays green.

## Please review the Arabic
| Key | Arabic | Note |
|---|---|---|
| `pref_title_language` | لغة التطبيق | |
| `language_system_default` | إعدادات النظام | |
| category titles | العرض / حدود مستوى البطارية / إعدادات أخرى / إعدادات التنبيهات / البطارية الممتلئة / مستوى التحذير / الحرارة / مستوى البطارية الحرج | |

## Testing
- `:app:assembleDebug`, `:app:testDebugUnitTest`, `:app:lintDebug` all green.
- ⚠️ **Not device-verified** — please check on a device/emulator: selecting العربية on an English device flips the whole UI to Arabic + RTL and persists across a restart; selecting English on an Arabic device does the reverse; "System default" follows the OS. This is the real end-to-end RTL pass called out in #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)