### PR TITLE
Shrink main gauge to 160dp + responsive title text (#74)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/widget/CircularProgressBar.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/widget/CircularProgressBar.java
@@ -89,6 +89,9 @@ public class CircularProgressBar extends ProgressBar {
 	private int progressAlertColor;
 	private int glowExtraStrokePx;
 
+	// Base (un-shrunk) title text size in px. onDraw() shrinks from this to fit wide values like "100%".
+	private float baseTitleTextSizePx;
+
 	/**
 	 * Constructor for programmatic instantiation
 	 *
@@ -415,6 +418,14 @@ public class CircularProgressBar extends ProgressBar {
 
 		// Draw title and subtitle
 		if (nonNull(title) && !title.isEmpty()) {
+			// Auto-fit the title so wide values (e.g. "100%") don't overflow the arc on a small gauge.
+			titlePaint.setTextSize(baseTitleTextSizePx);
+			final float maxTitleWidth = circleBounds.width() * 0.68f;
+			final float rawTitleWidth = titlePaint.measureText(title);
+			if (rawTitleWidth > maxTitleWidth) {
+				titlePaint.setTextSize(baseTitleTextSizePx * maxTitleWidth / rawTitleWidth);
+			}
+
 			float xPos = (int) (getMeasuredWidth() / 2f - titlePaint.measureText(title) / 2);
 			float yPos = getMeasuredHeight() / 2f;
 
@@ -559,6 +570,7 @@ public class CircularProgressBar extends ProgressBar {
 
 			// Percentage text - bold and clear
 			titlePaint.setTextSize(GeneralHelper.dpToPixel(res, titleTextSize));
+			baseTitleTextSizePx = titlePaint.getTextSize();
 			titlePaint.setStyle(Style.FILL);
 			titlePaint.setAntiAlias(true);
 			titlePaint.setTypeface(Typeface.create("sans-serif-medium", Typeface.BOLD));

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,7 +35,7 @@
             android:id="@+id/batteryPercentage"
             style="@style/Widget.ProgressBar.CircularProgressBar"
             android:layout_width="wrap_content"
-            android:layout_height="200dp"
+            android:layout_height="160dp"
             tools:cpb_subtitle="subtitle"
             tools:cpb_title="Title"
             android:layout_marginTop="10dp"


### PR DESCRIPTION
## What & why

The circular gauge was `200dp` — ~28% of a 720dp-height screen (~39% with the toolbar), so it dominated the main screen and squeezed the details table.

## Changes
- Gauge height **200dp → 160dp** (~22% of the screen, ~33% with the toolbar).
- **Responsive title text**: the fixed 64dp font let wide values like **"100%"** overflow/overlap the arc on the smaller circle. `onDraw()` now measures the title and shrinks the font to fit the ring's inner width — wide values scale down, typical values ("85%") are unchanged.

## Testing
- 📱 Verified on BLA-L29: gauge smaller, "100%" no longer overlaps.

## Note
The exact height (160dp) is easy to tune — say the word if you want 150/140dp.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)