### PR TITLE
🟡 Arabic: localize Settings toolbar title + rename details 'Health' row to 'Condition' (#98)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/SettingsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/SettingsActivity.java
@@ -107,6 +107,10 @@ public class SettingsActivity extends BaseActivity implements PreferenceFragment
 
 		// Load root preferences if this is the first creation
 		if (isNull(savedInstanceState)) {
+			// Set the title via the app's (locale-aware) resources. Without this, the toolbar falls back
+			// to the manifest android:label, which the framework resolves in the SYSTEM locale — showing an
+			// English "Settings" under an Arabic app until the back stack next changes (#98).
+			setTitle(R.string.title_activity_settings);
 			getSupportFragmentManager()
 					.beginTransaction()
 					.replace(R.id.settings_container, new HeaderFragment())

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -338,7 +338,7 @@ public class BatteryDetailsFragment extends Fragment {
 		valuesMap.put(getResources().getString(R.string.power_source), batteryDO.getPowerSource());
 		valuesMap.put(getResources().getString(R.string.temperature),
 				TemperatureUtils.format(view.getContext(), batteryDO.getTemperature()));
-		valuesMap.put(getResources().getString(R.string.health), batteryDO.getHealth());
+		valuesMap.put(getResources().getString(R.string.battery_condition), batteryDO.getHealth());
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -17,7 +17,7 @@
     <string name="temperature">الحرارة</string>
     <string name="technology">التكنولوجيا</string>
     <string name="voltage">الفولتية</string>
-    <string name="health">الصحة</string>
+    <string name="battery_condition">الحالة</string>
     <string name="capacity">السعة</string>
     <string name="battery_health_good">جيدة</string>
     <string name="battery_health_dead">منتهية</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,9 @@
     <string name="temperature">Temperature</string>
     <string name="technology">Technology</string>
     <string name="voltage">Voltage</string>
-    <string name="health">Health</string>
+    <!-- Details-table row: the OS battery-health flag (a coarse condition), distinct from the wear
+         percentage labelled "Battery Health" on the insights screen (#98) -->
+    <string name="battery_condition">Condition</string>
     <string name="capacity">Capacity</string>
     <string name="battery_health_good">Good</string>
     <string name="battery_health_dead">Dead</string>


### PR DESCRIPTION
Two small localisation / label fixes from QA.

## 1. Settings toolbar title showed English under Arabic

Opening Settings from the gear icon showed **"Settings"** in English even with the app in Arabic (content underneath was Arabic). `SettingsActivity` never set the title on first creation, so the toolbar fell back to the manifest `android:label`, which the framework resolves in the **system** locale — not the app's per-app (AppCompat) Arabic locale.

Fix: `setTitle(R.string.title_activity_settings)` on first creation, so it resolves via the app's locale-aware resources → **"الإعدادات"**. (The back-stack listener already did this on return to root, which is why navigating in-and-back used to "fix" it.)

## 2. Home "Health" row renamed to "Condition"

The details table's OS battery-health-**flag** row (Good / Overheat / Cold / Dead / …) was labelled "Health", clashing with the wear **percentage** labelled "Battery Health" on Insights. Relabelled the row to **"Condition" / "الحالة"** (new `battery_condition` string; the old single-use `health` string is replaced). The value (Good/جيدة/…) is unchanged.

## Test

`testDebugUnitTest` + `assembleDebug` green. Device was unplugged at build time so not yet installed — will install on reconnect. Please verify in Arabic: Settings title reads "الإعدادات", details row reads "الحالة".

Closes #98
