### PR TITLE
Upgrade build tooling: Gradle 9.6.1 + AGP 9.2.1, core 1.19.0 (#81)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ afterEvaluate {
 android {
     namespace 'com.almothafar.simplebatterynotifier'
 
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId "com.almothafar.simplebatterynotifier"
@@ -57,8 +57,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_25
-        targetCompatibility JavaVersion.VERSION_25
+        // Capped at 24 (not 25): AGP 9 registers a built-in Kotlin task even for this Java-only
+        // module, and AGP 9.2.1's bundled Kotlin supports JVM targets only up to 24. The app is
+        // dexed, so 24 vs 25 has no runtime effect. Revisit when AGP bundles Kotlin with 25 support.
+        sourceCompatibility JavaVersion.VERSION_24
+        targetCompatibility JavaVersion.VERSION_24
     }
 
     testOptions {
@@ -80,7 +83,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'androidx.core:core:1.18.0'                 // held at 1.18.0; core 1.19.0 requires AGP 9.1+ (see #81)
+    implementation 'androidx.core:core:1.19.0'
     implementation 'com.google.android.material:material:1.14.0'
 
     implementation 'androidx.preference:preference:1.2.1'     // AndroidX settings UI

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,11 +57,10 @@ android {
     }
 
     compileOptions {
-        // Capped at 24 (not 25): AGP 9 registers a built-in Kotlin task even for this Java-only
-        // module, and AGP 9.2.1's bundled Kotlin supports JVM targets only up to 24. The app is
-        // dexed, so 24 vs 25 has no runtime effect. Revisit when AGP bundles Kotlin with 25 support.
-        sourceCompatibility JavaVersion.VERSION_24
-        targetCompatibility JavaVersion.VERSION_24
+        // Java 25 requires AGP 9's built-in Kotlin task to run Kotlin 2.3+ (JVM target 25 support);
+        // the root build.gradle pins kotlin-gradle-plugin to 2.3.21 for that. See #81.
+        sourceCompatibility JavaVersion.VERSION_25
+        targetCompatibility JavaVersion.VERSION_25
     }
 
     testOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        // AGP 9 ships built-in Kotlin; its default (KGP 2.2.10) caps the JVM target at 24. Pin a
+        // newer Kotlin so the built-in Kotlin task accepts Java 25 (JVM target 25, added in Kotlin
+        // 2.3.0). Without this, sourceCompatibility/targetCompatibility 25 fails to configure.
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.21'
+    }
+}
+
 plugins {
     id 'com.android.application' version '9.2.1' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '8.12.3' apply false
+    id 'com.android.application' version '9.2.1' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The deferred major build-tooling upgrade.

| Component | From | To |
|---|---|---|
| Gradle wrapper | 9.2.1 | **9.6.1** |
| AGP `com.android.application` | 8.12.3 | **9.2.1** (latest stable) |
| androidx.core:core | 1.18.0 | **1.19.0** |
| compileSdk | 36 | **37** |
| Kotlin Gradle plugin (pinned) | — | **2.3.21** |
| Java source/target | 25 | **25** (kept) |

### Why compileSdk 37
`androidx.core:core:1.19.0` requires compiling against **API 37+** (this, plus the AGP 9.1+ requirement, is why it was gated in #80). AGP 9.2.1 supports API 37. **`targetSdk` stays 36**, so no new *runtime* behavior is opted into — compileSdk moves independently, per AGP's own guidance.

### Why the Kotlin pin (Java 25 stays)
AGP 9 ships **built-in Kotlin** and registers a `compileDebugKotlin` task even for this Java-only module. Its *default* bundled Kotlin (KGP 2.2.10) caps the JVM target at **24**, so a Java 25 source/target fails configuration (`Unknown Kotlin JVM target: 25`). The fix is not to lower the language level but to **pin `kotlin-gradle-plugin` to 2.3.21** in the root `buildscript` — Kotlin 2.3.0+ adds JVM target 25 support. Java source/target therefore **stays at 25** (matching the pre-AGP-9 setup); the Kotlin task is `NO-SOURCE` and merely needs to accept the target.

### Deprecations noted (not addressed here, future cleanup)
- `android.enableJetifier=true` is deprecated (removed in AGP 10). All deps are AndroidX, so it's removable — left out to keep this PR focused.
- Groovy space-assignment syntax (`minifyEnabled true`, `sourceCompatibility …`) is deprecated in Gradle 9 (breaks in Gradle 10).

### Testing
- `./gradlew assembleDebug` ✅
- `./gradlew test` ✅
- `./gradlew assembleRelease` ✅ (R8 minify)
- **On-device retest pending** — AGP major upgrades can shift packaging; verify the app installs and core flows work on the Mate 10 Pro.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)