### PR TITLE
🟠 Reuse sticky battery intent in BatteryLevelReceiver (#54)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -61,7 +61,8 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		final boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING;
 		final boolean isFull = status == BatteryManager.BATTERY_STATUS_FULL;
 
-		final BatteryDO batteryDO = SystemService.getBatteryInfo(context);
+		// Reuse the sticky intent we already read above instead of triggering a second read.
+		final BatteryDO batteryDO = SystemService.getBatteryInfo(context, batteryStatus);
 
 		// Keep the persistent foreground-service status notification live with the latest reading
 		NotificationService.updateOngoingNotification(context, batteryDO);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -42,7 +42,21 @@ public final class SystemService {
 	 * @return BatteryDO object containing battery information, or null if battery status is unavailable
 	 */
 	public static BatteryDO getBatteryInfo(final Context context) {
-		final Intent batteryStatus = getBatteryStatusIntent(context);
+		return getBatteryInfo(context, getBatteryStatusIntent(context));
+	}
+
+	/**
+	 * Build battery information from an already-obtained {@code ACTION_BATTERY_CHANGED} intent.
+	 * <p>
+	 * Lets a caller that already holds the sticky battery intent (e.g. a receiver that just read it)
+	 * reuse it instead of triggering a second sticky-broadcast read.
+	 *
+	 * @param context       The application context
+	 * @param batteryStatus A sticky {@code ACTION_BATTERY_CHANGED} intent, or null if unavailable
+	 *
+	 * @return BatteryDO built from the intent, or null when {@code batteryStatus} is null
+	 */
+	public static BatteryDO getBatteryInfo(final Context context, final Intent batteryStatus) {
 		if (isNull(batteryStatus)) {
 			return null;
 		}


### PR DESCRIPTION
## What & why

`BatteryLevelReceiver.onReceive()` read the sticky `ACTION_BATTERY_CHANGED` intent for the status extras, then called `SystemService.getBatteryInfo(context)` which read the **same** sticky broadcast a second time. `ACTION_BATTERY_CHANGED` fires frequently, so that's a redundant sticky read on every tick.

## Changes

- Add a `SystemService.getBatteryInfo(Context, Intent)` overload that builds the `BatteryDO` from an intent the caller already holds.
- `BatteryLevelReceiver` passes the sticky intent it just read → one read per tick instead of two.
- `getBatteryInfo(Context)` now delegates to the overload, so existing callers are unchanged.

## Scope note

`PowerConnectionReceiver` deliberately keeps its single sticky read: it's triggered by power-connected/disconnected intents that don't carry the battery extras, so it must read the sticky broadcast for the current plugged state (this is also how its unit test injects data).

## Testing

- CI: unit tests (`BatteryLevelReceiverTest` uses `sendStickyBroadcast`, which the reused read still picks up) + debug/release builds.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)