### PR TITLE
Always show measured battery health when a design capacity is set

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -70,12 +70,6 @@ public class BatteryHealthTracker {
 	private static final float MEASURED_HEALTH_MIN_PLAUSIBLE_RATIO = 0.40f;
 	private static final float MEASURED_HEALTH_MAX_PLAUSIBLE_RATIO = 1.15f;
 
-	// Minimum battery level (%) at which the measured health figure is trustworthy. The current
-	// full-capacity estimate is charge-counter (µAh) ÷ CAPACITY (integer %), so at low charge the
-	// integer rounding of CAPACITY dominates and the figure becomes jumpy. Below this level we
-	// withhold the measured figure and fall back to the cycle-based estimate. See issue #37.
-	static final int MEASURED_HEALTH_MIN_BATTERY_LEVEL = 80;
-
 	/**
 	 * Records battery state and updates charge cycle count if appropriate.
 	 *
@@ -279,15 +273,14 @@ public class BatteryHealthTracker {
 	 * user-entered design capacity.
 	 * <p>
 	 * {@code health % = current full capacity (measured) / design capacity (user-entered) * 100}.
-	 * This is the accurate figure requested in #32; it only applies when the user has entered a
-	 * design capacity, the device reports the live charge counter used to estimate the current full
-	 * capacity, <em>and</em> the battery is charged to at least {@link #MEASURED_HEALTH_MIN_BATTERY_LEVEL}%
-	 * (below which the estimate is too noisy — see issue #37).
+	 * This is the accurate figure requested in #32; it applies whenever the user has entered a design
+	 * capacity and the device reports the live charge counter used to estimate the current full
+	 * capacity. It is shown regardless of charge level so it stays consistent with the displayed
+	 * Capacity (#103); when no design capacity is set, callers fall back to the cycle-based estimate.
 	 *
 	 * @param context Application context
 	 *
-	 * @return Measured health percentage (1-100), or -1 when it cannot be determined or the battery is
-	 * too low for a stable reading
+	 * @return Measured health percentage (1-100), or -1 when it cannot be determined
 	 */
 	public static int getMeasuredHealthPercentage(final Context context) {
 		if (isNull(context)) {
@@ -295,30 +288,28 @@ public class BatteryHealthTracker {
 		}
 		return computeMeasuredHealth(
 				SystemService.getBatteryCapacity(context),
-				getDesignCapacity(context),
-				SystemService.getBatteryLevelPercent(context));
+				getDesignCapacity(context));
 	}
 
 	/**
 	 * Pure helper for the measured health percentage, unit-testable with no Android dependencies.
 	 * <p>
-	 * The measured figure is withheld (returns -1) below {@link #MEASURED_HEALTH_MIN_BATTERY_LEVEL}%
-	 * charge, where the charge-counter estimate is dominated by the integer CAPACITY rounding and
-	 * would otherwise show a jumpy value (issue #37). Callers then fall back to the cycle-based estimate.
+	 * Returns the current full capacity as a percentage of the design capacity, clamped to 1-100. As
+	 * long as a design capacity is set and the device reports a usable charge-counter estimate, the
+	 * measured figure is always returned so it stays consistent with the displayed Capacity — the app
+	 * no longer withholds it at low charge and silently substitutes the cycle-based estimate, which
+	 * read a misleading 100% on a new phone (issue #103, superseding the earlier near-full gate #37).
+	 * The worst readings are still handled elsewhere: {@code SystemService.estimateFullCapacityMah}
+	 * rejects an out-of-range charge counter (yielding 0 here, hence -1), and estimates wildly out of
+	 * line with the design capacity are flagged via {@link #isEstimateImplausible}.
 	 *
-	 * @param currentFullMah     measured current full capacity in mAh (0 when unknown)
-	 * @param designMah          user-entered design capacity in mAh (0 when unset)
-	 * @param batteryLevelPercent current battery level 1-100 (-1 when unknown)
+	 * @param currentFullMah measured current full capacity in mAh (0 when unknown)
+	 * @param designMah      user-entered design capacity in mAh (0 when unset)
 	 *
-	 * @return health percentage clamped to 1-100, or -1 when any input is unusable or the battery is
-	 * below the near-full threshold
+	 * @return health percentage clamped to 1-100, or -1 when either input is unusable
 	 */
-	static int computeMeasuredHealth(final int currentFullMah, final int designMah, final int batteryLevelPercent) {
+	static int computeMeasuredHealth(final int currentFullMah, final int designMah) {
 		if (currentFullMah <= 0 || designMah <= 0) {
-			return -1;
-		}
-		// Too low (or unknown) to trust the charge-counter estimate: defer to the cycle-based figure.
-		if (batteryLevelPercent < MEASURED_HEALTH_MIN_BATTERY_LEVEL) {
 			return -1;
 		}
 		final int percent = Math.round(currentFullMah * 100f / designMah);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -303,28 +303,6 @@ public final class SystemService {
 	}
 
 	/**
-	 * Read the current battery charge level as a percentage via the public
-	 * {@link BatteryManager#BATTERY_PROPERTY_CAPACITY} property.
-	 * <p>
-	 * Used to gate the measured health figure: the charge-counter-based full-capacity estimate is
-	 * only stable near full charge (see issue #37 and {@code BatteryHealthTracker}).
-	 *
-	 * @param context The application context
-	 *
-	 * @return current battery level (1-100), or -1 when it cannot be determined
-	 */
-	public static int getBatteryLevelPercent(final Context context) {
-		final BatteryManager batteryManager = (BatteryManager) context.getSystemService(Context.BATTERY_SERVICE);
-		if (isNull(batteryManager)) {
-			Log.w(TAG, "BatteryManager service unavailable");
-			return -1;
-		}
-		final int capacityPercent = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
-		// getIntProperty returns Integer.MIN_VALUE for unsupported properties; keep only a valid 1-100.
-		return (capacityPercent >= 1 && capacityPercent <= 100) ? capacityPercent : -1;
-	}
-
-	/**
 	 * Read the OS-reported charge cycle count, where available.
 	 * <p>
 	 * Exposed to apps via the public {@link BatteryManager#EXTRA_CYCLE_COUNT} extra on

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerTest.java
@@ -13,45 +13,37 @@ import static org.junit.Assert.assertTrue;
  */
 public class BatteryHealthTrackerTest {
 
-	// A near-full battery level, at/above the threshold, so these cases exercise the math (not the gate).
-	private static final int FULL = 95;
-
 	@Test
 	public void computeMeasuredHealth_typicalReadings() {
 		// 3800 mAh measured against a 4000 mAh design capacity -> 95%
-		assertEquals(95, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, FULL));
+		assertEquals(95, BatteryHealthTracker.computeMeasuredHealth(3800, 4000));
 		// A healthy battery measuring at its rated capacity -> 100%
-		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4000, 4000, FULL));
+		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4000, 4000));
 		// Worn battery: 3000 of 5000 -> 60%
