### PR TITLE
#75 Option 3: fading edge + scrollbar (details table)

### DIFF
--- a/app/src/main/res/layout/fragment_battery_details.xml
+++ b/app/src/main/res/layout/fragment_battery_details.xml
@@ -4,10 +4,15 @@
     android:layout_height="match_parent"
     tools:context="com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment">
 
+    <!-- Option 3 (#75): a bottom fading edge + scrollbar make it obvious the table scrolls,
+         so the rows below the fold aren't mistaken for the end of the list. Footer stays pinned. -->
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        android:scrollbars="vertical"
+        android:requiresFadingEdge="vertical"
+        android:fadingEdgeLength="28dp">
 
         <TableLayout
             android:id="@+id/batteryDetailsTable"


### PR DESCRIPTION
**One of three competing prototypes for #75** — do not merge until we pick a winner on-device.

## Option 3 — fade edge + scrollbar (cheapest)
Adds to the details `ScrollView`:
- `android:scrollbars="vertical"`
- `android:requiresFadingEdge="vertical"` + `android:fadingEdgeLength="28dp"`

So the table shows a bottom fade + scrollbar when more rows exist — fixing the "looks complete, no cue to scroll" problem. **Keeps the current layout and the pinned Insights button + signature.**

Trade-off: still requires the user to scroll (it hints, doesn't reveal). Near-zero risk, no restructure.

Part of #75 · siblings: Option 1 (non-sticky single scroll), Option 2 (auto-scroll animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)