### PR TITLE
🔴 Fix MediaPlayer leak in SystemService.playSound (#51)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -339,6 +339,10 @@ public final class SystemService {
 	 */
 	public static void playSound(final Context context, final Uri alert) {
 		final MediaPlayer mediaPlayer = new MediaPlayer();
+		// Release the native player once playback finishes so repeated alerts don't leak
+		// MediaPlayer instances. Paths where nothing plays release in the finally block below.
+		mediaPlayer.setOnCompletionListener(MediaPlayer::release);
+		boolean playbackStarted = false;
 		try {
 			mediaPlayer.setDataSource(context, alert);
 			final AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
@@ -357,11 +361,18 @@ public final class SystemService {
 				mediaPlayer.setAudioAttributes(audioAttributes);
 				mediaPlayer.prepare();
 				mediaPlayer.start();
+				playbackStarted = true; // OnCompletionListener now owns the release
 			}
 		} catch (IOException e) {
 			final String errorMsg = e.getMessage();
 			if (errorMsg != null) {
 				Log.e(TAG, errorMsg);
+			}
+		} finally {
+			// Nothing is playing (alarm silenced, no AudioManager, or setup failed): release now.
+			// When playback started, the OnCompletionListener releases on completion instead.
+			if (!playbackStarted) {
+				mediaPlayer.release();
 			}
 		}
 	}


### PR DESCRIPTION
## What & why

`SystemService.playSound()` created a `new MediaPlayer()` on every alert but never released it, leaking native audio resources on **all three** paths: after `start()` (no completion listener), when the alarm stream is silenced (`volume == 0`), and in the `catch (IOException)`.

## Changes

- Register `setOnCompletionListener(MediaPlayer::release)` so the player is freed once playback finishes.
- Add a `finally` block that releases the player whenever nothing is playing (silenced stream, missing `AudioManager`, or setup failure). The `finally` also covers unchecked setup exceptions that were previously uncaught.
- Track `playbackStarted` so we don't double-release once the completion listener owns cleanup.

## Testing

- CI: unit tests + debug/release builds.
- 📱 Device check (owner): trigger a low/critical alert repeatedly and confirm sound still plays and no `MediaPlayer` instances accumulate (profiler).

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)