### PR TITLE
#75 Option 1: non-sticky footer (single scroll)

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -43,44 +43,58 @@
             android:layout_marginBottom="-10dp" />
     </LinearLayout>
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/detailsFragmentLayout"
+    <!-- Option 1 (#75): table + footer share one NestedScrollView so the footer is non-sticky
+         and every row is reachable by scrolling. Toolbar + gauge stay pinned above. -->
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:name="com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment"
-        tools:layout="@layout/fragment_battery_details" />
+        android:fillViewport="true">
 
-    <!-- Battery Health Section -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:paddingTop="16dp"
-        android:paddingBottom="@dimen/content_navigation_bar_padding"
-        android:background="@android:color/white">
-
-        <!-- Battery Insights Button - Material3 -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/batteryInsightsButton"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/view_battery_insights"
-            android:textColor="@android:color/white"
-            app:backgroundTint="@color/top_background_color"
-            android:layout_marginBottom="8dp"
-            style="@style/Widget.Material3.Button" />
+            android:orientation="vertical">
 
-        <!-- Developer Signature Fragment -->
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/signatureFragmentLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:name="com.almothafar.simplebatterynotifier.ui.fragment.SignatureFragment"
-            tools:layout="@layout/fragment_signature" />
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/detailsFragmentLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:name="com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment"
+                tools:layout="@layout/fragment_battery_details" />
 
-    </LinearLayout>
+            <!-- Battery Health Section — now scrolls WITH the table (non-sticky) -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
+                android:paddingBottom="@dimen/content_navigation_bar_padding"
+                android:background="@android:color/white">
+
+                <!-- Battery Insights Button - Material3 -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/batteryInsightsButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/view_battery_insights"
+                    android:textColor="@android:color/white"
+                    app:backgroundTint="@color/top_background_color"
+                    android:layout_marginBottom="8dp"
+                    style="@style/Widget.Material3.Button" />
+
+                <!-- Developer Signature Fragment -->
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/signatureFragmentLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:name="com.almothafar.simplebatterynotifier.ui.fragment.SignatureFragment"
+                    tools:layout="@layout/fragment_signature" />
+
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_battery_details.xml
+++ b/app/src/main/res/layout/fragment_battery_details.xml
@@ -1,21 +1,9 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<!-- Option 1 (#75): no inner ScrollView — the table + footer scroll together in the activity's
+     NestedScrollView, so the footer is non-sticky and no rows stay hidden below the fold. -->
+<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/batteryDetailsTable"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment">
-
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fillViewport="true">
-
-        <TableLayout
-            android:id="@+id/batteryDetailsTable"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:stretchColumns="0,1"
-            android:padding="20sp"
-            android:orientation="horizontal" />
-
-    </ScrollView>
-</FrameLayout>
+    android:layout_height="wrap_content"
+    android:stretchColumns="0,1"
+    android:padding="20sp"
+    android:orientation="horizontal" />


### PR DESCRIPTION
**One of three competing prototypes for #75** — do not merge until we pick a winner on-device.

## Option 1 — non-sticky footer (single scroll)
- `fragment_battery_details.xml`: drops the inner `ScrollView`; the fragment is now just the `TableLayout`.
- `activity_main.xml`: the details fragment + bottom section (Insights button + signature) now live inside **one `NestedScrollView`**, so they scroll together. Toolbar + gauge remain pinned above.

**Result:** nothing can hide under the footer — scrolling reveals the whole table and ends naturally with the button + signature.

Trade-off: the Insights button is **no longer permanently pinned** (it scrolls with the content). When the table is short, the footer sits right below it rather than at the screen bottom.

Part of #75 · siblings: Option 3 (fade edge, #88), Option 2 (auto-scroll animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)