### PR TITLE
🟠 Localize permission-denied snackbar strings (#53)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -280,9 +280,9 @@ public class MainActivity extends BaseActivity {
 	private void showPermissionDeniedSnackbar() {
 		Snackbar.make(
 				findViewById(R.id.containerLayout),
-				"Notifications are important for this app to work properly",
+				R.string.notifications_permission_rationale,
 				Snackbar.LENGTH_LONG
-		).setAction("Open Settings", v -> openNotificationSettings()).show();
+		).setAction(R.string.open_settings, v -> openNotificationSettings()).show();
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -168,6 +168,10 @@
     <!-- Notification permission granted -->
     <string name="notifications_enabled_toast">شكراً! تم تفعيل التنبيهات الآن.</string>
 
+    <!-- Notification permission denied -->
+    <string name="notifications_permission_rationale">التنبيهات مهمة لكي يعمل التطبيق بشكل صحيح</string>
+    <string name="open_settings">فتح الإعدادات</string>
+
     <!-- App language picker -->
     <string name="pref_language_category">اللغة</string>
     <string name="pref_title_language">لغة التطبيق</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,10 @@
     <!-- Shown after the user grants the notification permission -->
     <string name="notifications_enabled_toast">Thank you! Notifications are now enabled.</string>
 
+    <!-- Shown when the user denies the notification permission -->
+    <string name="notifications_permission_rationale">Notifications are important for this app to work properly</string>
+    <string name="open_settings">Open Settings</string>
+
     <!-- App language picker -->
     <string name="pref_language_category">Language</string>
     <string name="pref_title_language">App language</string>


### PR DESCRIPTION
## What & why

`MainActivity.showPermissionDeniedSnackbar()` hardcoded English literals for the message and the "Open Settings" action. These ship **un-localized** in release — the `MissingTranslation` lint gate only flags missing `strings.xml` entries, not inline Java literals, so the gap was invisible to the build.

## Changes

- Add `notifications_permission_rationale` and `open_settings` to `res/values/strings.xml`.
- Add matching Arabic entries to `res/values-ar/strings.xml`.
- Reference the resources from the `Snackbar` (`R.string.…`) instead of literals.

## Arabic review

Please sanity-check the translations:
- `notifications_permission_rationale` → التنبيهات مهمة لكي يعمل التطبيق بشكل صحيح
- `open_settings` → فتح الإعدادات

## Testing

- CI: unit tests + debug/release builds (incl. the `MissingTranslation` gate).

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)