### PR TITLE
Accumulate partial charge cycles in tracked estimate (#67)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -16,8 +16,11 @@ import static java.util.Objects.isNull;
  * Tracks battery health metrics including charge cycles and estimated battery health.
  * <p>
  * Charge Cycle Definition:
- * A full charge cycle is counted when the battery charges from <= 20% to >= 95%.
- * This follows industry standards where partial charges accumulate to form complete cycles.
+ * A charge cycle is one full battery's worth of charge delivered (100 percentage-points). Partial
+ * charges accumulate: e.g. charging 40%->90% twice counts as one cycle. This matches the industry
+ * definition and, unlike a strict single low->high swing, counts real usage where the user tops up
+ * before empty and unplugs before full. This tracked estimate is only the fallback; the OS-reported
+ * count (EXTRA_CYCLE_COUNT, Android 14+) still takes precedence in {@link #getEffectiveCycleCount}.
  * <p>
  * Battery Health Estimation:
  * Based on charge cycles and typical lithium-ion battery degradation patterns:
@@ -33,16 +36,17 @@ public class BatteryHealthTracker {
 	// SharedPreferences keys
 	private static final String PREF_CHARGE_CYCLES = "_battery_health_charge_cycles";
 	private static final String PREF_FIRST_USE_DATE = "_battery_health_first_use_date";
-	private static final String PREF_LAST_LOW_BATTERY = "_battery_health_last_low_battery";
-	private static final String PREF_CYCLE_IN_PROGRESS = "_battery_health_cycle_in_progress";
+	// Last observed battery level, and the fractional charge accrued toward the next whole cycle
+	// (percentage-points, 0-99), persisted so a partial charge survives app/process restarts.
+	private static final String PREF_LAST_LEVEL = "_battery_health_last_level";
+	private static final String PREF_CYCLE_ACCRUAL_POINTS = "_battery_health_cycle_accrual_points";
 	private static final String PREF_DESIGN_CAPACITY = "key_battery_design_capacity";
 	// Debug-only cycle offset kept separate from real tracking so it can be cleared without
 	// destroying genuine data (see the debug menu in BatteryInsightsActivity).
 	private static final String PREF_DEBUG_CHARGE_CYCLES = "_battery_health_debug_charge_cycles";
 
-	// Battery thresholds for cycle tracking
-	private static final int LOW_BATTERY_THRESHOLD = 20;
-	private static final int FULL_BATTERY_THRESHOLD = 95;
+	// One charge cycle = this many percentage-points of charge delivered to the battery.
+	private static final int CYCLE_PERCENT_POINTS = 100;
 
 	// Health estimation thresholds (cycle-based)
 	private static final int EXCELLENT_THRESHOLD = 300;
@@ -88,34 +92,64 @@ public class BatteryHealthTracker {
 			Log.d(TAG, "First use date initialized");
 		}
 
-		// Track charge cycle progress (the three branches below are mutually exclusive)
-		final boolean cycleInProgress = prefs.getBoolean(PREF_CYCLE_IN_PROGRESS, false);
+		// Accrue partial charge cycles from the rise in battery level while charging. Each 100
+		// percentage-points of charge delivered counts as one cycle; the remainder carries over.
 		final boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING
 				|| status == BatteryManager.BATTERY_STATUS_FULL;
+		final int prevLevel = prefs.getInt(PREF_LAST_LEVEL, -1);
+		final int carry = prefs.getInt(PREF_CYCLE_ACCRUAL_POINTS, 0);
+		final CycleAccrual accrual = accruePartialCycles(prevLevel, batteryLevel, isCharging, carry);
 
-		if (batteryLevel <= LOW_BATTERY_THRESHOLD && !cycleInProgress) {
-			// Start a charge cycle when battery is low
-			editor.putBoolean(PREF_CYCLE_IN_PROGRESS, true)
-			      .putLong(PREF_LAST_LOW_BATTERY, System.currentTimeMillis());
+		if (accrual.completedCycles() > 0) {
+			final int total = prefs.getInt(PREF_CHARGE_CYCLES, 0) + accrual.completedCycles();
+			editor.putInt(PREF_CHARGE_CYCLES, total);
 			dirty = true;
-			Log.d(TAG, "Charge cycle started at " + batteryLevel + "%");
-		} else if (cycleInProgress && isCharging && batteryLevel >= FULL_BATTERY_THRESHOLD) {
-			// Complete a charge cycle when battery reaches full while charging
-			final int currentCycles = prefs.getInt(PREF_CHARGE_CYCLES, 0);
-			editor.putInt(PREF_CHARGE_CYCLES, currentCycles + 1)
-			      .putBoolean(PREF_CYCLE_IN_PROGRESS, false);
+			Log.i(TAG, "Charge cycle(s) completed (+" + accrual.completedCycles() + "). Total cycles: " + total);
+		}
+		if (accrual.carryPercentPoints() != carry) {
+			editor.putInt(PREF_CYCLE_ACCRUAL_POINTS, accrual.carryPercentPoints());
 			dirty = true;
-			Log.i(TAG, "Charge cycle completed! Total cycles: " + (currentCycles + 1));
-		} else if (cycleInProgress && !isCharging && batteryLevel > FULL_BATTERY_THRESHOLD) {
-			// Reset cycle tracking if battery goes back to high without charging
-			editor.putBoolean(PREF_CYCLE_IN_PROGRESS, false);
+		}
+		if (batteryLevel != prevLevel) {
+			editor.putInt(PREF_LAST_LEVEL, batteryLevel);
 			dirty = true;
-			Log.d(TAG, "Charge cycle reset - battery was not charged to full");
 		}
 
 		if (dirty) {
 			editor.apply();
 		}
+	}
+
+	/**
+	 * Accrues fractional charge cycles from a rise in battery level.
+	 * <p>
+	 * A charge cycle is {@link #CYCLE_PERCENT_POINTS} percentage-points of charge delivered, so partial
+	 * charges accumulate across sessions instead of requiring a single low-to-full swing. Only positive
+	 * level deltas observed while charging count; discharging, a flat level, or an unknown previous
+	 * level ({@code prevLevel < 0}) contribute nothing and leave the carry untouched. Pure and
+	 * Android-free so it is unit-testable.
+	 *
+	 * @param prevLevel          last recorded battery level (0-100), or -1 when unknown
+	 * @param currentLevel       current battery level (0-100)
+	 * @param charging           whether the battery is currently charging (or full)
+	 * @param carryPercentPoints percentage-points already accrued toward the next cycle (0-99)
+	 *
+	 * @return the whole cycles completed by this step and the new carry remainder
+	 */
+	static CycleAccrual accruePartialCycles(final int prevLevel, final int currentLevel,
+	                                        final boolean charging, final int carryPercentPoints) {
+		if (!charging || prevLevel < 0 || currentLevel <= prevLevel) {
+			return new CycleAccrual(0, carryPercentPoints);
+		}
+		final int total = carryPercentPoints + (currentLevel - prevLevel);
+		return new CycleAccrual(total / CYCLE_PERCENT_POINTS, total % CYCLE_PERCENT_POINTS);
+	}
+
+	/**
+	 * Result of {@link #accruePartialCycles}: the whole cycles completed this step, and the leftover
+	 * percentage-points carried toward the next cycle.
+	 */
+	record CycleAccrual(int completedCycles, int carryPercentPoints) {
 	}
 
 	/**
@@ -458,8 +492,8 @@ public class BatteryHealthTracker {
 		prefs.edit()
 		     .remove(PREF_CHARGE_CYCLES)
 		     .remove(PREF_FIRST_USE_DATE)
-		     .remove(PREF_LAST_LOW_BATTERY)
-		     .remove(PREF_CYCLE_IN_PROGRESS)
+		     .remove(PREF_LAST_LEVEL)
+		     .remove(PREF_CYCLE_ACCRUAL_POINTS)
 		     .remove(PREF_DEBUG_CHARGE_CYCLES)
 		     .apply();
 		Log.i(TAG, "Battery health data reset");
@@ -517,16 +551,16 @@ public class BatteryHealthTracker {
 		final int cycles = prefs.getInt(PREF_CHARGE_CYCLES, 0);
 		final int debugCycles = prefs.getInt(PREF_DEBUG_CHARGE_CYCLES, 0);
 		final long firstUse = prefs.getLong(PREF_FIRST_USE_DATE, 0);
-		final boolean cycleInProgress = prefs.getBoolean(PREF_CYCLE_IN_PROGRESS, false);
-		final long lastLowBattery = prefs.getLong(PREF_LAST_LOW_BATTERY, 0);
+		final int accrualPoints = prefs.getInt(PREF_CYCLE_ACCRUAL_POINTS, 0);
+		final int lastLevel = prefs.getInt(PREF_LAST_LEVEL, -1);
 
 		return "Tracking Status:\n" +
 				"- First Use: " + (firstUse == 0 ? "Not initialized" : new java.util.Date(firstUse)) + "\n" +
 				"- Charge Cycles (real): " + cycles + "\n" +
 				"- Charge Cycles (debug-injected): " + debugCycles + "\n" +
 				"- Effective Cycle Count: " + getEffectiveCycleCount(context) + "\n" +
-				"- Cycle in Progress: " + cycleInProgress + "\n" +
-				"- Last Low Battery: " + (lastLowBattery == 0 ? "Never" : new java.util.Date(lastLowBattery)) + "\n" +
+				"- Cycle accrual (toward next): " + accrualPoints + "/" + CYCLE_PERCENT_POINTS + "\n" +
+				"- Last Level: " + (lastLevel < 0 ? "Unknown" : lastLevel + "%") + "\n" +
 				"- Days Since First Use: " + getDaysSinceFirstUse(context);
 	}
 }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerStateTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerStateTest.java
@@ -34,38 +34,41 @@ public class BatteryHealthTrackerStateTest {
 	}
 
 	@Test
-	public void chargeCycle_completesWhenLowThenChargedToFull() {
-		// Drop to the low threshold -> a cycle begins but isn't counted yet
-		BatteryHealthTracker.recordBatteryState(context, 15, BatteryManager.BATTERY_STATUS_DISCHARGING);
+	public void chargeCycle_completesOnFullChargeFromEmpty() {
+		// Establish a starting level (first reading only seeds prevLevel, nothing accrues)
+		BatteryHealthTracker.recordBatteryState(context, 0, BatteryManager.BATTERY_STATUS_DISCHARGING);
 		assertEquals(0, BatteryHealthTracker.getChargeCycles(context));
 
-		// Charge back up past the full threshold -> the cycle completes
-		BatteryHealthTracker.recordBatteryState(context, 96, BatteryManager.BATTERY_STATUS_CHARGING);
+		// A full 0 -> 100 charge delivers 100 percentage-points = exactly one cycle
+		BatteryHealthTracker.recordBatteryState(context, 100, BatteryManager.BATTERY_STATUS_CHARGING);
 		assertEquals(1, BatteryHealthTracker.getChargeCycles(context));
 	}
 
 	@Test
 	public void chargeCycle_accumulatesAcrossPartialCharges() {
-		// A mid-range reading between low and full must not start or complete a cycle
-		BatteryHealthTracker.recordBatteryState(context, 15, BatteryManager.BATTERY_STATUS_DISCHARGING);
-		BatteryHealthTracker.recordBatteryState(context, 50, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		// Two 40 -> 90 partial charges together deliver 100 percentage-points = one cycle.
+		BatteryHealthTracker.recordBatteryState(context, 40, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 90, BatteryManager.BATTERY_STATUS_CHARGING); // +50 -> carry 50
 		assertEquals(0, BatteryHealthTracker.getChargeCycles(context));
 
-		BatteryHealthTracker.recordBatteryState(context, 96, BatteryManager.BATTERY_STATUS_FULL);
+		BatteryHealthTracker.recordBatteryState(context, 40, BatteryManager.BATTERY_STATUS_DISCHARGING); // drains, no accrual
+		BatteryHealthTracker.recordBatteryState(context, 90, BatteryManager.BATTERY_STATUS_CHARGING); // +50 -> 1 cycle
 		assertEquals(1, BatteryHealthTracker.getChargeCycles(context));
 	}
 
 	@Test
-	public void chargeCycle_notCountedWhenReachingFullWithoutCharging() {
-		BatteryHealthTracker.recordBatteryState(context, 15, BatteryManager.BATTERY_STATUS_DISCHARGING);
-		// Back above full while NOT charging -> tracking resets without counting a cycle
-		BatteryHealthTracker.recordBatteryState(context, 98, BatteryManager.BATTERY_STATUS_DISCHARGING);
+	public void chargeCycle_singlePartialChargeDoesNotComplete() {
+		// A single 20 -> 95 charge (the old "swing" that used to count 1) is only 0.75 of a cycle now.
+		BatteryHealthTracker.recordBatteryState(context, 20, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 95, BatteryManager.BATTERY_STATUS_CHARGING);
 		assertEquals(0, BatteryHealthTracker.getChargeCycles(context));
+	}
 
-		// And a fresh low->full charge after the reset still counts exactly one cycle
-		BatteryHealthTracker.recordBatteryState(context, 18, BatteryManager.BATTERY_STATUS_DISCHARGING);
-		BatteryHealthTracker.recordBatteryState(context, 97, BatteryManager.BATTERY_STATUS_CHARGING);
-		assertEquals(1, BatteryHealthTracker.getChargeCycles(context));
+	@Test
+	public void chargeCycle_dischargingNeverCounts() {
+		BatteryHealthTracker.recordBatteryState(context, 90, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 10, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		assertEquals(0, BatteryHealthTracker.getChargeCycles(context));
 	}
 
 	@Test
@@ -79,8 +82,8 @@ public class BatteryHealthTrackerStateTest {
 	@Test
 	public void effectiveCycleCount_fallsBackToTrackedEstimate() {
 		// No OS EXTRA_CYCLE_COUNT is available under test, so the effective count is the tracked one
-		BatteryHealthTracker.recordBatteryState(context, 12, BatteryManager.BATTERY_STATUS_DISCHARGING);
-		BatteryHealthTracker.recordBatteryState(context, 99, BatteryManager.BATTERY_STATUS_CHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 0, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 100, BatteryManager.BATTERY_STATUS_CHARGING);
 		assertEquals(1, BatteryHealthTracker.getEffectiveCycleCount(context));
 	}
 
@@ -107,8 +110,8 @@ public class BatteryHealthTrackerStateTest {
 
 	@Test
 	public void resetHealthData_clearsCyclesAndFirstUse() {
-		BatteryHealthTracker.recordBatteryState(context, 10, BatteryManager.BATTERY_STATUS_DISCHARGING);
-		BatteryHealthTracker.recordBatteryState(context, 96, BatteryManager.BATTERY_STATUS_CHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 0, BatteryManager.BATTERY_STATUS_DISCHARGING);
+		BatteryHealthTracker.recordBatteryState(context, 100, BatteryManager.BATTERY_STATUS_CHARGING);
 		assertEquals(1, BatteryHealthTracker.getChargeCycles(context));
 
 		BatteryHealthTracker.resetHealthData(context);

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
@@ -55,6 +55,34 @@ public class BatteryHealthTrackerTest {
 	}
 
 	@Test
+	public void accruePartialCycles_accumulatesPositiveDeltasWhileCharging() {
+		// +50 (40 -> 90) while charging, no prior carry -> 0 cycles, carry 50
+		final BatteryHealthTracker.CycleAccrual first =
+				BatteryHealthTracker.accruePartialCycles(40, 90, true, 0);
+		assertEquals(0, first.completedCycles());
+		assertEquals(50, first.carryPercentPoints());
+
+		// Another +50 on top of carry 50 -> exactly one cycle, carry resets to 0
+		final BatteryHealthTracker.CycleAccrual second =
+				BatteryHealthTracker.accruePartialCycles(40, 90, true, 50);
+		assertEquals(1, second.completedCycles());
+		assertEquals(0, second.carryPercentPoints());
+	}
+
+	@Test
+	public void accruePartialCycles_ignoresDischargeFlatNotChargingAndUnknownPrev() {
+		// Discharging (current < prev): no accrual, carry unchanged
+		assertEquals(0, BatteryHealthTracker.accruePartialCycles(90, 40, true, 30).completedCycles());
+		assertEquals(30, BatteryHealthTracker.accruePartialCycles(90, 40, true, 30).carryPercentPoints());
+		// Flat level
+		assertEquals(30, BatteryHealthTracker.accruePartialCycles(50, 50, true, 30).carryPercentPoints());
+		// Not charging, even though the level rose
+		assertEquals(30, BatteryHealthTracker.accruePartialCycles(40, 90, false, 30).carryPercentPoints());
+		// Unknown previous level (-1): first observation only, nothing accrues
+		assertEquals(30, BatteryHealthTracker.accruePartialCycles(-1, 90, true, 30).carryPercentPoints());
+	}
+
+	@Test
 	public void isValidDesignCapacity_enforcesRange() {
 		assertTrue(BatteryHealthTracker.isValidDesignCapacity(BatteryHealthTracker.MIN_DESIGN_CAPACITY_MAH));
 		assertTrue(BatteryHealthTracker.isValidDesignCapacity(BatteryHealthTracker.MAX_DESIGN_CAPACITY_MAH));


### PR DESCRIPTION
## What & why

Follow-up to #7 (root cause #2). `BatteryHealthTracker.recordBatteryState()` only counted a cycle on a single `<=20% → >=95%` swing observed in one span, and **never accumulated partial charges** — despite the Javadoc claiming it did. On a device without OS `EXTRA_CYCLE_COUNT` (pre-Android-14 or a fuel gauge that doesn't expose it) and no user-entered design capacity, the tracked estimate undercounted, skewing the cycle-based health optimistic.

## Changes

- **Fractional accrual**: sum the positive battery-level deltas seen while charging; one cycle = **100 percentage-points** delivered, carrying the remainder. Matches the industry "cycle = one full battery's worth of charge" definition and counts real top-up usage.
- New **pure, unit-testable** helper `accruePartialCycles()` + `CycleAccrual` record (mirrors `estimateFullCapacityMah` / `computeMeasuredHealth`).
- Carry + last level are **persisted** (`PREF_CYCLE_ACCRUAL_POINTS`, `PREF_LAST_LEVEL`) so a partial charge survives app/process restarts. These replace the swing-only `cycle_in_progress`/`last_low_battery` keys; `resetHealthData()` and `getDebugInfo()` updated to match.
- OS-reported `EXTRA_CYCLE_COUNT` **still takes precedence** in `getEffectiveCycleCount()` — this only improves the fallback estimate.
- Class Javadoc updated to the accrual definition.

## Behavior change (intentional) ⚠️

A **single** `20% → 95%` charge used to count as **1** cycle; under accrual it's **0.75** of a cycle. The state tests in `BatteryHealthTrackerStateTest` that encoded the old swing model were reworked to accrual semantics, and pure-helper tests were added. This is the point of the issue — partial charges now accumulate instead of a lone full swing being required.

## Testing

- CI: unit tests (reworked state tests + new `accruePartialCycles` cases) + debug/release builds.
- Pure helper covers: positive-delta accumulation, carry rollover at 100, and no-accrual on discharge / flat level / not-charging / unknown-prev.

## Follow-up (not in scope)

The most-accurate signal — integrating `CHARGE_COUNTER` (µAh) throughput rather than integer percentage-points — is noted in #67 as a possible future refinement; this PR uses the percentage-delta approach, which works with the existing `recordBatteryState(context, level, status)` signature on all devices.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)