### PR TITLE
🟡 Details table: fix RTL alignment + Western digits for Design Capacity (#96)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -99,8 +99,9 @@ public class BatteryInsightsActivity extends BaseActivity {
 		daysInUseText.setText(String.valueOf(BatteryHealthTracker.getDaysSinceFirstUse(this)));
 
 		final int designCapacity = BatteryHealthTracker.getDesignCapacity(this);
+		// Pass the number as a String so it renders in Western digits (0-9) in every locale (#96).
 		designCapacityText.setText(designCapacity > 0
-		                           ? getString(R.string.design_capacity_value, designCapacity)
+		                           ? getString(R.string.design_capacity_value, String.valueOf(designCapacity))
 		                           : getString(R.string.set_design_capacity_action));
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -101,12 +101,12 @@ public class BatteryDetailsFragment extends Fragment {
 
 		final TableLayout tableLayout = view.findViewById(R.id.batteryDetailsTable);
 		tableLayout.removeAllViews();
-		// Colon-aligned rows (#96): the label column (0) sizes to the widest label and its cells are
-		// end-aligned, so the colons line up; only the value column (2) stretches, so values sit right
-		// after the colon. Give the table the locale direction so columns order right-to-left in Arabic,
-		// and let long labels/values shrink rather than clip.
+		// Colon-aligned rows with the divider near the horizontal centre (#96): stretch BOTH the label (0)
+		// and value (2) columns so they share the width evenly, and the end-aligned labels' colons line up
+		// around the middle in both LTR and RTL (rather than wherever the widest label happens to end).
+		// Locale direction orders columns right-to-left in Arabic; long labels/values shrink rather than clip.
 		ViewCompat.setLayoutDirection(tableLayout, ViewCompat.LAYOUT_DIRECTION_LOCALE);
-		tableLayout.setColumnStretchable(0, false);
+		tableLayout.setColumnStretchable(0, true);
 		tableLayout.setColumnStretchable(1, false);
 		tableLayout.setColumnStretchable(2, true);
 		tableLayout.setColumnShrinkable(0, true);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -101,7 +101,14 @@ public class BatteryDetailsFragment extends Fragment {
 
 		final TableLayout tableLayout = view.findViewById(R.id.batteryDetailsTable);
 		tableLayout.removeAllViews();
-		tableLayout.setStretchAllColumns(true);
+		// Cluster each row tightly around the colon and mirror correctly in RTL (#96): stretch only the
+		// label (0) and value (2) columns so the colon column (1) keeps its natural width, let long values
+		// wrap, and give the table itself the locale direction so its columns order right-to-left in Arabic.
+		ViewCompat.setLayoutDirection(tableLayout, ViewCompat.LAYOUT_DIRECTION_LOCALE);
+		tableLayout.setColumnStretchable(0, true);
+		tableLayout.setColumnStretchable(1, false);
+		tableLayout.setColumnStretchable(2, true);
+		tableLayout.setColumnShrinkable(2, true);
 		final int cellPadding = getResources().getDimensionPixelSize(R.dimen.battery_details_cell_padding);
 		final int cellPaddingTop = getResources().getDimensionPixelSize(R.dimen.battery_details_cell_padding_top);
 
@@ -310,8 +317,9 @@ public class BatteryDetailsFragment extends Fragment {
 		// Show the user-entered design (rated) capacity when set (issue #32)
 		final int designCapacity = BatteryHealthTracker.getDesignCapacity(view.getContext());
 		if (designCapacity > 0) {
+			// Western digits (0-9) in every locale — see design_capacity_value / #96.
 			valuesMap.put(getResources().getString(R.string.design_capacity),
-					getResources().getString(R.string.design_capacity_value, designCapacity));
+					getResources().getString(R.string.design_capacity_value, String.valueOf(designCapacity)));
 		}
 
 		// Add charge cycles from the battery health tracker - positioned right after capacity

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -101,13 +101,15 @@ public class BatteryDetailsFragment extends Fragment {
 
 		final TableLayout tableLayout = view.findViewById(R.id.batteryDetailsTable);
 		tableLayout.removeAllViews();
-		// Cluster each row tightly around the colon and mirror correctly in RTL (#96): stretch only the
-		// label (0) and value (2) columns so the colon column (1) keeps its natural width, let long values
-		// wrap, and give the table itself the locale direction so its columns order right-to-left in Arabic.
+		// Colon-aligned rows (#96): the label column (0) sizes to the widest label and its cells are
+		// end-aligned, so the colons line up; only the value column (2) stretches, so values sit right
+		// after the colon. Give the table the locale direction so columns order right-to-left in Arabic,
+		// and let long labels/values shrink rather than clip.
 		ViewCompat.setLayoutDirection(tableLayout, ViewCompat.LAYOUT_DIRECTION_LOCALE);
-		tableLayout.setColumnStretchable(0, true);
+		tableLayout.setColumnStretchable(0, false);
 		tableLayout.setColumnStretchable(1, false);
 		tableLayout.setColumnStretchable(2, true);
+		tableLayout.setColumnShrinkable(0, true);
 		tableLayout.setColumnShrinkable(2, true);
 		final int cellPadding = getResources().getDimensionPixelSize(R.dimen.battery_details_cell_padding);
 		final int cellPaddingTop = getResources().getDimensionPixelSize(R.dimen.battery_details_cell_padding_top);
@@ -236,9 +238,12 @@ public class BatteryDetailsFragment extends Fragment {
 		final TextView textView = new TextView(view.getContext());
 		textView.setTextAppearance(R.style.DefaultTextStyle);
 		textView.setText(text);
+		// Right-align the label against the colon (END) so labels form a fixed column and the colons line
+		// up; relative padding + locale text direction keep the gap on the correct side in RTL (#96).
 		textView.setGravity(Gravity.END);
+		textView.setTextDirection(View.TEXT_DIRECTION_LOCALE);
 		textView.setTextColor(GeneralHelper.getColor(getResources(), R.color.battery_details_label_color));
-		textView.setPadding(0, 0, cellPadding, cellPaddingTop);
+		textView.setPaddingRelative(0, 0, cellPadding, cellPaddingTop);
 		return textView;
 	}
 
@@ -280,8 +285,11 @@ public class BatteryDetailsFragment extends Fragment {
 		textView.setTextAppearance(R.style.DefaultTextStyle);
 		textView.setText(text);
 		textView.setTextColor(GeneralHelper.getColor(getResources(), R.color.battery_details_value_color));
+		// Start-align + relative padding + locale text direction so numeric (Latin) values sit right after
+		// the colon like the Arabic text values do, instead of flying to the far edge in RTL (#96).
 		textView.setGravity(Gravity.START);
-		textView.setPadding(cellPadding, 0, 0, cellPaddingTop);
+		textView.setTextDirection(View.TEXT_DIRECTION_LOCALE);
+		textView.setPaddingRelative(cellPadding, 0, 0, cellPaddingTop);
 		if (unreliable) {
 			// #94: amber warning affordance after the value; tap to learn why the reading can't be trusted.
 			// Same mark as the insights health figure, so the two screens read consistently.

--- a/app/src/main/res/layout/fragment_battery_details.xml
+++ b/app/src/main/res/layout/fragment_battery_details.xml
@@ -19,7 +19,7 @@
             android:id="@+id/batteryDetailsTable"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stretchColumns="0,1"
+            android:stretchColumns="0,2"
             android:padding="20sp"
             android:orientation="horizontal" />
 

--- a/app/src/main/res/layout/fragment_battery_details.xml
+++ b/app/src/main/res/layout/fragment_battery_details.xml
@@ -19,7 +19,7 @@
             android:id="@+id/batteryDetailsTable"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stretchColumns="2"
+            android:stretchColumns="0,2"
             android:padding="20sp"
             android:orientation="horizontal" />
 

--- a/app/src/main/res/layout/fragment_battery_details.xml
+++ b/app/src/main/res/layout/fragment_battery_details.xml
@@ -19,7 +19,7 @@
             android:id="@+id/batteryDetailsTable"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stretchColumns="0,2"
+            android:stretchColumns="2"
             android:padding="20sp"
             android:orientation="horizontal" />
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -137,7 +137,7 @@
     <string name="about_battery_health">عن بطاريتك</string>
     <string name="battery_health_description_placeholder">ستظهر معلومات صحة بطاريتك هنا.</string>
     <string name="design_capacity">السعة التصميمية</string>
-    <string name="design_capacity_value">%1$d mAh</string>
+    <string name="design_capacity_value">%1$s mAh</string>
     <string name="set_design_capacity_action">أدخل السعة المقدّرة لحساب صحة أدق</string>
     <string name="design_capacity_dialog_title">السعة التصميمية للبطارية</string>
     <string name="design_capacity_dialog_message">أدخل السعة المقدّرة لبطاريتك بوحدة mAh من مواصفات الشركة المصنّعة. لقد عبّأنا تقديراً مقاساً — أكّده أو صحّحه للحصول على قيمة صحة دقيقة.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,7 +128,8 @@
     <string name="about_battery_health">About Your Battery</string>
     <string name="battery_health_description_placeholder">Your battery health information will appear here.</string>
     <string name="design_capacity">Design Capacity</string>
-    <string name="design_capacity_value">%1$d mAh</string>
+    <!-- %1$s is a Western-digit number (passed via String.valueOf) so it stays 0-9 in every locale (#96) -->
+    <string name="design_capacity_value">%1$s mAh</string>
     <string name="set_design_capacity_action">Set rated capacity for accurate health</string>
     <string name="design_capacity_dialog_title">Battery design capacity</string>
     <string name="design_capacity_dialog_message">Enter your battery\'s rated capacity in mAh from the manufacturer\'s specs. We\'ve prefilled a measured estimate — confirm or correct it for an accurate health figure.</string>


### PR DESCRIPTION
## What

Two details-screen fixes split out from the #94 review.

### Table alignment (RTL "chaos")

The details table used `setStretchAllColumns(true)`, so the **colon column stretched to a third of the width** and scattered label / colon / value with big uneven gaps. RTL column order is governed by the TableLayout's *own* layout direction, which wasn't being set (only the rows were).

- Stretch only the **label (0)** and **value (2)** columns; the colon column keeps its natural width, so rows cluster neatly around the colon.
- Set the **TableLayout's** `layoutDirection` to `LOCALE` so columns mirror right-to-left in Arabic.
- Value column is shrinkable so long values wrap instead of overflowing.

### Western digits for Design Capacity

`design_capacity_value` used `%1$d`, which renders **Eastern Arabic numerals** (`٤٠٠٠`) under the `ar` locale, while cycles/days already used `String.valueOf` (Western). Now formatted via `%1$s` + `String.valueOf`, so Design Capacity shows Western digits (0-9) everywhere — on both the home details table and the Battery Insights screen.

## Test

`testDebugUnitTest` + `assembleDebug` green; installed on the Mate 10 Pro.

**Please verify on device (Arabic + English):**
- Rows line up cleanly around the colon (no scattered gaps), labels/values on the correct sides in RTL.
- Design Capacity shows `4000`, not `٤٠٠٠`.

Alignment is hard to tune blind — if anything still looks off, tell me what you see and I'll iterate.

Closes #96
