### PR TITLE
Make quiet hours actually silence alerts, with a critical override (#111)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -63,6 +63,9 @@ public final class NotificationService {
 	private static final String CHANNEL_ID_FULL = "battery_full";
 	private static final String CHANNEL_ID_STATUS = "battery_status";
 	private static final String CHANNEL_ID_TEMPERATURE = "battery_temperature";
+	// Silent, low-importance channel used to deliver an alert quietly during the user's quiet hours:
+	// the alert is still visible but makes no sound or vibration (issue #111).
+	private static final String CHANNEL_ID_ALERTS_SILENT = "battery_alerts_quiet";
 
 	// Notification settings
 	private static final long[] VIBRATION_PATTERN = {0, 500, 250, 500, 250};
@@ -195,7 +198,12 @@ public final class NotificationService {
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 		final String temperature = TemperatureUtils.format(context, rawTenthsC);
 
-		final Notification.Builder builder = new Notification.Builder(context, CHANNEL_ID_TEMPERATURE)
+		// A high-temperature warning is not a critical battery alert, so it respects quiet hours: shown
+		// on the silent channel outside the window (issue #111).
+		final boolean withinWindow = isWithinNotificationWindow(context, prefs);
+		final String channelId = withinWindow ? CHANNEL_ID_TEMPERATURE : CHANNEL_ID_ALERTS_SILENT;
+
+		final Notification.Builder builder = new Notification.Builder(context, channelId)
 				.setSmallIcon(R.drawable.ic_stat_temperature_hot)
 				.setTicker(context.getString(R.string.notification_temperature_ticker))
 				.setContentTitle(context.getString(R.string.notification_temperature_title))
@@ -215,7 +223,7 @@ public final class NotificationService {
 		final String sound = prefs.getString(
 				context.getString(R.string._pref_key_notifications_alert_sound_ringtone),
 				context.getString(R.string._default_notification_sound_uri));
-		playAlarm(context, sound, isWithinNotificationWindow(context, prefs), shouldIgnoreSilentMode(context, prefs),
+		playAlarm(context, sound, withinWindow, shouldIgnoreSilentMode(context, prefs),
 				isVibrationEnabled(context, prefs));
 	}
 
@@ -367,28 +375,32 @@ public final class NotificationService {
 		createChannelIfNotExists(manager, CHANNEL_ID_TEMPERATURE,
 				context.getString(R.string.notification_temperature_channel_name),
 				context.getString(R.string.notification_temperature_channel_description), Color.RED, vibrate);
-		createStatusChannelIfNotExists(manager,
+		createSilentChannelIfNotExists(manager, CHANNEL_ID_STATUS,
 				context.getString(R.string.notification_status_channel_name),
 				context.getString(R.string.notification_status_channel_description));
+		createSilentChannelIfNotExists(manager, CHANNEL_ID_ALERTS_SILENT,
+				context.getString(R.string.notification_quiet_channel_name),
+				context.getString(R.string.notification_quiet_channel_description));
 	}
 
 	/**
-	 * Create the low-importance channel used by the persistent status notification.
+	 * Create a low-importance, fully silent channel (no sound, vibration, lights or badge).
 	 * <p>
-	 * Unlike the alert channels, this channel is silent (no sound, vibration, lights or badge)
-	 * so the ongoing battery-status notification stays unobtrusive.
+	 * Used both by the persistent status notification and, during the user's quiet hours, to deliver
+	 * an alert quietly so it stays visible without disturbing the user (issue #111).
 	 *
 	 * @param manager     The NotificationManager
+	 * @param channelId   The channel ID to create
 	 * @param name        The channel name
 	 * @param description The channel description
 	 */
-	private static void createStatusChannelIfNotExists(final NotificationManager manager, final String name,
-	                                                   final String description) {
-		if (nonNull(manager.getNotificationChannel(CHANNEL_ID_STATUS))) {
+	private static void createSilentChannelIfNotExists(final NotificationManager manager, final String channelId,
+	                                                   final String name, final String description) {
+		if (nonNull(manager.getNotificationChannel(channelId))) {
 			return;
 		}
 
-		final NotificationChannel channel = new NotificationChannel(CHANNEL_ID_STATUS, name, NotificationManager.IMPORTANCE_LOW);
+		final NotificationChannel channel = new NotificationChannel(channelId, name, NotificationManager.IMPORTANCE_LOW);
 		channel.setDescription(description);
 		channel.enableLights(false);
 		channel.enableVibration(false);
@@ -452,7 +464,10 @@ public final class NotificationService {
 	 * @return Notification.Builder instance
 	 */
 	private static Notification.Builder createNotificationBuilder(final Context context, final NotificationConfig config) {
-		final Notification.Builder builder = new Notification.Builder(context, config.channelId).setSmallIcon(config.iconRes);
+		// During quiet hours the alert is still shown, but on the silent channel so it makes no sound or
+		// vibration (issue #111). Alerts allowed to sound keep their high-importance channel.
+		final String channelId = config.alertsAllowed ? config.channelId : CHANNEL_ID_ALERTS_SILENT;
+		final Notification.Builder builder = new Notification.Builder(context, channelId).setSmallIcon(config.iconRes);
 
 		if (config.type != CRITICAL_TYPE) {
 			builder.setOnlyAlertOnce(true);
@@ -516,22 +531,22 @@ public final class NotificationService {
 	 * @param config  The notification configuration
 	 */
 	private static void playSoundIfNeeded(final Context context, final NotificationConfig config) {
-		playAlarm(context, config.alarmSound, config.withinTime, config.ignoreSilent, config.vibrate);
+		playAlarm(context, config.alarmSound, config.alertsAllowed, config.ignoreSilent, config.vibrate);
 	}
 
 	/**
 	 * Play the alert sound (and optionally vibrate) when the phone is silenced but the user opted
 	 * to override silent mode. In normal ringer mode the notification channel plays its own sound.
 	 *
-	 * @param context      The application context
-	 * @param soundUriStr  The alarm sound URI string
-	 * @param withinTime   Whether the current time is inside the allowed notification window
-	 * @param ignoreSilent Whether the user opted to override silent/DND mode
-	 * @param vibrate      Whether the user enabled vibration
+	 * @param context       The application context
+	 * @param soundUriStr   The alarm sound URI string
+	 * @param alertsAllowed Whether alerts may sound now (inside the window, or a critical override)
+	 * @param ignoreSilent  Whether the user opted to override silent/DND mode
+	 * @param vibrate       Whether the user enabled vibration
 	 */
 	private static void playAlarm(final Context context, final String soundUriStr,
-	                              final boolean withinTime, final boolean ignoreSilent, final boolean vibrate) {
-		if (!withinTime) {
+	                              final boolean alertsAllowed, final boolean ignoreSilent, final boolean vibrate) {
+		if (!alertsAllowed) {
 			return;
 		}
 
@@ -573,7 +588,10 @@ public final class NotificationService {
 	 * @return true if alerts are allowed at the current time
 	 */
 	private static boolean isWithinNotificationWindow(final Context context, final SharedPreferences prefs) {
-		final boolean limitedTime = prefs.getBoolean(context.getString(R.string._pref_key_notifications_time_range), false);
+		// Default ON to match the toggle's XML default (pref_time_settings.xml). Reading false here let a
+		// fresh install that never opened Time Settings alert around the clock, so quiet hours silently
+		// did nothing (issue #111). Now quiet hours apply by default (06:30–23:30).
+		final boolean limitedTime = prefs.getBoolean(context.getString(R.string._pref_key_notifications_time_range), true);
 		final String startTime = prefs.getString(
 				context.getString(R.string._pref_key_notifications_time_range_start),
 				context.getString(R.string._pref_value_notifications_time_range_start));
@@ -581,6 +599,22 @@ public final class NotificationService {
 				context.getString(R.string._pref_key_notifications_time_range_end),
 				context.getString(R.string._pref_value_notifications_time_range_end));
 		return isWithinTime(startTime, endTime) || !limitedTime;
+	}
+
+	/**
+	 * Whether an alert may sound/vibrate right now, given the quiet-hours window and the critical-alert
+	 * override. Alerts are allowed inside the window; a critical alert may additionally be allowed to
+	 * break through quiet hours when the user has left that option on (default), so a genuinely low
+	 * battery still wakes them (issue #111). Pure and Android-free so it is unit-testable.
+	 *
+	 * @param withinWindow             whether now falls inside the allowed notification window
+	 * @param isCritical               whether this is a critical (about-to-die) alert
+	 * @param criticalIgnoresQuietHours whether critical alerts are allowed to break through quiet hours
+	 * @return true when the alert may sound/vibrate now
+	 */
+	static boolean alertsAllowedNow(final boolean withinWindow, final boolean isCritical,
+	                                final boolean criticalIgnoresQuietHours) {
+		return withinWindow || (isCritical && criticalIgnoresQuietHours);
 	}
 
 	/**
@@ -744,7 +778,7 @@ public final class NotificationService {
 		final String content;
 		final String bigContent;
 		final String alarmSound;
-		final boolean withinTime;
+		final boolean alertsAllowed;
 		final boolean ignoreSilent;
 		final boolean vibrate;
 		final boolean stickyNotification;
@@ -764,7 +798,10 @@ public final class NotificationService {
 			final int criticalLevel = prefs.getInt(context.getString(R.string._pref_key_critical_battery_level), 20);
 
 			this.stickyNotification = prefs.getBoolean(context.getString(R.string._pref_key_notifications_sticky), false);
-			this.withinTime = isWithinNotificationWindow(context, prefs);
+			final boolean withinWindow = isWithinNotificationWindow(context, prefs);
+			final boolean criticalIgnoresQuietHours = prefs.getBoolean(
+					context.getString(R.string._pref_key_critical_ignore_quiet_hours), true);
+			this.alertsAllowed = alertsAllowedNow(withinWindow, type == CRITICAL_TYPE, criticalIgnoresQuietHours);
 			this.ignoreSilent = shouldIgnoreSilentMode(context, prefs);
 			this.vibrate = isVibrationEnabled(context, prefs);
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -223,8 +223,9 @@ public final class NotificationService {
 		final String sound = prefs.getString(
 				context.getString(R.string._pref_key_notifications_alert_sound_ringtone),
 				context.getString(R.string._default_notification_sound_uri));
-		playAlarm(context, sound, withinWindow, shouldIgnoreSilentMode(context, prefs),
-				isVibrationEnabled(context, prefs));
+		if (withinWindow) {
+			playAlarm(context, sound, shouldIgnoreSilentMode(context, prefs), isVibrationEnabled(context, prefs));
+		}
 	}
 
 	/**
@@ -531,25 +532,27 @@ public final class NotificationService {
 	 * @param config  The notification configuration
 	 */
 	private static void playSoundIfNeeded(final Context context, final NotificationConfig config) {
-		playAlarm(context, config.alarmSound, config.alertsAllowed, config.ignoreSilent, config.vibrate);
+		if (config.alertsAllowed) {
+			playAlarm(context, config.alarmSound, config.ignoreSilent, config.vibrate);
+		}
 	}
 
 	/**
 	 * Play the alert sound (and optionally vibrate) when the phone is silenced but the user opted
 	 * to override silent mode. In normal ringer mode the notification channel plays its own sound.
+	 * <p>
+	 * Callers must first check that alerts are allowed right now (quiet hours / critical override).
 	 *
-	 * @param context       The application context
-	 * @param soundUriStr   The alarm sound URI string
-	 * @param alertsAllowed Whether alerts may sound now (inside the window, or a critical override)
-	 * @param ignoreSilent  Whether the user opted to override silent/DND mode
-	 * @param vibrate       Whether the user enabled vibration
+	 * @param context      The application context
+	 * @param soundUriStr  The alarm sound URI string
+	 * @param ignoreSilent Whether the user opted to override silent/DND mode
+	 * @param vibrate      Whether the user enabled vibration
 	 */
-	private static void playAlarm(final Context context, final String soundUriStr,
-	                              final boolean alertsAllowed, final boolean ignoreSilent, final boolean vibrate) {
-		if (!alertsAllowed) {
-			return;
-		}
-
+	private static void playAlarm(
+			final Context context,
+			final String soundUriStr,
+			final boolean ignoreSilent,
+			final boolean vibrate) {
 		final Uri soundUri = Uri.parse(soundUriStr);
 		final AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
 		if (isNull(audioManager)) {
@@ -799,8 +802,7 @@ public final class NotificationService {
 
 			this.stickyNotification = prefs.getBoolean(context.getString(R.string._pref_key_notifications_sticky), false);
 			final boolean withinWindow = isWithinNotificationWindow(context, prefs);
-			final boolean criticalIgnoresQuietHours = prefs.getBoolean(
-					context.getString(R.string._pref_key_critical_ignore_quiet_hours), true);
+			final boolean criticalIgnoresQuietHours = prefs.getBoolean(context.getString(R.string._pref_key_critical_ignore_quiet_hours), true);
 			this.alertsAllowed = alertsAllowedNow(withinWindow, type == CRITICAL_TYPE, criticalIgnoresQuietHours);
 			this.ignoreSilent = shouldIgnoreSilentMode(context, prefs);
 			this.vibrate = isVibrationEnabled(context, prefs);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -162,7 +162,12 @@ public final class NotificationService {
 		                    ? R.drawable.ic_stat_device_battery_charging_20
 		                    : R.drawable.ic_stat_device_battery_charging_50;
 
-		final Notification.Builder builder = new Notification.Builder(context, CHANNEL_ID_FULL)
+		// Plugging in during quiet hours shouldn't ding: shown on the silent channel outside the
+		// window instead of the audible full-battery channel (issue #111).
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		final boolean withinWindow = isWithinNotificationWindow(context, prefs);
+
+		final Notification.Builder builder = new Notification.Builder(context, channelFor(withinWindow, CHANNEL_ID_FULL))
 				.setSmallIcon(iconRes)
 				.setOnlyAlertOnce(true)
 				.setTicker(ticker)
@@ -198,10 +203,9 @@ public final class NotificationService {
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 		final String temperature = TemperatureUtils.format(context, rawTenthsC);
 
-		// A high-temperature warning is not a critical battery alert, so it respects quiet hours: shown
-		// on the silent channel outside the window (issue #111).
+		// A high-temperature warning is not a critical battery alert, so it respects quiet hours (#111).
 		final boolean withinWindow = isWithinNotificationWindow(context, prefs);
-		final String channelId = withinWindow ? CHANNEL_ID_TEMPERATURE : CHANNEL_ID_ALERTS_SILENT;
+		final String channelId = channelFor(withinWindow, CHANNEL_ID_TEMPERATURE);
 
 		final Notification.Builder builder = new Notification.Builder(context, channelId)
 				.setSmallIcon(R.drawable.ic_stat_temperature_hot)
@@ -395,8 +399,11 @@ public final class NotificationService {
 	 * @param name        The channel name
 	 * @param description The channel description
 	 */
-	private static void createSilentChannelIfNotExists(final NotificationManager manager, final String channelId,
-	                                                   final String name, final String description) {
+	private static void createSilentChannelIfNotExists(
+			final NotificationManager manager,
+			final String channelId,
+			final String name,
+			final String description) {
 		if (nonNull(manager.getNotificationChannel(channelId))) {
 			return;
 		}
@@ -420,8 +427,13 @@ public final class NotificationService {
 	 * @param ledColor  The LED color for notifications
 	 * @param vibrate   Whether the channel should vibrate (from the user's Vibrate preference)
 	 */
-	private static void createChannelIfNotExists(final NotificationManager manager, final String channelId, final String name,
-	                                             final String description, final int ledColor, final boolean vibrate) {
+	private static void createChannelIfNotExists(
+			final NotificationManager manager,
+			final String channelId,
+			final String name,
+			final String description,
+			final int ledColor,
+			final boolean vibrate) {
 		if (nonNull(manager.getNotificationChannel(channelId))) {
 			return;
 		}
@@ -465,9 +477,7 @@ public final class NotificationService {
 	 * @return Notification.Builder instance
 	 */
 	private static Notification.Builder createNotificationBuilder(final Context context, final NotificationConfig config) {
-		// During quiet hours the alert is still shown, but on the silent channel so it makes no sound or
-		// vibration (issue #111). Alerts allowed to sound keep their high-importance channel.
-		final String channelId = config.alertsAllowed ? config.channelId : CHANNEL_ID_ALERTS_SILENT;
+		final String channelId = channelFor(config.alertsAllowed, config.channelId);
 		final Notification.Builder builder = new Notification.Builder(context, channelId).setSmallIcon(config.iconRes);
 
 		if (config.type != CRITICAL_TYPE) {
@@ -475,6 +485,19 @@ public final class NotificationService {
 		}
 
 		return builder;
+	}
+
+	/**
+	 * The channel an alerting notification should post to: its normal audible (high-importance) channel
+	 * when alerts may sound now, or the shared silent channel during quiet hours so the alert is still
+	 * shown but makes no sound or vibration (issue #111).
+	 *
+	 * @param alertsAllowed    whether alerts may sound now (inside the window, or a critical override)
+	 * @param audibleChannelId the channel to use when alerts are allowed to sound
+	 * @return the channel id to post the notification on
+	 */
+	private static String channelFor(final boolean alertsAllowed, final String audibleChannelId) {
+		return alertsAllowed ? audibleChannelId : CHANNEL_ID_ALERTS_SILENT;
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -81,6 +81,9 @@
     <string name="notify_every_tick">التنبيه للمستوى الحرج كل (1%)</string>
     <string name="notify_every_tick_summary_on">التنبيه كل درجة (1%) للمستوى الحرج مفعل</string>
     <string name="notify_every_tick_summary_off">التنبيه كل درجة (1%) للمستوى الحرج معطل</string>
+    <string name="critical_ignore_quiet_hours">التنبيهات الحرجة تتجاوز ساعات الهدوء</string>
+    <string name="critical_ignore_quiet_hours_summary_on">البطارية المنخفضة جداً تنبّهك حتى أثناء ساعات الهدوء</string>
+    <string name="critical_ignore_quiet_hours_summary_off">التنبيهات الحرجة تبقى صامتة أثناء ساعات الهدوء</string>
 
     <string name="notification_critical_ticker">مستوى حرج للبطارية أقل من %1$d%%</string>
     <string name="notification_critical_title">وقت الشحن الصحي</string>
@@ -113,6 +116,8 @@
     <!-- Persistent foreground-service status notification -->
     <string name="notification_status_channel_name">حالة البطارية</string>
     <string name="notification_status_channel_description">حالة البطارية المستمرة أثناء تفعيل المراقبة</string>
+    <string name="notification_quiet_channel_name">تنبيهات صامتة</string>
+    <string name="notification_quiet_channel_description">تنبيهات البطارية تُعرض بصمت أثناء ساعات الهدوء</string>
     <string name="notification_status_content">%1$d%% · %2$s · %3$s</string>
 
     <!-- High temperature alert -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,9 @@
     <string name="notify_every_tick">Notify for critical every (1%)</string>
     <string name="notify_every_tick_summary_on">Notify every tick (1%) for critical level enabled</string>
     <string name="notify_every_tick_summary_off">Notify every tick (1%) for critical level disabled</string>
+    <string name="critical_ignore_quiet_hours">Critical alerts ignore quiet hours</string>
+    <string name="critical_ignore_quiet_hours_summary_on">A critically low battery still alerts during quiet hours</string>
+    <string name="critical_ignore_quiet_hours_summary_off">Critical alerts stay silent during quiet hours</string>
 
     <string name="notification_critical_ticker">Your battery in critical level and below %1$d%%</string>
     <string name="notification_critical_title">Healthy charge time</string>
@@ -105,6 +108,9 @@
     <!-- Persistent foreground-service status notification -->
     <string name="notification_status_channel_name">Battery Status</string>
     <string name="notification_status_channel_description">Ongoing battery status while monitoring is active</string>
+    <!-- Silent channel used to show an alert quietly during quiet hours (issue #111) -->
+    <string name="notification_quiet_channel_name">Quiet Alerts</string>
+    <string name="notification_quiet_channel_description">Battery alerts shown silently during your quiet hours</string>
     <!-- e.g. "85% · Discharging · 32.0 °C" -->
     <string name="notification_status_content">%1$d%% · %2$s · %3$s</string>
 
@@ -224,14 +230,15 @@
     <string name="_pref_key_notifications_time_range_end" translatable="false">key_notifications_time_range_end</string>
     <string name="_pref_key_notifications_apply_silent_mode" translatable="false">key_notifications_apply_silent_mode</string>
     <string name="_pref_key_notify_every_tick" translatable="false">key_notify_every_tick</string>
+    <string name="_pref_key_critical_ignore_quiet_hours" translatable="false">key_critical_ignore_quiet_hours</string>
     <string name="_pref_key_notify_high_temperature" translatable="false">key_notify_high_temperature</string>
     <string name="_pref_key_high_temperature_threshold" translatable="false">key_high_temperature_threshold</string>
     <string name="_pref_key_language" translatable="false">key_language</string>
 
     <string name="_pref_value_temperatures_unit_c" translatable="false">celsius</string>
     <string name="_pref_value_temperatures_unit_f" translatable="false">fahrenheit</string>
-    <string name="_pref_value_notifications_time_range_end" translatable="false">23:00</string>
-    <string name="_pref_value_notifications_time_range_start" translatable="false">08:00</string>
+    <string name="_pref_value_notifications_time_range_end" translatable="false">23:30</string>
+    <string name="_pref_value_notifications_time_range_start" translatable="false">06:30</string>
 
     <!-- Validation error messages -->
     <string name="error_warning_level_too_low">Warning level must be higher than critical level (%d%%)</string>

--- a/app/src/main/res/xml/pref_notification.xml
+++ b/app/src/main/res/xml/pref_notification.xml
@@ -124,6 +124,16 @@
             android:title="@string/notify_every_tick"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/_pref_key_critical_ignore_quiet_hours"
+            android:summaryOff="@string/critical_ignore_quiet_hours_summary_off"
+            android:summaryOn="@string/critical_ignore_quiet_hours_summary_on"
+            android:switchTextOff="@string/off"
+            android:switchTextOn="@string/on"
+            android:title="@string/critical_ignore_quiet_hours"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
@@ -71,4 +71,27 @@ public class NotificationServiceTest {
 		assertTrue(NotificationService.isWithinTimeRange(0, 10 * 60, 10 * 60));
 		assertTrue(NotificationService.isWithinTimeRange(23 * 60 + 59, 10 * 60, 10 * 60));
 	}
+
+	// --- alertsAllowedNow: quiet-hours gating with the critical override (issue #111) ---
+
+	@Test
+	public void insideWindow_alwaysAllowed() {
+		assertTrue(NotificationService.alertsAllowedNow(true, false, false));
+		assertTrue(NotificationService.alertsAllowedNow(true, true, false));
+	}
+
+	@Test
+	public void outsideWindow_nonCritical_silenced() {
+		assertFalse(NotificationService.alertsAllowedNow(false, false, true));
+	}
+
+	@Test
+	public void outsideWindow_critical_breaksThroughWhenEnabled() {
+		assertTrue(NotificationService.alertsAllowedNow(false, true, true));
+	}
+
+	@Test
+	public void outsideWindow_critical_silencedWhenOverrideOff() {
+		assertFalse(NotificationService.alertsAllowedNow(false, true, false));
+	}
 }


### PR DESCRIPTION
Fixes #111.

## The problem

An alert fired **outside** the configured quiet-hours window (default 08:00–23:00), on DnD, and still made sound + vibration. Research turned up three causes:

1. The alert channels are `IMPORTANCE_HIGH` and play their own default sound + vibration; **nothing gated that on the quiet-hours window** — only the separate manual override-sound path was gated.
2. The time-range toggle was read with a default of `false` in code while its XML default is `true`, so a fresh install that never opened Time Settings alerted around the clock.
3. (Related, tracked in #112) "Apply Silent Mode" has inverted, confusing semantics — left untouched here.

## What this PR does

- **Silent channel during quiet hours.** Alerts outside the window are posted on a new low-importance, fully silent channel (`battery_alerts_quiet`) — still visible in the shade, no sound/vibration — instead of the high-importance alert channel.
- **Fix the default mismatch.** Code now defaults the time-range toggle to `true` to match the XML, and the default window moves to **06:30–23:30**.
- **Critical override (new option).** "Critical alerts ignore quiet hours" in the Critical section, **default on**, so a genuinely low battery still breaks through overnight. Turn it off and even critical stays silent. The decision is a pure, unit-tested helper (`alertsAllowedNow`).
- **Temperature alerts** respect quiet hours like warnings (no critical override).

## Product decisions (from the issue discussion)

- Quiet hours **on by default**, window **06:30–23:30**.
- Critical alerts bypass quiet hours by default, behind a user toggle.
- Temperature is silenced during quiet hours (not treated as critical) — easy to change if we'd rather a hot battery always alerts.

## Notes for review

- **Arabic strings are Claude drafts pending review** (`values-ar/strings.xml`): the critical-toggle title/summaries and the quiet-channel name/description.
- Changing the quiet-hours default to on is a behaviour change for existing users who never opened Time Settings.

## Tests

- 5 new unit tests for `alertsAllowedNow` (inside window, outside window non-critical, critical override on/off).
- `assembleDebug` + `testDebugUnitTest` pass.

## Manual testing

Quiet hours can be tested without waiting for night: set the window to a range that excludes the current time, then trigger an alert — it should arrive silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)