### PR TITLE
Bump AndroidX / Material / test dependencies (#80)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,19 +80,19 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'androidx.core:core:1.17.0'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'androidx.core:core:1.18.0'                 // held at 1.18.0; core 1.19.0 requires AGP 9.1+ (see #81)
+    implementation 'com.google.android.material:material:1.14.0'
 
     implementation 'androidx.preference:preference:1.2.1'     // AndroidX settings UI
-    implementation 'androidx.activity:activity:1.12.1'        // Activity Result API (for ringtone picker)
+    implementation 'androidx.activity:activity:1.13.0'        // Activity Result API (for ringtone picker)
     implementation 'androidx.cardview:cardview:1.0.0'         // CardView for battery insights
 
     // Testing dependencies (latest versions)
     testImplementation 'junit:junit:4.13.2'                   // JUnit 4 (Android standard)
-    testImplementation 'org.mockito:mockito-core:5.21.0'      // Mockito for mocking (latest)
-    testImplementation 'org.robolectric:robolectric:4.16'     // Robolectric for Android unit tests (latest)
+    testImplementation 'org.mockito:mockito-core:5.23.0'      // Mockito for mocking (latest)
+    testImplementation 'org.robolectric:robolectric:4.16.1'   // Robolectric for Android unit tests (latest)
     testImplementation 'androidx.test:core:1.7.0'             // AndroidX Test Core (latest)
-    testImplementation 'androidx.test.ext:junit:1.2.1'        // AndroidX JUnit extensions
+    testImplementation 'androidx.test.ext:junit:1.3.0'        // AndroidX JUnit extensions
 
     // Add more AndroidX as you update imports (e.g., constraintlayout)
     // implementation 'androidx.constraintlayout:constraintlayout:2.1.4'


### PR DESCRIPTION
Refreshes libraries to the latest stable versions **compatible with the current AGP 8.12.3**.

| Dependency | From | To | Note |
|---|---|---|---|
| androidx.core:core | 1.17.0 | **1.18.0** | 1.19.0 requires AGP 9.1+ → deferred to #81 |
| com.google.android.material:material | 1.13.0 | **1.14.0** | |
| androidx.activity:activity | 1.12.1 | **1.13.0** | |
| androidx.test.ext:junit | 1.2.1 | **1.3.0** | test-only |
| org.mockito:mockito-core | 5.21.0 | **5.23.0** | test-only |
| org.robolectric:robolectric | 4.16 | **4.16.1** | test-only |

Unchanged (already current): appcompat 1.7.1, preference 1.2.1, cardview 1.0.0 (frozen), androidx.test:core 1.7.0, junit 4.13.2 (JUnit4 final).

### Compatibility note
While bumping I found `androidx.core:core:1.19.0` hard-requires **AGP 9.1.0+**, so core is capped at **1.18.0** here (annotated in `build.gradle`). The jump to 1.19.0 rides along with the AGP 8→9 upgrade tracked in #81.

### Testing
- `./gradlew test` ✅ (mockito 5.23 / robolectric 4.16.1 / test-ext 1.3.0 exercised)
- `./gradlew assembleDebug` ✅
- `./gradlew assembleRelease` ✅ (R8 minify)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)