-		assertEquals(60, BatteryHealthTracker.computeMeasuredHealth(3000, 5000, FULL));
+		assertEquals(60, BatteryHealthTracker.computeMeasuredHealth(3000, 5000));
 	}
 
 	@Test
 	public void computeMeasuredHealth_clampsToRange() {
 		// Measured above rated (fresh cell / rounding) is clamped to 100
-		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4200, 4000, FULL));
+		assertEquals(100, BatteryHealthTracker.computeMeasuredHealth(4200, 4000));
 		// Never reports 0; the smallest positive result is 1
-		assertEquals(1, BatteryHealthTracker.computeMeasuredHealth(1, 15000, FULL));
+		assertEquals(1, BatteryHealthTracker.computeMeasuredHealth(1, 15000));
 	}
 
 	@Test
 	public void computeMeasuredHealth_unusableInputs_returnsMinusOne() {
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(0, 4000, FULL));
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 0, FULL));
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(-5, 4000, FULL));
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(0, 4000));
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 0));
+		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(-5, 4000));
 	}
 
 	@Test
-	public void computeMeasuredHealth_belowNearFullThreshold_returnsMinusOne() {
-		final int threshold = BatteryHealthTracker.MEASURED_HEALTH_MIN_BATTERY_LEVEL;
-		// Just below the threshold: withheld as too noisy, so callers fall back to the cycle estimate.
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, threshold - 1));
-		// A low charge level is withheld even with otherwise-usable capacity inputs.
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, 5));
-		// Unknown level (-1) is also withheld.
-		assertEquals(-1, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, -1));
-		// Exactly at the threshold: the measured figure is returned.
-		assertEquals(95, BatteryHealthTracker.computeMeasuredHealth(3800, 4000, threshold));
+	public void computeMeasuredHealth_shownRegardlessOfChargeLevel() {
+		// #103: the measured figure no longer depends on charge level and is never withheld in favour
+		// of a misleading cycle-based 100%. A ~4400 mAh estimate on a 4700 mAh design reads 94% whether
+		// the battery is near full or nearly empty, staying consistent with the displayed Capacity.
+		assertEquals(94, BatteryHealthTracker.computeMeasuredHealth(4400, 4700));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem
With a design capacity set (e.g. 4700 mAh) and a measured full-capacity estimate of ~4400 mAh, Insights showed **Health = 100%** while Capacity clearly implied ~94% — a contradiction the user spotted, and essentially the old #7 'always 100%' resurfacing.

## Root cause
`computeMeasuredHealth` withheld the measured figure below **80% charge** (`MEASURED_HEALTH_MIN_BATTERY_LEVEL`, a near-full gate from #37) and `showResolvedHealth` fell back to the **cycle-based estimate**, which is trivially **100%** on a new phone (0 cycles). Capacity (ungated) and Health (gated) disagreed.

## Change (maintainer-approved: 'always show measured')
- Drop the charge-level gate: once a design capacity is set and the device reports a usable charge-counter estimate, **always show the measured figure** (current full capacity ÷ design), clamped to 1–100, so Health stays consistent with Capacity regardless of charge level.
- The worst readings are still handled without the gate: `estimateFullCapacityMah` rejects an out-of-range charge counter (→ unknown → cycle estimate), and the 40–115% plausibility window still flags an untrustworthy reading with the #94 warning.
- The cycle-based estimate remains only when **no** design capacity is set.
- Removes the now-unused `MEASURED_HEALTH_MIN_BATTERY_LEVEL` constant and the `SystemService.getBatteryLevelPercent` helper that existed solely to feed the gate.

## Tests
- `computeMeasuredHealth` is now 2-arg; updated the pure-helper unit tests and added a regression test for the reporter's case (4400 / 4700 → **94%**).
- `testDebugUnitTest` + `assembleDebug` green; installed on device.

## Note
On a new phone the charge counter commonly reads ~94% of design — that's the honest measured value, not a bug. Verify on-device: Insights health now matches Capacity (no more 100% at lower charge).

Closes #103