### PR TITLE
Polish toolbar: white overflow icon + smaller title (#78)

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,6 +19,7 @@
             android:theme="@style/ToolBarStyle"
             app:popupTheme="@style/ThemeOverlay.Material3.Light"
             app:title="@string/app_name"
+            app:titleTextAppearance="@style/ToolBarStyle.Title"
             app:titleTextColor="@android:color/white"/>
 
     <LinearLayout

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -40,6 +40,14 @@
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="android:textColorSecondary">@android:color/white</item>
         <item name="actionMenuTextColor">@android:color/white</item>
+        <!-- Tint control icons (the overflow three-dots) white to match the white gear -->
+        <item name="colorControlNormal">@android:color/white</item>
+    </style>
+
+    <!-- Slightly smaller toolbar title so the long app name doesn't dominate the bar.
+         Color stays white via the Toolbar's app:titleTextColor. -->
+    <style name="ToolBarStyle.Title" parent="TextAppearance.Material3.TitleLarge">
+        <item name="android:textSize">18sp</item>
     </style>
 
     <!-- Settings theme without ActionBar (we use Toolbar instead) -->


### PR DESCRIPTION
Two small toolbar appearance fixes from on-device use.

## Overflow icon → white
The overflow three-dots (which holds **Send feedback**) rendered dark while the settings gear was white. The Material3 `ThemeOverlay.Material3.Toolbar.Surface` overlay tints control icons via `colorControlNormal` (a dark on-surface color); `ToolBarStyle` forced white for text/action-menu but not for the icon tint. Added `colorControlNormal=@android:color/white` to `ToolBarStyle`.

## Title → smaller
`Simple Battery Notifier` used the default 22sp `TitleLarge`. Added `ToolBarStyle.Title` (18sp) and applied it via `app:titleTextAppearance`. Color stays white through the existing `app:titleTextColor`. The 18sp is easily nudged if you want it smaller/larger.

## Testing
- `./gradlew assembleDebug` ✅
- Visual verification on device pending.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)