### PR TITLE
Inset Home & Insights footers above the system navigation bar

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -52,6 +52,11 @@ public class BatteryInsightsActivity extends BaseActivity {
 		final Toolbar toolbar = findViewById(R.id.toolbar);
 		setupToolbar(toolbar, true);
 
+		// Keep the scrollable content (down to the developer signature) clear of the system
+		// navigation bar. Android 15+ (targetSdk 35+) enforces edge-to-edge and no longer insets
+		// content above the nav bar, so without this the footer draws underneath it (#102).
+		applyBottomSystemBarInset(findViewById(R.id.insightsScrollContent));
+
 		// Initialize views
 		healthPercentageText = findViewById(R.id.healthPercentageText);
 		healthStatusText = findViewById(R.id.healthStatusText);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -113,6 +113,11 @@ public class MainActivity extends BaseActivity {
 		final Toolbar toolbar = findViewById(R.id.toolbar);
 		setupToolbar(toolbar);
 
+		// Keep the bottom section (Insights button + developer signature) clear of the system
+		// navigation bar. Android 15+ (targetSdk 35+) enforces edge-to-edge and no longer insets
+		// content above the nav bar, so without this the signature draws underneath it (#102).
+		applyBottomSystemBarInset(findViewById(R.id.homeBottomSection));
+
 		// setStatusBarColor()/setNavigationBarColor() removed (deprecated in API 35).
 		// Edge-to-edge is enforced by the platform on Android 15+; system-bar insets are handled
 		// in BaseActivity. System bar colors should be set via themes (values/themes.xml).

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -29,6 +29,7 @@
             android:fillViewport="true">
 
         <LinearLayout
+                android:id="@+id/insightsScrollContent"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -53,6 +53,7 @@
 
     <!-- Battery Health Section -->
     <LinearLayout
+        android:id="@+id/homeBottomSection"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"


### PR DESCRIPTION
## What
On Android 15+ the system navigation bar overlapped the footer (developer signature / insights content) on the **Home** and **Battery Insights** screens.

## Why
Android 15+ (targetSdk 35+) enforces edge-to-edge and no longer insets app content above the nav bar — the app must. `SettingsActivity` already does this via `applyBottomSystemBarInset(...)`, but Home and Insights only used a fixed 16dp bottom padding (`content_navigation_bar_padding`). Older Android (e.g. Mate 10 Pro) auto-insets content, which is why it looked fine there.

## Change
- Give the Home bottom section (`homeBottomSection`) and the Insights scroll content (`insightsScrollContent`) ids.
- Apply `BaseActivity.applyBottomSystemBarInset(...)` to each in `onCreate`, so the real nav-bar inset is added on top of the 16dp breathing room.

## Test
- `assembleDebug` green; installed on device (Samsung, Android 15+).
- Please verify on-device: the footer/signature on **Home** and **Insights** now sits above the navigation bar (and Settings is unchanged).

Closes #102