### PR TITLE
Best-effort auto-detect battery design capacity from the kernel

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -44,6 +44,9 @@ public class BatteryHealthTracker {
 	// Debug-only cycle offset kept separate from real tracking so it can be cleared without
 	// destroying genuine data (see the debug menu in BatteryInsightsActivity).
 	private static final String PREF_DEBUG_CHARGE_CYCLES = "_battery_health_debug_charge_cycles";
+	// Set once we've attempted the best-effort auto-detect of the design capacity, so a user who clears
+	// the value isn't silently re-populated on the next run. See issue #104.
+	private static final String PREF_DESIGN_CAPACITY_AUTO_TRIED = "_battery_design_capacity_auto_tried";
 
 	// One charge cycle = this many percentage-points of charge delivered to the battery.
 	private static final int CYCLE_PERCENT_POINTS = 100;
@@ -238,6 +241,50 @@ public class BatteryHealthTracker {
 	 */
 	public static boolean hasDesignCapacity(final Context context) {
 		return getDesignCapacity(context) > 0;
+	}
+
+	/**
+	 * Best-effort: auto-detect and store the battery design capacity when the user hasn't set one.
+	 * <p>
+	 * Reads the kernel's rated-capacity node via {@link SystemService#getDesignCapacityFromSystem()}
+	 * (available on some devices, blocked on many newer ones). Attempted at most once — a flag records
+	 * the attempt so a user who later clears the value isn't re-populated — and never overrides a value
+	 * the user already set. When nothing is readable this is a silent no-op and manual entry stands.
+	 *
+	 * @param context Application context
+	 *
+	 * @return true when a design capacity was auto-detected and stored by this call
+	 */
+	public static boolean autoDetectDesignCapacityIfUnset(final Context context) {
+		if (isNull(context)) {
+			return false;
+		}
+		return applyAutoDetectedDesignCapacity(context, SystemService.getDesignCapacityFromSystem());
+	}
+
+	/**
+	 * Applies an already-read auto-detected capacity under the once-only, never-override rules. Split
+	 * out (and package-private) from {@link #autoDetectDesignCapacityIfUnset} so the policy can be
+	 * unit-tested without depending on the device's sysfs nodes.
+	 *
+	 * @param context     Application context
+	 * @param detectedMah design capacity read from the system in mAh, or {@code <= 0} when unavailable
+	 *
+	 * @return true when {@code detectedMah} was stored as the design capacity by this call
+	 */
+	static boolean applyAutoDetectedDesignCapacity(final Context context, final int detectedMah) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		// Attempt at most once, and never override a value the user already has.
+		if (prefs.getBoolean(PREF_DESIGN_CAPACITY_AUTO_TRIED, false) || hasDesignCapacity(context)) {
+			return false;
+		}
+		prefs.edit().putBoolean(PREF_DESIGN_CAPACITY_AUTO_TRIED, true).apply();
+		if (detectedMah <= 0) {
+			return false;
+		}
+		setDesignCapacity(context, detectedMah);
+		Log.i(TAG, "Design capacity auto-detected from system: " + detectedMah + " mAh");
+		return true;
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -20,6 +20,9 @@ import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.model.BatteryHealthStatus;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 
 import static java.util.Objects.isNull;
@@ -35,6 +38,11 @@ public final class SystemService {
 	// mAh estimates; anything outside this range is treated as "unknown". See issue #69.
 	private static final int MIN_PLAUSIBLE_CAPACITY_MAH = 500;
 	private static final int MAX_PLAUSIBLE_CAPACITY_MAH = 15000;
+
+	// Linux power-supply sysfs directory; a supply's charge_full_design node holds the rated capacity
+	// in µAh. Readable on some devices, blocked by SELinux on many newer ones (issue #104).
+	private static final String POWER_SUPPLY_DIR = "/sys/class/power_supply";
+	private static final String CHARGE_FULL_DESIGN_NODE = "charge_full_design";
 
 	private SystemService() {
 		// Utility class - prevent instantiation
@@ -300,6 +308,83 @@ public final class SystemService {
 			return 0;
 		}
 		return estimateMah;
+	}
+
+	// --- Battery design (rated) capacity, read best-effort from the kernel (issue #104) ---
+
+	/**
+	 * Best-effort read of the battery's design (rated) capacity from the kernel power-supply nodes.
+	 * <p>
+	 * Android exposes no public API for design capacity, but many devices surface it via the Linux
+	 * power-supply class at {@code /sys/class/power_supply/<supply>/charge_full_design} (in µAh). This
+	 * scans the available supplies for that node and returns the first plausible value in mAh. When the
+	 * node is missing or blocked — common under SELinux on newer devices — it returns 0 so callers fall
+	 * back to manual entry.
+	 *
+	 * @return design capacity in mAh, or 0 when it cannot be read
+	 */
+	public static int getDesignCapacityFromSystem() {
+		final File[] supplies = new File(POWER_SUPPLY_DIR).listFiles();
+		if (isNull(supplies)) {
+			return 0; // Directory not listable (e.g. SELinux) — fall back to manual entry.
+		}
+		for (final File supply : supplies) {
+			final int mah = readDesignCapacityMah(new File(supply, CHARGE_FULL_DESIGN_NODE));
+			if (mah > 0) {
+				return mah;
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Reads and validates a single {@code charge_full_design} node.
+	 * <p>
+	 * The expected "missing" cases (node absent or not readable) are validated up front rather than
+	 * caught. Only the genuinely-exceptional case — the node passes those checks but the read still
+	 * fails — is caught, logged (not swallowed) and treated as "unavailable".
+	 *
+	 * @param node the candidate {@code charge_full_design} file
+	 *
+	 * @return design capacity in mAh, or 0 when unavailable or implausible
+	 */
+	private static int readDesignCapacityMah(final File node) {
+		if (!node.exists() || !node.canRead()) {
+			return 0;
+		}
+		try (BufferedReader reader = new BufferedReader(new FileReader(node))) {
+			return designCapacityMahFromMicroAmpHours(reader.readLine());
+		} catch (IOException e) {
+			Log.d(TAG, "Unable to read " + node + ": " + e.getMessage());
+			return 0;
+		}
+	}
+
+	/**
+	 * Converts a raw {@code charge_full_design} value (microampere-hours) to a plausible mAh capacity.
+	 * <p>
+	 * Pure and Android-free so it is unit-testable. Validates the text before parsing (so malformed
+	 * content is a no-op, not an exception) and rejects results outside the plausible battery range,
+	 * mirroring {@link #estimateFullCapacityMah}.
+	 *
+	 * @param rawMicroAmpHours raw node contents (µAh as text), or null
+	 *
+	 * @return design capacity in mAh, or 0 when the value is missing, malformed or implausible
+	 */
+	static int designCapacityMahFromMicroAmpHours(final String rawMicroAmpHours) {
+		if (isNull(rawMicroAmpHours)) {
+			return 0;
+		}
+		final String trimmed = rawMicroAmpHours.trim();
+		// µAh for a phone battery is at most ~8 digits; bound the length so the parse can't overflow.
+		if (!trimmed.matches("\\d{1,9}")) {
+			return 0;
+		}
+		final int mah = (int) (Long.parseLong(trimmed) / 1000L);
+		if (mah < MIN_PLAUSIBLE_CAPACITY_MAH || mah > MAX_PLAUSIBLE_CAPACITY_MAH) {
+			return 0;
+		}
+		return mah;
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -28,6 +28,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
+import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.PowerConnectionService;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.ui.widget.CircularProgressBar;
@@ -149,6 +150,11 @@ public class MainActivity extends BaseActivity {
 
 		// Set up button click listeners
 		batteryInsightsButton.setOnClickListener(v -> openBatteryInsights());
+
+		// Best-effort: auto-fill the battery design capacity from the device on first run, so the
+		// measured health/capacity works without the user having to look up and type it in (#104).
+		// No-op on devices where the kernel node isn't readable — manual entry still applies there.
+		BatteryHealthTracker.autoDetectDesignCapacityIfUnset(this);
 
 		// Start the power connection service as a foreground service so monitoring
 		// survives the app being closed (required on Android 8+).

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerStateTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTrackerStateTest.java
@@ -109,6 +109,33 @@ public class BatteryHealthTrackerStateTest {
 	}
 
 	@Test
+	public void autoDetectDesignCapacity_storesDetectedValueOnceWhenUnset() {
+		// A readable kernel value is stored as the design capacity...
+		assertTrue(BatteryHealthTracker.applyAutoDetectedDesignCapacity(context, 4700));
+		assertEquals(4700, BatteryHealthTracker.getDesignCapacity(context));
+		// ...and a later detection never overrides the now-present value.
+		assertFalse(BatteryHealthTracker.applyAutoDetectedDesignCapacity(context, 5000));
+		assertEquals(4700, BatteryHealthTracker.getDesignCapacity(context));
+	}
+
+	@Test
+	public void autoDetectDesignCapacity_neverOverridesUserValue() {
+		BatteryHealthTracker.setDesignCapacity(context, 4000);
+		assertFalse(BatteryHealthTracker.applyAutoDetectedDesignCapacity(context, 4700));
+		assertEquals(4000, BatteryHealthTracker.getDesignCapacity(context));
+	}
+
+	@Test
+	public void autoDetectDesignCapacity_attemptsAtMostOnce() {
+		// First attempt finds nothing readable (0) but records the attempt...
+		assertFalse(BatteryHealthTracker.applyAutoDetectedDesignCapacity(context, 0));
+		assertFalse(BatteryHealthTracker.hasDesignCapacity(context));
+		// ...so even a later successful read is ignored (a user who cleared the value isn't re-populated).
+		assertFalse(BatteryHealthTracker.applyAutoDetectedDesignCapacity(context, 4700));
+		assertFalse(BatteryHealthTracker.hasDesignCapacity(context));
+	}
+
+	@Test
 	public void resetHealthData_clearsCyclesAndFirstUse() {
 		BatteryHealthTracker.recordBatteryState(context, 0, BatteryManager.BATTERY_STATUS_DISCHARGING);
 		BatteryHealthTracker.recordBatteryState(context, 100, BatteryManager.BATTERY_STATUS_CHARGING);

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/SystemServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/SystemServiceTest.java
@@ -45,4 +45,34 @@ public class SystemServiceTest {
 		assertEquals(500, SystemService.estimateFullCapacityMah(500_000, 100));
 		assertEquals(15000, SystemService.estimateFullCapacityMah(15_000_000, 100));
 	}
+
+	@Test
+	public void designCapacityFromMicroAmpHours_typicalReadings() {
+		// charge_full_design is reported in µAh: 4,700,000 µAh -> 4700 mAh
+		assertEquals(4700, SystemService.designCapacityMahFromMicroAmpHours("4700000"));
+		// Surrounding whitespace / trailing newline from the sysfs node is tolerated
+		assertEquals(4000, SystemService.designCapacityMahFromMicroAmpHours(" 4000000\n"));
+	}
+
+	@Test
+	public void designCapacityFromMicroAmpHours_missingOrMalformed_returnsZero() {
+		assertEquals(0, SystemService.designCapacityMahFromMicroAmpHours(null));
+		assertEquals(0, SystemService.designCapacityMahFromMicroAmpHours(""));
+		assertEquals(0, SystemService.designCapacityMahFromMicroAmpHours("N/A"));
+		assertEquals(0, SystemService.designCapacityMahFromMicroAmpHours("-4700000"));
+	}
+
+	@Test
+	public void designCapacityFromMicroAmpHours_implausibleResult_returnsZero() {
+		// A value already in mAh (non-standard) divides down to 4 mAh -> rejected as implausible.
+		assertEquals(0, SystemService.designCapacityMahFromMicroAmpHours("4700"));
+		// Absurdly large (wrong unit the other way): 200,000,000 µAh -> 200000 mAh -> rejected.
+		assertEquals(0, SystemService.designCapacityMahFromMicroAmpHours("200000000"));
+	}
+
+	@Test
+	public void designCapacityFromMicroAmpHours_plausibleBoundaries_areKept() {
+		assertEquals(500, SystemService.designCapacityMahFromMicroAmpHours("500000"));
+		assertEquals(15000, SystemService.designCapacityMahFromMicroAmpHours("15000000"));
+	}
 }


### PR DESCRIPTION
## What
Design (rated) capacity had no public Android API, so it was always manual entry. Many devices expose it via the Linux power-supply class at `/sys/class/power_supply/<supply>/charge_full_design` (µAh), so this reads it best-effort and **auto-fills** the design capacity on first run — enabling measured health/capacity without the user having to look it up.

## Change
- `SystemService.getDesignCapacityFromSystem()` scans the power-supply nodes and returns the first plausible value in mAh. `designCapacityMahFromMicroAmpHours()` validates the text before parsing and rejects out-of-range results (pure, unit-tested). Missing/blocked nodes (common under SELinux on newer devices) return 0, so **manual entry still applies**. Only a genuinely unexpected read failure is caught + logged (not swallowed), per the no-silent-catch policy (#43).
- `BatteryHealthTracker.autoDetectDesignCapacityIfUnset()` stores it under **once-only, never-override** rules — a flag records the attempt so a user who clears the value isn't re-populated, and a user-set value is never overwritten. The policy is split into a package-private `applyAutoDetectedDesignCapacity()` so it's unit-testable without sysfs.
- `MainActivity` triggers the best-effort detection on launch (so both Home capacity and Insights health benefit).

## Tests
- New pure-helper tests for `designCapacityMahFromMicroAmpHours` (typical µAh, whitespace, malformed, implausible, boundaries) and Robolectric tests for the once-only/never-override policy.
- `testDebugUnitTest` + `assembleDebug` green; installed on device. Verified it merges cleanly with #103.

## Note
On this newer device the node is likely **SELinux-blocked**, so auto-detect may no-op and manual entry (prefilled with the measured estimate) still stands — expected. It helps on devices where the node is readable.

Closes #104