### PR TITLE
🟡 Unify Fahrenheit rounding on Math.round (#56)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/util/GeneralHelper.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/util/GeneralHelper.java
@@ -45,17 +45,6 @@ public final class GeneralHelper {
 	}
 
 	/**
-	 * Convert temperature from Celsius to Fahrenheit, rounded to one decimal place
-	 *
-	 * @param temperature Temperature in Celsius
-	 * @return Temperature in Fahrenheit
-	 */
-	public static float fromCtoF(final float temperature) {
-		final float fahrenheit = (9.0f / 5.0f) * temperature + 32;
-		return (float) Math.ceil(fahrenheit * 10.0f) / 10.0f;
-	}
-
-	/**
 	 * Extract hour from time string in format "HH:MM"
 	 *
 	 * @param time Time string in format "HH:MM"

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/util/TemperatureUtils.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/util/TemperatureUtils.java
@@ -54,9 +54,14 @@ public final class TemperatureUtils {
 		return Math.round((fahrenheit - 32) * 5f / 9f);
 	}
 
-	/** Convert degrees Celsius to degrees Fahrenheit (one-decimal precision). */
+	/**
+	 * Convert degrees Celsius to degrees Fahrenheit (one-decimal precision), rounded to the nearest
+	 * tenth. Uses {@code Math.round} so the display path matches the whole-degree overload above
+	 * (the previous implementation rounded up via {@code Math.ceil}, biasing displayed °F upward).
+	 */
 	public static float celsiusToFahrenheit(final float celsius) {
-		return GeneralHelper.fromCtoF(celsius);
+		final float fahrenheit = celsius * 9f / 5f + 32f;
+		return Math.round(fahrenheit * 10f) / 10f;
 	}
 
 	/**

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/util/TemperatureUtilsTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/util/TemperatureUtilsTest.java
@@ -21,6 +21,14 @@ public class TemperatureUtilsTest {
 	}
 
 	@Test
+	public void celsiusToFahrenheit_float_roundsToNearestTenth() {
+		assertEquals(89.6f, TemperatureUtils.celsiusToFahrenheit(32.0f), 0.001f);
+		assertEquals(98.6f, TemperatureUtils.celsiusToFahrenheit(37.0f), 0.001f);
+		// 20.02 °C -> 68.036 °F: rounds DOWN to 68.0 (the old Math.ceil path returned 68.1).
+		assertEquals(68.0f, TemperatureUtils.celsiusToFahrenheit(20.02f), 0.001f);
+	}
+
+	@Test
 	public void fahrenheitToCelsius_knownValues() {
 		assertEquals(0, TemperatureUtils.fahrenheitToCelsius(32));
 		assertEquals(40, TemperatureUtils.fahrenheitToCelsius(104));


### PR DESCRIPTION
## What & why

Two Celsius→Fahrenheit conversions rounded differently:

- `GeneralHelper.fromCtoF(float)` (one-decimal, **display** path) used `Math.ceil` — always rounds up.
- `TemperatureUtils.celsiusToFahrenheit(int)` (threshold path) used `Math.round`.

The displayed battery temperature went through the `ceil` path, so shown °F was biased upward relative to the threshold the user set.

## Changes

- Inline the one-decimal conversion into `TemperatureUtils.celsiusToFahrenheit(float)` using `Math.round`.
- Remove the now-unused `GeneralHelper.fromCtoF` duplicate (single source of truth in `TemperatureUtils`).
- Extend `TemperatureUtilsTest` with a case that distinguishes `round` from the old `ceil` (20.02 °C → 68.0 °F, not 68.1).

## Testing

- CI: unit tests (extended) + debug/release builds.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)