### PR TITLE
🔴 Make battery details scrollable + trim footer padding (#70)

### DIFF
--- a/app/src/main/res/layout/fragment_battery_details.xml
+++ b/app/src/main/res/layout/fragment_battery_details.xml
@@ -4,13 +4,18 @@
     android:layout_height="match_parent"
     tools:context="com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment">
 
-    <TableLayout
-        android:id="@+id/batteryDetailsTable"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:stretchColumns="0,1"
-        android:padding="20sp"
-        android:orientation="horizontal">
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
 
-    </TableLayout>
+        <TableLayout
+            android:id="@+id/batteryDetailsTable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:stretchColumns="0,1"
+            android:padding="20sp"
+            android:orientation="horizontal" />
+
+    </ScrollView>
 </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,5 +8,7 @@
 
     <!-- System UI overlap fixes -->
     <dimen name="toolbar_status_bar_padding">24dp</dimen>
-    <dimen name="content_navigation_bar_padding">64dp</dimen>
+    <!-- Small content breathing room at the bottom. On API < 35 the system already insets content
+         above the navigation bar, so a large fixed value here just wastes space (see issue #70). -->
+    <dimen name="content_navigation_bar_padding">16dp</dimen>
 </resources>


### PR DESCRIPTION
## What & why

Found on-device (Mate 10 Pro, API 29). On the main screen the bottom section (View Battery Insights button + developer signature) took **~1/3 of the screen** with a large empty margin, and the battery details table's lower rows were **hidden with no way to scroll**.

## Root cause

1. The details table was a bare `TableLayout` with **no `ScrollView`** — in a weighted slot, so extra rows clipped.
2. `content_navigation_bar_padding` was a hardcoded **64dp**; on non-edge-to-edge devices (API < 35) the system already insets content above the nav bar, so it was pure wasted space.

## Changes

- Wrap the `TableLayout` in a `ScrollView` (`fillViewport=true`) so the details always scroll.
- `content_navigation_bar_padding` **64dp → 16dp**.

## Testing

- 📱 Verified on BLA-L29 (API 29) via the combined test build — table scrolls, footer no longer dominates.

## Follow-up (noted in #70)

Proper edge-to-edge bottom-inset handling for the main/insights screens (via `BaseActivity.applyBottomSystemBarInset`, as Settings already does) so API 35+ devices clear the nav bar dynamically instead of relying on the fixed dimension.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)