### PR TITLE
🟡 Modernize BatteryInsights dialogs + drop layout placeholders (#58)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -1,6 +1,5 @@
 package com.almothafar.simplebatterynotifier.ui;
 
-import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -10,12 +9,14 @@ import android.os.Bundle;
 import android.text.InputFilter;
 import android.text.InputType;
 import android.text.TextUtils;
-import android.view.Gravity;
-import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
@@ -171,7 +172,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 				"Reset ALL (incl. real data)"
 		};
 
-		new AlertDialog.Builder(this)
+		new MaterialAlertDialogBuilder(this)
 				.setTitle("Battery Health Debug")
 				.setItems(options, (dialog, which) -> {
 					switch (which) {
@@ -192,7 +193,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 */
 	private void showDebugInfo() {
 		final String debugInfo = BatteryHealthTracker.getDebugInfo(this);
-		new AlertDialog.Builder(this)
+		new MaterialAlertDialogBuilder(this)
 				.setTitle("Tracking Debug Info")
 				.setMessage(debugInfo)
 				.setPositiveButton("OK", null)
@@ -226,17 +227,22 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 * the value and reverts to the cycle-based estimate.
 	 */
 	private void showDesignCapacityDialog() {
-		final EditText input = new EditText(this);
+		final TextInputLayout inputLayout = new TextInputLayout(this);
+		inputLayout.setBoxBackgroundMode(TextInputLayout.BOX_BACKGROUND_OUTLINE);
+		inputLayout.setHint(getString(R.string.design_capacity_hint));
+		inputLayout.setSuffixText(getString(R.string.capacity_unit_mah));
+
+		final TextInputEditText input = new TextInputEditText(inputLayout.getContext());
 		input.setInputType(InputType.TYPE_CLASS_NUMBER);
 		// Max valid capacity is 15000 (5 digits); cap the length so the field can't overflow an int.
 		input.setFilters(new InputFilter[]{new InputFilter.LengthFilter(MAX_DESIGN_CAPACITY_DIGITS)});
-		input.setHint(R.string.design_capacity_hint);
+		inputLayout.addView(input);
 
 		final int stored = BatteryHealthTracker.getDesignCapacity(this);
 		final int prefill = stored > 0 ? stored : SystemService.getBatteryCapacity(this);
 		if (prefill > 0) {
 			input.setText(String.valueOf(prefill));
-			input.setSelection(input.getText().length());
+			input.setSelection(String.valueOf(prefill).length());
 		}
 
 		// Indent the field to match the dialog's message padding
@@ -246,10 +252,9 @@ public class BatteryInsightsActivity extends BaseActivity {
 				FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);
 		params.leftMargin = padding;
 		params.rightMargin = padding;
-		container.addView(input, params);
-		input.setGravity(Gravity.START);
+		container.addView(inputLayout, params);
 
-		final AlertDialog dialog = new AlertDialog.Builder(this)
+		final AlertDialog dialog = new MaterialAlertDialogBuilder(this)
 				.setTitle(R.string.design_capacity_dialog_title)
 				.setMessage(R.string.design_capacity_dialog_message)
 				.setView(container)
@@ -262,7 +267,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 
 		// Override click handlers so invalid input (Save) and the lookup action (Neutral) don't dismiss.
 		dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
-			if (saveDesignCapacity(input.getText().toString())) {
+			final CharSequence text = input.getText();
+			if (saveDesignCapacity(text == null ? "" : text.toString())) {
 				dialog.dismiss();
 			}
 		});
@@ -332,7 +338,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 * Resets all health tracking data, including the first-use date and real charge cycles.
 	 */
 	private void resetHealthData() {
-		new AlertDialog.Builder(this)
+		new MaterialAlertDialogBuilder(this)
 				.setTitle("Reset ALL health data?")
 				.setMessage("This deletes ALL tracked battery health data, including the first-use date "
 						+ "and real charge cycles. Are you sure?")

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,4 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:circular="http://schemas.android.com/apk/res-auto"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -37,8 +36,8 @@
             style="@style/Widget.ProgressBar.CircularProgressBar"
             android:layout_width="wrap_content"
             android:layout_height="200dp"
-            circular:cpb_subtitle="subtitle"
-            circular:cpb_title="Title"
+            tools:cpb_subtitle="subtitle"
+            tools:cpb_title="Title"
             android:layout_marginTop="10dp"
             android:layout_marginBottom="-10dp" />
     </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -142,6 +142,8 @@
     <string name="design_capacity_dialog_title">السعة التصميمية للبطارية</string>
     <string name="design_capacity_dialog_message">أدخل السعة المقدّرة لبطاريتك بوحدة mAh من مواصفات الشركة المصنّعة. لقد عبّأنا تقديراً مقاساً — أكّده أو صحّحه للحصول على قيمة صحة دقيقة.</string>
     <string name="design_capacity_hint">السعة (mAh)</string>
+    <!-- Unit symbol (milliamp-hours); shown as the capacity field's suffix -->
+    <string name="capacity_unit_mah">mAh</string>
     <string name="look_up_my_model">ابحث عن طرازي</string>
     <string name="no_browser_found">لا يوجد متصفح لفتح البحث</string>
     <string name="save">حفظ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,8 @@
     <string name="design_capacity_dialog_title">Battery design capacity</string>
     <string name="design_capacity_dialog_message">Enter your battery\'s rated capacity in mAh from the manufacturer\'s specs. We\'ve prefilled a measured estimate — confirm or correct it for an accurate health figure.</string>
     <string name="design_capacity_hint">Capacity (mAh)</string>
+    <!-- Unit symbol (milliamp-hours); shown as the capacity field's suffix -->
+    <string name="capacity_unit_mah">mAh</string>
     <string name="look_up_my_model">Look up my model</string>
     <string name="no_browser_found">No browser available to open the search</string>
     <string name="save">Save</string>


### PR DESCRIPTION
## What & why

The insights screen used `android.app.AlertDialog`, which renders with the plain platform style instead of the app's Material3 theme, and built the design-capacity input as a bare `EditText` inside a `FrameLayout` margin hack.

## Changes

- Switch all four dialogs to `MaterialAlertDialogBuilder` for consistent Material3 styling (button handles via `androidx.appcompat.app.AlertDialog`).
- Replace the bare `EditText` with a Material `TextInputLayout` + `TextInputEditText` (outline box, `mAh` suffix). New `capacity_unit_mah` string added in EN + AR.
- Move the `CircularProgressBar` placeholder `title`/`subtitle` in `activity_main.xml` to the `tools:` namespace so no literal placeholder strings ship, and drop the now-unused `circular` xmlns.

The app theme is already `Theme.Material3.Light.NoActionBar`, so `MaterialAlertDialogBuilder`/`TextInputLayout` are supported.

## Scope note

Debug-menu button/title literals (e.g. "Battery Health Debug") are left as-is — they're debug-tier and out of scope for this UI-polish PR.

## Testing

- CI: unit tests + debug/release builds (incl. `MissingTranslation`).
- 📱 Device check (owner): open **Battery Insights → tap the design-capacity card**; confirm the Material dialog + `TextInputLayout` with `mAh` suffix, prefill, save/clear, and "look up my model" all work.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)