### PR TITLE
Modernize build tooling on AGP 8: Gradle 9.5.1 + AGP 8.13.2 (#86)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,21 +32,21 @@ afterEvaluate {
 }
 
 android {
-    namespace 'com.almothafar.simplebatterynotifier'
+    namespace = 'com.almothafar.simplebatterynotifier'
 
     compileSdk = 36
 
     defaultConfig {
-        applicationId "com.almothafar.simplebatterynotifier"
+        applicationId = "com.almothafar.simplebatterynotifier"
         minSdk = 26
         targetSdk = 36
-        versionCode versionProps['versionCode'].toInteger()
-        versionName "${versionProps['versionPrefix']}.${versionProps['versionCode']}"
+        versionCode = versionProps['versionCode'].toInteger()
+        versionName = "${versionProps['versionPrefix']}.${versionProps['versionCode']}"
     }
 
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
                     'proguard-rules.pro'
         }
@@ -57,8 +57,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_25
-        targetCompatibility JavaVersion.VERSION_25
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
     }
 
     testOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '8.12.3' apply false
+    id 'com.android.application' version '8.13.2' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
-# AndroidX migration flags
+# AndroidX (Jetifier not needed — all dependencies are already AndroidX)
 android.useAndroidX=true
-android.enableJetifier=true
 
 # (optional) memory
 org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Keeps the project on the AGP 8 line (AGP 9 parked in #81) while bringing the tooling current and clearing deprecated/unneeded build config.

| Change | From | To |
|---|---|---|
| Gradle wrapper | 9.2.1 | **9.5.1** |
| AGP `com.android.application` | 8.12.3 | **8.13.2** |
| `android.enableJetifier` | `true` | **removed** |
| Groovy space-assignment DSL | `prop value` | **`prop = value`** |

### Why Gradle 9.5.1 (not 9.6.1)
**AGP 8.x is incompatible with Gradle 9.6.x** — Gradle 9.6.0 removed the internal `InternalProblems` API that AGP 8 relies on (`Plugin 'com.android.internal.application' relies on … removed in Gradle 9.6.0`). So **9.5.1 is the newest Gradle that works with AGP 8**; going to 9.6.x would require AGP 9 (see #81, parked).

### DSL modernization (`app/build.gradle`)
Converted the deprecated Groovy space-assignment syntax (breaks in Gradle 10) to `= value`: `namespace`, `applicationId`, `versionCode`, `versionName`, `minifyEnabled`, `sourceCompatibility`, `targetCompatibility`. **Behavior is unchanged — R8 minification stays ON** (only the syntax changed). `proguardFiles(...)` is a genuine method call, left as-is.

### Left as-is (not ours to fix)
Two `multi-string notation` deprecations remain; both originate **inside AGP 8.13.2** (`com.android.tools.lint:lint-gradle`, `com.android.tools.build:aapt2`), not our scripts — Google resolves these in a future AGP.

### Unchanged
`compileSdk`/`targetSdk` stay 36, dependencies unchanged (core stays 1.18.0), **Java stays 25** (native on AGP 8 — no built-in Kotlin, so no KGP pin needed).

### Testing
- `./gradlew assembleDebug --warning-mode all` ✅ (our deprecations gone)
- `./gradlew test` ✅
- `./gradlew assembleRelease` ✅ (R8 minify)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)