### PR TITLE
#75 Option 2: gentle one-time auto-scroll hint

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -1,11 +1,19 @@
 package com.almothafar.simplebatterynotifier.ui.fragment;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.AnimatorSet;
+import android.animation.ObjectAnimator;
+import android.annotation.SuppressLint;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.AccelerateDecelerateInterpolator;
+import android.widget.ScrollView;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
@@ -66,6 +74,8 @@ public class BatteryDetailsFragment extends Fragment {
 			createDetailsTable(view);
 		}
 
+		maybeShowScrollHint(view);
+
 		return view;
 	}
 
@@ -101,6 +111,59 @@ public class BatteryDetailsFragment extends Fragment {
 		if (nonNull(viewRef) && nonNull(batteryDO)) {
 			this.createDetailsTable(viewRef);
 		}
+	}
+
+	/**
+	 * Option 2 (#75): once on first display, gently bob the details list down and back up when rows
+	 * sit below the fold — a moving cue that the table scrolls. The first touch cancels it so it
+	 * never fights the user, and it is skipped when the system "remove animations" setting is on.
+	 *
+	 * @param root The fragment view containing the scroll view
+	 */
+	@SuppressLint("ClickableViewAccessibility")
+	private void maybeShowScrollHint(final View root) {
+		final ScrollView scroll = root.findViewById(R.id.batteryDetailsScroll);
+		if (isNull(scroll)) {
+			return;
+		}
+		// Respect the accessibility "remove animations" setting.
+		final float animScale = Settings.Global.getFloat(
+				root.getContext().getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1f);
+		if (animScale == 0f) {
+			return;
+		}
+		// Delay so the initial layout/measure (and the first data refresh) have settled.
+		scroll.postDelayed(() -> {
+			final View content = scroll.getChildAt(0);
+			if (isNull(content)) {
+				return;
+			}
+			final int hiddenPx = content.getHeight() - scroll.getHeight();
+			if (hiddenPx <= 0) {
+				return; // nothing below the fold — no hint needed
+			}
+			final int reveal = Math.min(hiddenPx,
+					Math.round(96 * scroll.getResources().getDisplayMetrics().density));
+			final ObjectAnimator down = ObjectAnimator.ofInt(scroll, "scrollY", 0, reveal);
+			final ObjectAnimator up = ObjectAnimator.ofInt(scroll, "scrollY", reveal, 0);
+			final AnimatorSet hint = new AnimatorSet();
+			hint.playSequentially(down, up);
+			hint.setDuration(850);
+			hint.setInterpolator(new AccelerateDecelerateInterpolator());
+
+			// Never fight the user: the first touch cancels the hint and hands scrolling back.
+			scroll.setOnTouchListener((v, event) -> {
+				hint.cancel();
+				return false; // don't consume — let the ScrollView scroll normally
+			});
+			hint.addListener(new AnimatorListenerAdapter() {
+				@Override
+				public void onAnimationEnd(final Animator animation) {
+					scroll.setOnTouchListener(null);
+				}
+			});
+			hint.start();
+		}, 700L);
 	}
 
 	/**

--- a/app/src/main/res/layout/fragment_battery_details.xml
+++ b/app/src/main/res/layout/fragment_battery_details.xml
@@ -4,7 +4,9 @@
     android:layout_height="match_parent"
     tools:context="com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment">
 
+    <!-- Option 2 (#75): id lets the fragment run a one-time "bob" animation hinting the table scrolls. -->
     <ScrollView
+        android:id="@+id/batteryDetailsScroll"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true">


### PR DESCRIPTION
**One of three competing prototypes for #75** — do not merge until we pick a winner on-device.

## Option 2 — gentle auto-scroll animation (the fun-but-costly one)
Keeps the current layout (pinned footer). On first display, `BatteryDetailsFragment` runs a **one-time** hint: if the table has rows below the fold, it bobs the list down ~96dp and back up so the motion reveals there's more.

Guardrails (the reason this is the costliest option):
- **First touch cancels it** — never fights the user; scrolling immediately takes over.
- **Runs once** (from `onCreateView`, not on the 3s data refresh).
- **Respects accessibility** — skipped when `ANIMATOR_DURATION_SCALE == 0` (system "remove animations").
- Only fires when content actually overflows.

Trade-off: most moving parts / most code; motion can feel gimmicky on a utility app. Adds a `@+id/batteryDetailsScroll` id and ~45 lines in the fragment.

Part of #75 · siblings: Option 3 (fade edge, #88), Option 1 (non-sticky, #89).

🤖 Generated with [Claude Code](https://claude.com/claude-code)