### PR TITLE
Add GitHub issue templates + email contact link (#83)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: 🐞 Bug report
+description: Something isn't working correctly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to report a bug. The more detail you give, the faster it can be fixed.
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Shown in the app / Play listing (e.g. 2.0.71).
+      placeholder: "2.0.71"
+    validations:
+      required: false
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      placeholder: "e.g. Huawei Mate 10 Pro (BLA-L29)"
+    validations:
+      required: true
+  - type: input
+    id: android
+    attributes:
+      label: Android / vendor skin version
+      placeholder: "e.g. Android 10 / EMUI 12"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug — what went wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Tap ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: Logs / screenshots (optional)
+      description: Paste any logcat output or drag in screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📧 Email the developer
+    url: mailto:support@almothafar.com?subject=Simple%20Battery%20Notifier%20feedback
+    about: Prefer email? Reach out directly — please include your device model and app version.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: 💡 Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Is your request related to a problem or frustration? Describe it.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about (optional).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,18 @@
+name: 💬 Feedback
+description: Share general feedback or impressions
+labels: ["feedback"]
+body:
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Your feedback
+      description: What do you like, dislike, or wish were different?
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Device (optional)
+      placeholder: "e.g. Huawei Mate 10 Pro"
+    validations:
+      required: false


### PR DESCRIPTION
Issue-form templates so the in-app **Report on GitHub** button (#73) lands on a useful picker instead of a blank issue. Split out of #73/#76 per review feedback.

| File | Purpose |
|---|---|
| `config.yml` | Disable blank issues; add "📧 Email the developer" contact link (`support@almothafar.com`) |
| `bug_report.yml` | Bug form (device / Android version / steps), label `bug` |
| `feature_request.yml` | Feature form (problem / solution / alternatives), label `enhancement` |
| `feedback.yml` | Freeform feedback, label `feedback` |

### Notes
- Templates only take effect on `…/issues/new/choose` once merged to the **default branch** (master).
- Needs a **`feedback` label** in the repo — please create it if it doesn't exist, or GitHub will show a warning on that template.
- The support email is duplicated here (GitHub `contact_links` can't read app resources); the app copy lives as a `translatable="false"` config string. Keep the two in sync.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)