### PR TITLE
Fix crash opening General settings from language picker's SummaryProvider

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
@@ -325,9 +325,15 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 
 	/**
 	 * Update summary for ListPreference
+	 * <p>
+	 * Skipped when a SummaryProvider is set (e.g. useSimpleSummaryProvider): calling
+	 * setSummary() in that case throws IllegalStateException, and the provider already
+	 * keeps the summary in sync with the selected entry.
 	 */
 	private void updateListPreferenceSummary(final ListPreference listPref) {
-		listPref.setSummary(listPref.getEntry());
+		if (isNull(listPref.getSummaryProvider())) {
+			listPref.setSummary(listPref.getEntry());
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Problem
The app-language `ListPreference` added in #48 (PR #49) uses `app:useSimpleSummaryProvider="true"`, which installs a `SummaryProvider` on the preference. The generic `updateListPreferenceSummary()` calls `setSummary()` on **every** `ListPreference`, and AndroidX `Preference.setSummary()` **throws `IllegalStateException` when a `SummaryProvider` is set**.

`initSummary()` runs on every `onResume()` and recurses into the language category, so **opening the General settings screen crashes on-device**. The existing temperature-unit `ListPreference` never tripped this because it uses the legacy `android:summary="%s"` (no provider) — the language picker is the first one with a provider, so it's a new crash path that unit tests don't exercise.

## Fix
Guard `updateListPreferenceSummary()` to skip when a `SummaryProvider` is present — the same pattern `updateEditTextPreferenceSummary()` already uses. The provider keeps the summary in sync with the selected entry on its own.

One-line follow-up to already-merged #48. Build + unit tests + lint green.

## Testing
- [x] `:app:assembleDebug :app:testDebugUnitTest` green
- [ ] Device: open Settings → General no longer crashes; language summary shows the selected entry