### PR TITLE
🟡 Extract shared battery status→label mapping (#57)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -704,26 +704,9 @@ public final class NotificationService {
 	 */
 	private static String statusText(final Context context, final BatteryDO batteryDO) {
 		final int percentage = isNull(batteryDO) ? 0 : Math.round(batteryDO.getBatteryPercentage());
-		final String statusLabel = statusLabel(context, isNull(batteryDO) ? -1 : batteryDO.getStatus());
+		final String statusLabel = SystemService.getStatusLabel(context, isNull(batteryDO) ? -1 : batteryDO.getStatus());
 		final String temperature = isNull(batteryDO) ? "" : TemperatureUtils.format(context, batteryDO.getTemperature());
 		return context.getString(R.string.notification_status_content, percentage, statusLabel, temperature);
-	}
-
-	/**
-	 * Map a BatteryManager status constant to a localized label.
-	 *
-	 * @param context The application context
-	 * @param status  BatteryManager status constant
-	 * @return Localized status label
-	 */
-	private static String statusLabel(final Context context, final int status) {
-		return switch (status) {
-			case BatteryManager.BATTERY_STATUS_FULL -> context.getString(R.string.charged);
-			case BatteryManager.BATTERY_STATUS_CHARGING -> context.getString(R.string.charging);
-			case BatteryManager.BATTERY_STATUS_NOT_CHARGING -> context.getString(R.string.not_charging);
-			case BatteryManager.BATTERY_STATUS_DISCHARGING -> context.getString(R.string.discharging);
-			default -> context.getString(R.string.unknown);
-		};
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -56,6 +56,29 @@ public final class SystemService {
 	}
 
 	/**
+	 * Map a {@link BatteryManager} status constant to its localized label
+	 * (e.g. "Charging", "Discharging", "Charged").
+	 * <p>
+	 * Single source of truth shared by the main screen's subtitle and the ongoing status
+	 * notification, so the two can't drift.
+	 *
+	 * @param context The application context
+	 * @param status  A {@code BatteryManager.BATTERY_STATUS_*} constant
+	 *
+	 * @return The localized status label ("Unknown" for unrecognized values)
+	 */
+	public static String getStatusLabel(final Context context, final int status) {
+		final Resources resources = context.getResources();
+		return switch (status) {
+			case BatteryManager.BATTERY_STATUS_FULL -> resources.getString(R.string.charged);
+			case BatteryManager.BATTERY_STATUS_CHARGING -> resources.getString(R.string.charging);
+			case BatteryManager.BATTERY_STATUS_NOT_CHARGING -> resources.getString(R.string.not_charging);
+			case BatteryManager.BATTERY_STATUS_DISCHARGING -> resources.getString(R.string.discharging);
+			default -> resources.getString(R.string.unknown);
+		};
+	}
+
+	/**
 	 * Get battery status intent from system
 	 *
 	 * @param context The application context

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -180,22 +180,8 @@ public class MainActivity extends BaseActivity {
 			return;
 		}
 
-		final int status = batteryDO.getStatus();
 		batteryPercentage = (int) batteryDO.getBatteryPercentage();
-
-		// Map battery status to appropriate string resource
-		if (status == BatteryManager.BATTERY_STATUS_FULL) {
-			subTitle = getResources().getString(R.string.charged);
-		} else if (status == BatteryManager.BATTERY_STATUS_CHARGING) {
-			subTitle = getResources().getString(R.string.charging);
-		} else if (status == BatteryManager.BATTERY_STATUS_NOT_CHARGING) {
-			subTitle = getResources().getString(R.string.not_charging);
-		} else if (status == BatteryManager.BATTERY_STATUS_DISCHARGING) {
-			subTitle = getResources().getString(R.string.discharging);
-		} else {
-			// BATTERY_STATUS_UNKNOWN or any other status
-			subTitle = getResources().getString(R.string.unknown);
-		}
+		subTitle = SystemService.getStatusLabel(this, batteryDO.getStatus());
 	}
 
 	/**


### PR DESCRIPTION
## What & why

The `BatteryManager` status → localized label mapping was duplicated:

- `MainActivity.fillBatteryInfo()` — `if/else` chain.
- `NotificationService.statusLabel()` — `switch`.

Two copies can drift (a new status handled in one place but not the other).

## Changes

- Add `SystemService.getStatusLabel(Context, int)` as the single source of truth (alongside the other `get*String`/`getHealthString` helpers).
- Use it from both the main-screen subtitle and the ongoing status notification.
- Remove the now-redundant private `statusLabel()` in `NotificationService` and the `if/else` chain in `MainActivity`.

No behavioural change — same labels, same fallback to "Unknown".

## Testing

- CI: unit tests + debug/release builds.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)