### PR TITLE
🔴 Guard implausible battery capacity estimates (#69)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -30,6 +30,12 @@ import static java.util.Objects.isNull;
 public final class SystemService {
 	private static final String TAG = "com.almothafar";
 
+	// A plausible phone-battery full-capacity range (mAh). Some devices (e.g. certain Kirin/HiSilicon)
+	// report BATTERY_PROPERTY_CHARGE_COUNTER in a non-standard unit, yielding absurd single/double-digit
+	// mAh estimates; anything outside this range is treated as "unknown". See issue #69.
+	private static final int MIN_PLAUSIBLE_CAPACITY_MAH = 500;
+	private static final int MAX_PLAUSIBLE_CAPACITY_MAH = 15000;
+
 	private SystemService() {
 		// Utility class - prevent instantiation
 	}
@@ -274,19 +280,26 @@ public final class SystemService {
 	 * <p>
 	 * Pure helper with no Android dependencies, so it is unit-testable. {@code getIntProperty}
 	 * returns {@link Integer#MIN_VALUE} for unsupported properties; any non-positive or
-	 * out-of-range input yields 0 ("unknown").
+	 * out-of-range input, or a result outside a plausible battery range, yields 0 ("unknown").
 	 *
 	 * @param chargeCounterUah remaining charge in microampere-hours (µAh)
 	 * @param capacityPercent  remaining charge as a percentage (1-100)
 	 *
-	 * @return estimated full capacity in mAh, or 0 when the inputs are unusable
+	 * @return estimated full capacity in mAh, or 0 when the inputs are unusable or the result is implausible
 	 */
 	static int estimateFullCapacityMah(final int chargeCounterUah, final int capacityPercent) {
 		if (chargeCounterUah <= 0 || capacityPercent <= 0 || capacityPercent > 100) {
 			return 0; // Unknown / unsupported on this device
 		}
 		// full µAh = chargeCounter / (percent / 100); mAh = full / 1000  ==>  chargeCounter / (percent * 10)
-		return Math.round(chargeCounterUah / (capacityPercent * 10f));
+		final int estimateMah = Math.round(chargeCounterUah / (capacityPercent * 10f));
+		// Some devices report CHARGE_COUNTER in the wrong unit, producing absurd values (e.g. 9 mAh from a
+		// raw counter of 9000). Reject anything outside a plausible battery range so callers show "Unknown"
+		// and fall back to the cycle-based estimate rather than garbage. See issue #69.
+		if (estimateMah < MIN_PLAUSIBLE_CAPACITY_MAH || estimateMah > MAX_PLAUSIBLE_CAPACITY_MAH) {
+			return 0;
+		}
+		return estimateMah;
 	}
 
 	/**

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/SystemServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/SystemServiceTest.java
@@ -28,4 +28,21 @@ public class SystemServiceTest {
 		assertEquals(0, SystemService.estimateFullCapacityMah(2_000_000, -1));
 		assertEquals(0, SystemService.estimateFullCapacityMah(2_000_000, 101));
 	}
+
+	@Test
+	public void estimateFullCapacity_implausibleResult_returnsZero() {
+		// Kirin/HiSilicon device reporting CHARGE_COUNTER in the wrong unit: raw 9000 at 100% -> 9 mAh,
+		// far below any real battery, so it must be rejected as "unknown" (issue #69).
+		assertEquals(0, SystemService.estimateFullCapacityMah(9000, 100));
+		assertEquals(0, SystemService.estimateFullCapacityMah(2000, 50)); // -> 4 mAh
+		// Absurdly large (wrong unit the other way) is rejected too: 200,000,000 µAh at 100% -> 200000 mAh
+		assertEquals(0, SystemService.estimateFullCapacityMah(200_000_000, 100));
+	}
+
+	@Test
+	public void estimateFullCapacity_plausibleBoundaries_areKept() {
+		// A small-but-real 500 mAh battery (lower bound) and a large 15000 mAh (upper bound) are kept.
+		assertEquals(500, SystemService.estimateFullCapacityMah(500_000, 100));
+		assertEquals(15000, SystemService.estimateFullCapacityMah(15_000_000, 100));
+	}
 }


### PR DESCRIPTION
## What & why

Found on-device (Huawei Mate 10 Pro / Kirin, API 29). `BATTERY_PROPERTY_CHARGE_COUNTER` should be **µAh** (~4,000,000 for a full 4000 mAh battery) but this device reports **~9000**, so `estimateFullCapacityMah(9000, 100) = 9 mAh`. That 9 mAh showed as the **Capacity**, and poisoned measured health: `9 / 4000 → clamped to "1% Poor"`.

```
$ adb shell dumpsys battery
  Charge counter: 9000     # should be ~4,000,000 µAh at 100%
  level: 100  scale: 100
```

## Changes

- `estimateFullCapacityMah` now rejects results outside a plausible battery range (**500–15000 mAh**) by returning `0`.
- Callers already treat `0` as **"Unknown"**, and `getMeasuredHealthPercentage` returns `-1` → the UI falls back to the honest **Estimated** (cycle-based) health instead of "1%".
- Normal readings (e.g. `4,000,000 µAh @ 100% → 4000 mAh`) are unaffected.
- `SystemServiceTest`: added guard cases (`9000@100→0`, `2000@50→0`, oversized→0) and plausible-boundary cases (500 / 15000 kept).

## Note

On this device a *measured* capacity/health simply isn't obtainable (the charge counter is unusable), so the labeled **Estimated** fallback is the correct, honest behavior.

## Testing

- CI: unit tests + builds. Also verified on the BLA-L29 (see #69 → combined test build).

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)