### PR TITLE
Fast-drain alert: warn when battery drains abnormally fast for a sustained time (#109)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -11,6 +11,7 @@ import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.BatteryRateTracker;
+import com.almothafar.simplebatterynotifier.service.FastDrainDetector;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
@@ -66,7 +67,8 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		final BatteryDO batteryDO = SystemService.getBatteryInfo(context, batteryStatus);
 
 		// Feed the charge/drain rate window from this broadcast (no polling timer of our own) so both the
-		// ongoing notification below and the details table reflect the latest reading (issue #108).
+		// ongoing notification below and the details table reflect the latest reading (issue #108). The
+		// fast-drain alert (#109) then evaluates the same smoothed rate.
 		final BatteryRateTracker.BatteryRate rate = BatteryRateTracker.record(context, batteryDO);
 
 		// Keep the persistent foreground-service status notification live with the latest reading,
@@ -101,6 +103,9 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		}
 
 		handleTemperature(context, batteryDO, sharedPref);
+
+		// #109: warn when the (smoothed #108) drain rate stays abnormally high for a sustained time.
+		FastDrainDetector.evaluate(context, batteryDO, rate);
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
@@ -1,0 +1,193 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import androidx.preference.PreferenceManager;
+
+import com.almothafar.simplebatterynotifier.R;
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
+import com.almothafar.simplebatterynotifier.service.BatteryRateTracker.BatteryRate;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Warns when the battery drains abnormally fast for a <em>sustained</em> time (issue #109).
+ * <p>
+ * This is the alerting layer on top of the drain rate from {@link BatteryRateTracker} (#108). It needs
+ * no per-app data — it watches the whole-battery %/h — so it is fully buildable by a normal app. It is
+ * evaluated on each {@code ACTION_BATTERY_CHANGED} broadcast; there is <b>no new timer/alarm/wakelock</b>
+ * (reminders piggyback the broadcasts, which are frequent precisely while draining fast).
+ * <p>
+ * <b>Sustained, not spikes:</b> the rate (already smoothed by #108) must stay at/above the user's limit
+ * for the whole window (default 5 min); a brief flare breaks the streak. <b>Context-aware repeats:</b>
+ * warn once per episode while the screen is on and unlocked (the user can see it), but remind every
+ * {@code reminderGap} while the screen is off or locked (background drain the user can't see — the
+ * highest-value case). Hysteresis re-arms the episode only once the rate drops back below the limit,
+ * exactly like the high-temperature alert. The decision core is pure and unit-tested; the streak is
+ * persisted so it survives process restarts, like {@link BatteryHealthTracker}.
+ */
+public final class FastDrainDetector {
+
+	// Persisted streak/hysteresis state (survives process restarts).
+	private static final String PREF_STREAK_START = "_fast_drain_streak_start";
+	private static final String PREF_ALERTED = "_fast_drain_alerted";
+	private static final String PREF_LAST_REMINDER = "_fast_drain_last_reminder";
+
+	// Defaults (all user-tunable), matching the settings XML.
+	static final int DEFAULT_SUSTAINED_MINUTES = 5;
+	static final int DEFAULT_REMINDER_MINUTES = 15;
+
+	private static final long MS_PER_MINUTE = 60_000L;
+
+	private static final FastDrainState CLEARED = new FastDrainState(0, false, 0);
+
+	private FastDrainDetector() {
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Evaluates the fast-drain rule against the freshly-computed rate and (re)notifies when warranted.
+	 * Called from {@link com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver} after the
+	 * rate is recorded, so it reads the same smoothed value the table and notification show.
+	 *
+	 * @param context   Application context
+	 * @param batteryDO Current battery snapshot (may be null)
+	 * @param rate      The rate just computed by {@link BatteryRateTracker#record}
+	 */
+	public static void evaluate(final Context context, final BatteryDO batteryDO, final BatteryRate rate) {
+		if (isNull(context) || isNull(batteryDO)) {
+			return;
+		}
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+		final boolean enabled = prefs.getBoolean(context.getString(R.string._pref_key_notify_fast_drain), true);
+		final boolean discharging = !BatteryRateTracker.isChargingDirection(batteryDO.getStatus());
+		// Only while discharging, and only when enabled. Either way the episode is re-armed (charging, or
+		// the feature being off, ends any streak) so a later fast discharge starts fresh.
+		if (!enabled || !discharging) {
+			clearState(prefs);
+			return;
+		}
+
+		final int limit = BatteryRateTracker.getDrainLimitPercentPerHour(context);
+		final long sustainedMs = minutesPref(prefs, context, R.string._pref_key_fast_drain_sustained_minutes, DEFAULT_SUSTAINED_MINUTES);
+		final long reminderGapMs = minutesPref(prefs, context, R.string._pref_key_fast_drain_reminder_minutes, DEFAULT_REMINDER_MINUTES);
+		final boolean activelyUsed = SystemService.isActivelyUsed(context);
+		final long now = System.currentTimeMillis();
+
+		final FastDrainDecision decision = decide(loadState(prefs), rate.hasRate(), rate.percentPerHour(),
+				limit, sustainedMs, reminderGapMs, activelyUsed, now);
+
+		saveState(prefs, decision.newState());
+		if (decision.shouldNotify()) {
+			final int elapsedMinutes = Math.max(1, Math.round(decision.elapsedMs() / (float) MS_PER_MINUTE));
+			NotificationService.sendFastDrainNotification(context, rate.percentPerHour(), limit, elapsedMinutes);
+		}
+	}
+
+	/**
+	 * Pure decision core, unit-testable with no Android dependencies.
+	 * <ul>
+	 *   <li><b>Rate unavailable</b> (#108 can't produce a %/h yet — warm-up, or an unsupported device):
+	 *       the alert <em>sleeps</em>. No notification, and the streak is left intact so a brief data gap
+	 *       doesn't reset it. Fail-quiet = no false alarms.</li>
+	 *   <li><b>Rate below the limit</b>: the drain has calmed → re-arm the episode (clear the streak and
+	 *       the alerted flag), so a later flare-up warns again (hysteresis).</li>
+	 *   <li><b>Rate at/above the limit</b>: start the streak if new; once it has been sustained for the
+	 *       window, fire the first alert (regardless of screen state — warn at least once). After that,
+	 *       stay silent while actively used, but remind every {@code reminderGap} while off/locked.</li>
+	 * </ul>
+	 *
+	 * @param state         current persisted state
+	 * @param rateAvailable whether #108 produced a trustworthy %/h this tick
+	 * @param ratePph       the drain rate magnitude in %/h (valid when {@code rateAvailable})
+	 * @param limitPph      the user's high-drain limit in %/h
+	 * @param sustainedMs   how long the rate must stay at/above the limit before the first alert
+	 * @param reminderGapMs minimum gap between reminders while the screen is off/locked
+	 * @param activelyUsed  whether the screen is on and unlocked right now
+	 * @param nowMillis     current time in millis
+	 *
+	 * @return the notify flag, the new state to persist, and the streak's elapsed time (for the message)
+	 */
+	static FastDrainDecision decide(final FastDrainState state, final boolean rateAvailable, final int ratePph,
+	                                final int limitPph, final long sustainedMs, final long reminderGapMs,
+	                                final boolean activelyUsed, final long nowMillis) {
+		if (!rateAvailable) {
+			return new FastDrainDecision(false, state, 0); // sleep — keep the streak, don't fire
+		}
+		if (ratePph < limitPph) {
+			return new FastDrainDecision(false, CLEARED, 0); // calmed — re-arm the episode
+		}
+
+		final long start = state.streakStart() == 0 ? nowMillis : state.streakStart();
+		final long elapsed = nowMillis - start;
+		boolean alerted = state.alerted();
+		long lastReminder = state.lastReminder();
+		boolean notify = false;
+
+		if (elapsed >= sustainedMs) {
+			if (!alerted) {
+				notify = true;          // first alert this episode, regardless of screen state
+				alerted = true;
+				lastReminder = nowMillis;
+			} else if (!activelyUsed && nowMillis - lastReminder >= reminderGapMs) {
+				notify = true;          // background drain the user can't see — remind on the gap
+				lastReminder = nowMillis;
+			}
+		}
+		return new FastDrainDecision(notify, new FastDrainState(start, alerted, lastReminder), elapsed);
+	}
+
+	private static long minutesPref(final SharedPreferences prefs, final Context context,
+	                                final int keyRes, final int defaultMinutes) {
+		return prefs.getInt(context.getString(keyRes), defaultMinutes) * MS_PER_MINUTE;
+	}
+
+	private static FastDrainState loadState(final SharedPreferences prefs) {
+		return new FastDrainState(
+				prefs.getLong(PREF_STREAK_START, 0),
+				prefs.getBoolean(PREF_ALERTED, false),
+				prefs.getLong(PREF_LAST_REMINDER, 0));
+	}
+
+	private static void saveState(final SharedPreferences prefs, final FastDrainState state) {
+		prefs.edit()
+		     .putLong(PREF_STREAK_START, state.streakStart())
+		     .putBoolean(PREF_ALERTED, state.alerted())
+		     .putLong(PREF_LAST_REMINDER, state.lastReminder())
+		     .apply();
+	}
+
+	/**
+	 * Clears the streak only when it isn't already clear, so charging/disabled broadcasts don't churn
+	 * SharedPreferences on every tick.
+	 *
+	 * @param prefs the shared preferences
+	 */
+	private static void clearState(final SharedPreferences prefs) {
+		if (!loadState(prefs).equals(CLEARED)) {
+			saveState(prefs, CLEARED);
+		}
+	}
+
+	/**
+	 * Persisted streak/hysteresis state.
+	 *
+	 * @param streakStart  when the rate first reached the limit this episode (0 = no active streak)
+	 * @param alerted      whether the first alert has fired this episode
+	 * @param lastReminder when the last (re)notification was sent
+	 */
+	record FastDrainState(long streakStart, boolean alerted, long lastReminder) {
+	}
+
+	/**
+	 * Result of {@link #decide}: whether to (re)notify, the new state to persist, and the streak's
+	 * elapsed time (for the "for the last N minutes" message).
+	 *
+	 * @param shouldNotify whether to send a notification now
+	 * @param newState     the state to persist
+	 * @param elapsedMs    the streak's elapsed time in millis
+	 */
+	record FastDrainDecision(boolean shouldNotify, FastDrainState newState, long elapsedMs) {
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
@@ -32,14 +32,26 @@ public final class FastDrainDetector {
 	private static final String PREF_STREAK_START = "_fast_drain_streak_start";
 	private static final String PREF_ALERTED = "_fast_drain_alerted";
 	private static final String PREF_LAST_REMINDER = "_fast_drain_last_reminder";
+	private static final String PREF_LAST_SEEN_ABOVE = "_fast_drain_last_seen_above";
 
-	// Defaults (all user-tunable), matching the settings XML.
+	// Defaults and accepted ranges (user-tunable), matching the settings XML min/max — enforced when the
+	// preferences are read, so a corrupt/out-of-range value can't turn this into a spike alarm.
 	static final int DEFAULT_SUSTAINED_MINUTES = 5;
+	static final int MIN_SUSTAINED_MINUTES = 1;
+	static final int MAX_SUSTAINED_MINUTES = 30;
 	static final int DEFAULT_REMINDER_MINUTES = 15;
+	static final int MIN_REMINDER_MINUTES = 5;
+	static final int MAX_REMINDER_MINUTES = 60;
+
+	// How long the streak survives without a fresh above-limit observation. The rate itself is smoothed
+	// over BatteryRateTracker.WINDOW_MS, so continuity beyond that window is unknowable — after a longer
+	// gap (process death, doze, unusable rate) the "sustained" claim has lapsed and the episode restarts,
+	// rather than instantly alerting with a wildly inflated "for the last N minutes".
+	static final long MAX_OBSERVATION_GAP_MS = BatteryRateTracker.WINDOW_MS;
 
 	private static final long MS_PER_MINUTE = 60_000L;
 
-	private static final FastDrainState CLEARED = new FastDrainState(0, false, 0);
+	private static final FastDrainState CLEARED = new FastDrainState(0, false, 0, 0);
 
 	private FastDrainDetector() {
 		// Utility class - prevent instantiation
@@ -70,15 +82,22 @@ public final class FastDrainDetector {
 		}
 
 		final int limit = BatteryRateTracker.getDrainLimitPercentPerHour(context);
-		final long sustainedMs = minutesPref(prefs, context, R.string._pref_key_fast_drain_sustained_minutes, DEFAULT_SUSTAINED_MINUTES);
-		final long reminderGapMs = minutesPref(prefs, context, R.string._pref_key_fast_drain_reminder_minutes, DEFAULT_REMINDER_MINUTES);
+		final long sustainedMs = minutesPref(prefs, context, R.string._pref_key_fast_drain_sustained_minutes,
+				DEFAULT_SUSTAINED_MINUTES, MIN_SUSTAINED_MINUTES, MAX_SUSTAINED_MINUTES);
+		final long reminderGapMs = minutesPref(prefs, context, R.string._pref_key_fast_drain_reminder_minutes,
+				DEFAULT_REMINDER_MINUTES, MIN_REMINDER_MINUTES, MAX_REMINDER_MINUTES);
 		final boolean activelyUsed = SystemService.isActivelyUsed(context);
 		final long now = System.currentTimeMillis();
 
-		final FastDrainDecision decision = decide(loadState(prefs), rate.hasRate(), rate.percentPerHour(),
+		final FastDrainState previous = loadState(prefs);
+		final FastDrainDecision decision = decide(previous, rate.hasRate(), rate.percentPerHour(),
 				limit, sustainedMs, reminderGapMs, activelyUsed, now);
 
-		saveState(prefs, decision.newState());
+		// Persist only on change: the common case (discharging below the limit) re-decides CLEARED on
+		// every broadcast, and rewriting identical state would churn SharedPreferences for nothing.
+		if (!decision.newState().equals(previous)) {
+			saveState(prefs, decision.newState());
+		}
 		if (decision.shouldNotify()) {
 			final int elapsedMinutes = Math.max(1, Math.round(decision.elapsedMs() / (float) MS_PER_MINUTE));
 			NotificationService.sendFastDrainNotification(context, rate.percentPerHour(), limit, elapsedMinutes);
@@ -90,7 +109,10 @@ public final class FastDrainDetector {
 	 * <ul>
 	 *   <li><b>Rate unavailable</b> (#108 can't produce a %/h yet — warm-up, or an unsupported device):
 	 *       the alert <em>sleeps</em>. No notification, and the streak is left intact so a brief data gap
-	 *       doesn't reset it. Fail-quiet = no false alarms.</li>
+	 *       doesn't reset it. Fail-quiet = no false alarms. Continuity is bounded, though: if the rate
+	 *       hasn't been observed at/above the limit for {@link #MAX_OBSERVATION_GAP_MS}, the streak has
+	 *       lapsed and the next above-limit reading starts a fresh episode instead of instantly alerting
+	 *       with a duration built on unobserved time.</li>
 	 *   <li><b>Rate below the limit</b>: the drain has calmed → re-arm the episode (clear the streak and
 	 *       the alerted flag), so a later flare-up warns again (hysteresis).</li>
 	 *   <li><b>Rate at/above the limit</b>: start the streak if new; once it has been sustained for the
@@ -119,10 +141,16 @@ public final class FastDrainDetector {
 			return new FastDrainDecision(false, CLEARED, 0); // calmed — re-arm the episode
 		}
 
-		final long start = state.streakStart() == 0 ? nowMillis : state.streakStart();
+		// Continuity: the sleep above keeps the streak through a brief data gap, but after a long one
+		// (process death, doze) the "sustained" claim has lapsed — start a fresh episode instead of
+		// alerting immediately with an inflated duration built on unobserved time.
+		final boolean lapsed = state.streakStart() != 0
+				&& nowMillis - state.lastSeenAbove() > MAX_OBSERVATION_GAP_MS;
+
+		final long start = (state.streakStart() == 0 || lapsed) ? nowMillis : state.streakStart();
 		final long elapsed = nowMillis - start;
-		boolean alerted = state.alerted();
-		long lastReminder = state.lastReminder();
+		boolean alerted = !lapsed && state.alerted();
+		long lastReminder = lapsed ? 0 : state.lastReminder();
 		boolean notify = false;
 
 		if (elapsed >= sustainedMs) {
@@ -135,19 +163,36 @@ public final class FastDrainDetector {
 				lastReminder = nowMillis;
 			}
 		}
-		return new FastDrainDecision(notify, new FastDrainState(start, alerted, lastReminder), elapsed);
+		return new FastDrainDecision(notify, new FastDrainState(start, alerted, lastReminder, nowMillis), elapsed);
 	}
 
-	private static long minutesPref(final SharedPreferences prefs, final Context context,
-	                                final int keyRes, final int defaultMinutes) {
-		return prefs.getInt(context.getString(keyRes), defaultMinutes) * MS_PER_MINUTE;
+	private static long minutesPref(final SharedPreferences prefs, final Context context, final int keyRes,
+	                                final int defaultMinutes, final int minMinutes, final int maxMinutes) {
+		return clampMinutesToMs(prefs.getInt(context.getString(keyRes), defaultMinutes), minMinutes, maxMinutes);
+	}
+
+	/**
+	 * Clamps a stored minutes preference to its slider range and converts to millis. Mirrors
+	 * {@link BatteryRateTracker#clampDrainLimit}: the slider constrains UI input, but a corrupt or
+	 * out-of-range stored value (e.g. 0 sustained minutes) would otherwise defeat the sustained-window
+	 * requirement and fire on a momentary spike. Pure so it is unit-testable.
+	 *
+	 * @param storedMinutes the raw persisted value in minutes
+	 * @param minMinutes    the slider's minimum
+	 * @param maxMinutes    the slider's maximum
+	 *
+	 * @return the clamped duration in milliseconds
+	 */
+	static long clampMinutesToMs(final int storedMinutes, final int minMinutes, final int maxMinutes) {
+		return Math.max(minMinutes, Math.min(maxMinutes, storedMinutes)) * MS_PER_MINUTE;
 	}
 
 	private static FastDrainState loadState(final SharedPreferences prefs) {
 		return new FastDrainState(
 				prefs.getLong(PREF_STREAK_START, 0),
 				prefs.getBoolean(PREF_ALERTED, false),
-				prefs.getLong(PREF_LAST_REMINDER, 0));
+				prefs.getLong(PREF_LAST_REMINDER, 0),
+				prefs.getLong(PREF_LAST_SEEN_ABOVE, 0));
 	}
 
 	private static void saveState(final SharedPreferences prefs, final FastDrainState state) {
@@ -155,6 +200,7 @@ public final class FastDrainDetector {
 		     .putLong(PREF_STREAK_START, state.streakStart())
 		     .putBoolean(PREF_ALERTED, state.alerted())
 		     .putLong(PREF_LAST_REMINDER, state.lastReminder())
+		     .putLong(PREF_LAST_SEEN_ABOVE, state.lastSeenAbove())
 		     .apply();
 	}
 
@@ -173,11 +219,13 @@ public final class FastDrainDetector {
 	/**
 	 * Persisted streak/hysteresis state.
 	 *
-	 * @param streakStart  when the rate first reached the limit this episode (0 = no active streak)
-	 * @param alerted      whether the first alert has fired this episode
-	 * @param lastReminder when the last (re)notification was sent
+	 * @param streakStart   when the rate first reached the limit this episode (0 = no active streak)
+	 * @param alerted       whether the first alert has fired this episode
+	 * @param lastReminder  when the last (re)notification was sent
+	 * @param lastSeenAbove when the rate was last observed at/above the limit; a gap longer than
+	 *                      {@link #MAX_OBSERVATION_GAP_MS} lapses the streak (continuity unknowable)
 	 */
-	record FastDrainState(long streakStart, boolean alerted, long lastReminder) {
+	record FastDrainState(long streakStart, boolean alerted, long lastReminder, long lastSeenAbove) {
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -68,6 +68,7 @@ public final class NotificationService {
 	private static final String CHANNEL_ID_FULL = "battery_full";
 	private static final String CHANNEL_ID_STATUS = "battery_status";
 	private static final String CHANNEL_ID_TEMPERATURE = "battery_temperature";
+	private static final String CHANNEL_ID_FAST_DRAIN = "battery_fast_drain";
 	// Silent, low-importance channel used to deliver an alert quietly during the user's quiet hours:
 	// the alert is still visible but makes no sound or vibration (issue #111).
 	private static final String CHANNEL_ID_ALERTS_SILENT = "battery_alerts_quiet";
@@ -79,6 +80,8 @@ public final class NotificationService {
 	private static final int ONGOING_NOTIFICATION_ID = 1641988;
 	// Separate ID so a temperature alert doesn't replace a battery-level alert
 	private static final int TEMPERATURE_NOTIFICATION_ID = 1641989;
+	// Separate ID so a fast-drain alert doesn't replace a level or temperature alert (#109)
+	private static final int FAST_DRAIN_NOTIFICATION_ID = 1641990;
 
 	// Do Not Disturb mode constants
 	private static final String ZEN_MODE = "zen_mode";
@@ -365,6 +368,64 @@ public final class NotificationService {
 	}
 
 	/**
+	 * Send a "battery draining fast" alert (issue #109).
+	 * <p>
+	 * Uses a dedicated channel and notification ID so it never replaces a level or temperature alert, and
+	 * honours the same quiet-hours / silent-mode / vibrate preferences as the other alerts. The message is
+	 * transparent: it states the real measured rate, how long it has been sustained, and the user's own
+	 * limit, so it explains why it fired and that the user controls it. It deliberately cannot name the
+	 * culprit app (that needs a privileged permission — see the issue).
+	 *
+	 * @param context        The application context
+	 * @param ratePph        The measured drain rate in %/h
+	 * @param limitPph       The user's high-drain limit in %/h
+	 * @param elapsedMinutes How long the rate has been sustained at/above the limit, in minutes
+	 */
+	public static void sendFastDrainNotification(final Context context, final int ratePph,
+	                                             final int limitPph, final int elapsedMinutes) {
+		if (lacksNotificationPermission(context)) {
+			Log.w(TAG, "Missing POST_NOTIFICATIONS permission, fast-drain alert not sent");
+			return;
+		}
+
+		createNotificationChannels(context);
+
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		// A fast-drain warning is not a critical battery alert, so it respects quiet hours (#111).
+		final boolean withinWindow = isWithinNotificationWindow(context, prefs);
+		final String channelId = channelFor(withinWindow, CHANNEL_ID_FAST_DRAIN);
+
+		// Western digits in every locale (#96) via String.valueOf.
+		final String rate = String.valueOf(ratePph);
+		final String limit = String.valueOf(limitPph);
+		final String minutes = String.valueOf(elapsedMinutes);
+
+		final Notification.Builder builder = new Notification.Builder(context, channelId)
+				.setSmallIcon(R.drawable.ic_stat_device_battery_charging_20)
+				.setTicker(context.getString(R.string.notification_fast_drain_ticker))
+				.setContentTitle(context.getString(R.string.notification_fast_drain_title))
+				.setContentText(context.getString(R.string.notification_fast_drain_content, rate, minutes, limit))
+				.setWhen(System.currentTimeMillis())
+				.setLargeIcon(getLauncherIcon(context))
+				.setContentIntent(createMainActivityIntent(context))
+				.setVisibility(Notification.VISIBILITY_PUBLIC)
+				.setStyle(new Notification.BigTextStyle()
+						          .bigText(context.getString(R.string.notification_fast_drain_content, rate, minutes, limit)));
+
+		final NotificationManager manager = getNotificationManager(context);
+		if (nonNull(manager)) {
+			manager.notify(FAST_DRAIN_NOTIFICATION_ID, builder.build());
+		}
+
+		final String sound = prefs.getString(
+				context.getString(R.string._pref_key_notifications_alert_sound_ringtone),
+				context.getString(R.string._default_notification_sound_uri));
+		if (withinWindow) {
+			playAlarm(context, sound, shouldIgnoreSilentMode(context, prefs), isVibrationEnabled(context, prefs));
+		}
+	}
+
+	/**
 	 * Clear all battery notifications
 	 *
 	 * @param context The application context
@@ -529,6 +590,9 @@ public final class NotificationService {
 		createChannelIfNotExists(manager, CHANNEL_ID_TEMPERATURE,
 				context.getString(R.string.notification_temperature_channel_name),
 				context.getString(R.string.notification_temperature_channel_description), Color.RED, vibrate);
+		createChannelIfNotExists(manager, CHANNEL_ID_FAST_DRAIN,
+				context.getString(R.string.notification_fast_drain_channel_name),
+				context.getString(R.string.notification_fast_drain_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
 		createSilentChannelIfNotExists(manager, CHANNEL_ID_STATUS,
 				context.getString(R.string.notification_status_channel_name),
 				context.getString(R.string.notification_status_channel_description));
@@ -615,6 +679,7 @@ public final class NotificationService {
 		manager.deleteNotificationChannel(CHANNEL_ID_WARNING);
 		manager.deleteNotificationChannel(CHANNEL_ID_FULL);
 		manager.deleteNotificationChannel(CHANNEL_ID_TEMPERATURE);
+		manager.deleteNotificationChannel(CHANNEL_ID_FAST_DRAIN);
 		createNotificationChannels(context);
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -1,6 +1,7 @@
 package com.almothafar.simplebatterynotifier.service;
 
 import android.annotation.SuppressLint;
+import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -12,6 +13,7 @@ import android.net.Uri;
 import android.os.BatteryManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.os.VibratorManager;
@@ -454,6 +456,28 @@ public final class SystemService {
 		}
 		final int cycles = batteryStatus.getIntExtra(BatteryManager.EXTRA_CYCLE_COUNT, -1);
 		return cycles > 0 ? cycles : -1;
+	}
+
+	/**
+	 * Whether the user is actively using the phone right now: the screen is on <em>and</em> unlocked.
+	 * <p>
+	 * Used by the fast-drain alert (#109) to tell a visible, expected drain (warn once) from a background
+	 * drain the user can't see (remind while it continues). Needs no special permission. A missing
+	 * PowerManager conservatively reads as "not actively used", so the higher-value background reminders
+	 * still fire.
+	 *
+	 * @param context The application context
+	 *
+	 * @return true when the screen is interactive and the keyguard is not locked
+	 */
+	public static boolean isActivelyUsed(final Context context) {
+		final PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+		if (isNull(powerManager) || !powerManager.isInteractive()) {
+			return false;
+		}
+		final KeyguardManager keyguardManager = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+		// No keyguard service means we can't confirm it's unlocked; treat as unlocked since the screen is on.
+		return isNull(keyguardManager) || !keyguardManager.isKeyguardLocked();
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -164,7 +164,19 @@
     <string name="show_rate_in_notification_summary_on">يعرض الإشعار المستمر معدل الشحن/الاستهلاك المباشر بجانب الحالة</string>
     <string name="show_rate_in_notification_summary_off">يعرض الإشعار المستمر تسمية الحالة فقط</string>
     <string name="drain_limit">حد الاستهلاك المرتفع</string>
-    <string name="drain_limit_summary">يتحول معدل الاستهلاك إلى اللون الكهرماني عند الاقتراب من هذا الحد وإلى الأحمر عند بلوغه أو تجاوزه. يُقاس بنقاط مئوية في الساعة.</string>
+    <string name="drain_limit_summary">يتحول معدل الاستهلاك إلى اللون الكهرماني عند الاقتراب من هذا الحد وإلى الأحمر عند بلوغه أو تجاوزه، ويُطلق تنبيه الاستهلاك السريع عند بقائه عند الحد. يُقاس بنقاط مئوية في الساعة.</string>
+
+    <!-- تنبيه الاستهلاك السريع (#109) -->
+    <string name="notify_fast_drain">تنبيه الاستهلاك السريع</string>
+    <string name="notify_fast_drain_summary_on">ينبهك عندما تستمر البطارية في الاستهلاك أسرع من حدّك — الأكثر فائدة عندما يكون الهاتف في جيبك</string>
+    <string name="notify_fast_drain_summary_off">تنبيهات الاستهلاك السريع معطّلة</string>
+    <string name="fast_drain_sustained_minutes">التنبيه بعد (دقائق)</string>
+    <string name="fast_drain_reminder_minutes">التذكير أثناء القفل (دقائق)</string>
+    <string name="notification_fast_drain_channel_name">استهلاك سريع للبطارية</string>
+    <string name="notification_fast_drain_channel_description">ينبّه عندما تُستهلك البطارية بسرعة غير طبيعية</string>
+    <string name="notification_fast_drain_ticker">البطارية تُستهلك بسرعة</string>
+    <string name="notification_fast_drain_title">البطارية تُستهلك بسرعة</string>
+    <string name="notification_fast_drain_content">يفقد نحو %1$s%% في الساعة خلال آخر %2$s دقيقة (حدّك: %3$s%%/h). قد يكون أحد التطبيقات يستهلك طاقة كبيرة.</string>
 
     <!-- Battery Insights screen -->
     <string name="battery_insights_title">تحليلات البطارية</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,7 +170,20 @@
     <string name="show_rate_in_notification_summary_on">The ongoing notification shows the live drain/charge rate next to the status</string>
     <string name="show_rate_in_notification_summary_off">The ongoing notification shows only the status label</string>
     <string name="drain_limit">High drain limit</string>
-    <string name="drain_limit_summary">The drain rate turns amber near this limit and red at or above it. Measured in percentage points per hour.</string>
+    <string name="drain_limit_summary">The drain rate turns amber near this limit and red at or above it, and the fast-drain alert fires when it stays there. Measured in percentage points per hour.</string>
+
+    <!-- Fast-drain alert (#109) -->
+    <string name="notify_fast_drain">Fast-drain alert</string>
+    <string name="notify_fast_drain_summary_on">Warns you when the battery keeps draining faster than your limit — most useful while it\'s in your pocket</string>
+    <string name="notify_fast_drain_summary_off">Fast-drain alerts are disabled</string>
+    <string name="fast_drain_sustained_minutes">Alert after (minutes)</string>
+    <string name="fast_drain_reminder_minutes">Reminder while locked (minutes)</string>
+    <string name="notification_fast_drain_channel_name">Fast Battery Drain</string>
+    <string name="notification_fast_drain_channel_description">Warns when the battery is draining abnormally fast</string>
+    <string name="notification_fast_drain_ticker">Battery draining fast</string>
+    <string name="notification_fast_drain_title">Battery draining fast</string>
+    <!-- %1$s rate, %2$s minutes, %3$s limit — all Western-digit numbers (String.valueOf) for every locale (#96) -->
+    <string name="notification_fast_drain_content">Losing ~%1$s%% per hour for the last %2$s minutes (your limit: %3$s%%/h). Something may be using a lot of power.</string>
 
     <!-- Battery Insights Screen -->
     <string name="battery_insights_title">Battery Insights</string>
@@ -285,6 +298,10 @@
     <!-- #108/#109: append the rate to the ongoing notification, and the shared "high drain" limit (%/h) -->
     <string name="_pref_key_show_rate_in_notification" translatable="false">key_show_rate_in_notification</string>
     <string name="_pref_key_fast_drain_limit" translatable="false">key_fast_drain_limit</string>
+    <!-- #109: fast-drain alert enable + timing -->
+    <string name="_pref_key_notify_fast_drain" translatable="false">key_notify_fast_drain</string>
+    <string name="_pref_key_fast_drain_sustained_minutes" translatable="false">key_fast_drain_sustained_minutes</string>
+    <string name="_pref_key_fast_drain_reminder_minutes" translatable="false">key_fast_drain_reminder_minutes</string>
     <string name="_pref_key_language" translatable="false">key_language</string>
 
     <string name="_pref_value_temperatures_unit_c" translatable="false">celsius</string>

--- a/app/src/main/res/xml/pref_notification.xml
+++ b/app/src/main/res/xml/pref_notification.xml
@@ -116,8 +116,19 @@
         android:title="@string/pref_cat_title_drain"
         app:iconSpaceReserved="false">
 
-        <!-- defaultValue/min/max must match BatteryRateTracker.DEFAULT/MIN/MAX_DRAIN_LIMIT_PPH, which
-             clamp the stored value when it is read (#108/#109). -->
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/_pref_key_notify_fast_drain"
+            android:summaryOff="@string/notify_fast_drain_summary_off"
+            android:summaryOn="@string/notify_fast_drain_summary_on"
+            android:switchTextOff="@string/off"
+            android:switchTextOn="@string/on"
+            android:title="@string/notify_fast_drain"
+            app:iconSpaceReserved="false" />
+
+        <!-- Shared with #108's table colouring, so it is NOT gated by the alert toggle above.
+             defaultValue/min/max must match BatteryRateTracker.DEFAULT/MIN/MAX_DRAIN_LIMIT_PPH,
+             which clamp the stored value when it is read (#108/#109). -->
         <SeekBarPreference
             android:defaultValue="20"
             android:key="@string/_pref_key_fast_drain_limit"
@@ -125,6 +136,30 @@
             android:max="60"
             android:summary="@string/drain_limit_summary"
             android:title="@string/drain_limit"
+            style="@style/PreferenceSeekBar"
+            app:showSeekBarValue="true"
+            app:adjustable="true"
+            app:iconSpaceReserved="false" />
+
+        <SeekBarPreference
+            android:defaultValue="5"
+            android:dependency="@string/_pref_key_notify_fast_drain"
+            android:key="@string/_pref_key_fast_drain_sustained_minutes"
+            android:min="1"
+            android:max="30"
+            android:title="@string/fast_drain_sustained_minutes"
+            style="@style/PreferenceSeekBar"
+            app:showSeekBarValue="true"
+            app:adjustable="true"
+            app:iconSpaceReserved="false" />
+
+        <SeekBarPreference
+            android:defaultValue="15"
+            android:dependency="@string/_pref_key_notify_fast_drain"
+            android:key="@string/_pref_key_fast_drain_reminder_minutes"
+            android:min="5"
+            android:max="60"
+            android:title="@string/fast_drain_reminder_minutes"
             style="@style/PreferenceSeekBar"
             app:showSeekBarValue="true"
             app:adjustable="true"

--- a/app/src/main/res/xml/pref_notification.xml
+++ b/app/src/main/res/xml/pref_notification.xml
@@ -141,6 +141,9 @@
             app:adjustable="true"
             app:iconSpaceReserved="false" />
 
+        <!-- defaultValue/min/max of both timing sliders must match FastDrainDetector's
+             DEFAULT/MIN/MAX_SUSTAINED_MINUTES and DEFAULT/MIN/MAX_REMINDER_MINUTES, which clamp
+             the stored values when they are read (#109). -->
         <SeekBarPreference
             android:defaultValue="5"
             android:dependency="@string/_pref_key_notify_fast_drain"

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/FastDrainDetectorTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/FastDrainDetectorTest.java
@@ -1,0 +1,127 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import com.almothafar.simplebatterynotifier.service.FastDrainDetector.FastDrainDecision;
+import com.almothafar.simplebatterynotifier.service.FastDrainDetector.FastDrainState;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the pure fast-drain decision core {@link FastDrainDetector#decide} (issue #109):
+ * the sustained-streak trigger, the once-vs-reminder split by screen state, and the re-arm hysteresis.
+ * Times in millis; limit in %/h.
+ */
+public class FastDrainDetectorTest {
+
+	private static final int LIMIT = 20;
+	private static final long SUSTAINED_MS = 5 * 60_000L;   // 5 min
+	private static final long REMINDER_MS = 15 * 60_000L;   // 15 min
+	private static final boolean USED = true;
+	private static final boolean LOCKED = false; // "not actively used" == screen off/locked
+
+	private static final FastDrainState CLEARED = new FastDrainState(0, false, 0);
+
+	@Test
+	public void rateUnavailable_sleepsAndKeepsStreak() {
+		final FastDrainState state = new FastDrainState(1000, true, 2000);
+		final FastDrainDecision d = FastDrainDetector.decide(state, false, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 999_999);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(state, d.newState()); // untouched
+	}
+
+	@Test
+	public void rateBelowLimit_reArmsEpisode() {
+		final FastDrainState state = new FastDrainState(1000, true, 2000);
+		final FastDrainDecision d = FastDrainDetector.decide(state, true, 10, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(CLEARED, d.newState());
+	}
+
+	@Test
+	public void rateAtLimit_startsStreakButDoesNotFireYet() {
+		final FastDrainDecision d = FastDrainDetector.decide(CLEARED, true, 20, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 1000);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(1000, d.newState().streakStart());
+		assertFalse(d.newState().alerted());
+	}
+
+	@Test
+	public void streakNotYetSustained_doesNotFire() {
+		final FastDrainState state = new FastDrainState(1000, false, 0);
+		final long now = 1000 + 2 * 60_000L; // only 2 min in
+		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(1000, d.newState().streakStart()); // start preserved
+		assertFalse(d.newState().alerted());
+	}
+
+	@Test
+	public void sustained_firesFirstAlertEvenWhileActivelyUsed() {
+		final FastDrainState state = new FastDrainState(1000, false, 0);
+		final long now = 1000 + SUSTAINED_MS;
+		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, USED, now);
+
+		assertTrue(d.shouldNotify());              // warn at least once per episode
+		assertTrue(d.newState().alerted());
+		assertEquals(now, d.newState().lastReminder());
+		assertEquals(SUSTAINED_MS, d.elapsedMs());
+	}
+
+	@Test
+	public void afterAlert_activelyUsed_staysSilent() {
+		final long start = 1000;
+		final FastDrainState state = new FastDrainState(start, true, start);
+		final long now = start + REMINDER_MS + 60_000L; // well past a reminder gap
+		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, USED, now);
+
+		assertFalse(d.shouldNotify());                       // once per episode while the user can see it
+		assertEquals(start, d.newState().lastReminder()); // reminder time untouched
+	}
+
+	@Test
+	public void afterAlert_lockedAndGapElapsed_reminds() {
+		final long start = 1000;
+		final FastDrainState state = new FastDrainState(start, true, start);
+		final long now = start + REMINDER_MS;
+		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+
+		assertTrue(d.shouldNotify());
+		assertEquals(now, d.newState().lastReminder());
+		assertEquals(REMINDER_MS, d.elapsedMs()); // "for the last 15 minutes"
+	}
+
+	@Test
+	public void afterAlert_lockedButGapNotElapsed_staysSilent() {
+		final long start = 1000;
+		final FastDrainState state = new FastDrainState(start, true, start);
+		final long now = start + REMINDER_MS - 60_000L; // one minute short of the gap
+		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(start, d.newState().lastReminder());
+	}
+
+	@Test
+	public void reArmedEpisode_canAlertAgainLater() {
+		// A calmed episode clears, then a fresh flare re-starts the streak and alerts once sustained.
+		final FastDrainDecision calmed = FastDrainDetector.decide(
+				new FastDrainState(1000, true, 1000), true, 5, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 400_000);
+		assertEquals(CLEARED, calmed.newState());
+
+		final FastDrainDecision restart = FastDrainDetector.decide(
+				calmed.newState(), true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000);
+		assertFalse(restart.shouldNotify());
+		assertEquals(500_000, restart.newState().streakStart());
+
+		final FastDrainDecision reAlert = FastDrainDetector.decide(
+				restart.newState(), true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000 + SUSTAINED_MS);
+		assertTrue(reAlert.shouldNotify());
+	}
+}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/FastDrainDetectorTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/FastDrainDetectorTest.java
@@ -11,22 +11,25 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the pure fast-drain decision core {@link FastDrainDetector#decide} (issue #109):
- * the sustained-streak trigger, the once-vs-reminder split by screen state, and the re-arm hysteresis.
- * Times in millis; limit in %/h.
+ * the sustained-streak trigger, the once-vs-reminder split by screen state, the re-arm hysteresis,
+ * the observation-gap lapse rule, and the timing-preference clamp.
+ * Times in millis; limit in %/h. States carry a lastSeenAbove close to "now" where the scenario
+ * implies continuous observation — in production every above-limit tick refreshes it.
  */
 public class FastDrainDetectorTest {
 
 	private static final int LIMIT = 20;
 	private static final long SUSTAINED_MS = 5 * 60_000L;   // 5 min
 	private static final long REMINDER_MS = 15 * 60_000L;   // 15 min
+	private static final long MINUTE_MS = 60_000L;
 	private static final boolean USED = true;
 	private static final boolean LOCKED = false; // "not actively used" == screen off/locked
 
-	private static final FastDrainState CLEARED = new FastDrainState(0, false, 0);
+	private static final FastDrainState CLEARED = new FastDrainState(0, false, 0, 0);
 
 	@Test
 	public void rateUnavailable_sleepsAndKeepsStreak() {
-		final FastDrainState state = new FastDrainState(1000, true, 2000);
+		final FastDrainState state = new FastDrainState(1000, true, 2000, 2000);
 		final FastDrainDecision d = FastDrainDetector.decide(state, false, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 999_999);
 
 		assertFalse(d.shouldNotify());
@@ -35,7 +38,7 @@ public class FastDrainDetectorTest {
 
 	@Test
 	public void rateBelowLimit_reArmsEpisode() {
-		final FastDrainState state = new FastDrainState(1000, true, 2000);
+		final FastDrainState state = new FastDrainState(1000, true, 2000, 2000);
 		final FastDrainDecision d = FastDrainDetector.decide(state, true, 10, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000);
 
 		assertFalse(d.shouldNotify());
@@ -48,23 +51,25 @@ public class FastDrainDetectorTest {
 
 		assertFalse(d.shouldNotify());
 		assertEquals(1000, d.newState().streakStart());
+		assertEquals(1000, d.newState().lastSeenAbove());
 		assertFalse(d.newState().alerted());
 	}
 
 	@Test
 	public void streakNotYetSustained_doesNotFire() {
-		final FastDrainState state = new FastDrainState(1000, false, 0);
-		final long now = 1000 + 2 * 60_000L; // only 2 min in
+		final FastDrainState state = new FastDrainState(1000, false, 0, 1000);
+		final long now = 1000 + 2 * MINUTE_MS; // only 2 min in
 		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
 
 		assertFalse(d.shouldNotify());
 		assertEquals(1000, d.newState().streakStart()); // start preserved
+		assertEquals(now, d.newState().lastSeenAbove()); // observation refreshed
 		assertFalse(d.newState().alerted());
 	}
 
 	@Test
 	public void sustained_firesFirstAlertEvenWhileActivelyUsed() {
-		final FastDrainState state = new FastDrainState(1000, false, 0);
+		final FastDrainState state = new FastDrainState(1000, false, 0, 1000);
 		final long now = 1000 + SUSTAINED_MS;
 		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, USED, now);
 
@@ -77,8 +82,8 @@ public class FastDrainDetectorTest {
 	@Test
 	public void afterAlert_activelyUsed_staysSilent() {
 		final long start = 1000;
-		final FastDrainState state = new FastDrainState(start, true, start);
-		final long now = start + REMINDER_MS + 60_000L; // well past a reminder gap
+		final long now = start + REMINDER_MS + MINUTE_MS; // well past a reminder gap
+		final FastDrainState state = new FastDrainState(start, true, start, now - MINUTE_MS);
 		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, USED, now);
 
 		assertFalse(d.shouldNotify());                       // once per episode while the user can see it
@@ -88,8 +93,8 @@ public class FastDrainDetectorTest {
 	@Test
 	public void afterAlert_lockedAndGapElapsed_reminds() {
 		final long start = 1000;
-		final FastDrainState state = new FastDrainState(start, true, start);
 		final long now = start + REMINDER_MS;
+		final FastDrainState state = new FastDrainState(start, true, start, now - MINUTE_MS);
 		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
 
 		assertTrue(d.shouldNotify());
@@ -100,8 +105,8 @@ public class FastDrainDetectorTest {
 	@Test
 	public void afterAlert_lockedButGapNotElapsed_staysSilent() {
 		final long start = 1000;
-		final FastDrainState state = new FastDrainState(start, true, start);
-		final long now = start + REMINDER_MS - 60_000L; // one minute short of the gap
+		final long now = start + REMINDER_MS - MINUTE_MS; // one minute short of the gap
+		final FastDrainState state = new FastDrainState(start, true, start, now - MINUTE_MS);
 		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
 
 		assertFalse(d.shouldNotify());
@@ -112,7 +117,7 @@ public class FastDrainDetectorTest {
 	public void reArmedEpisode_canAlertAgainLater() {
 		// A calmed episode clears, then a fresh flare re-starts the streak and alerts once sustained.
 		final FastDrainDecision calmed = FastDrainDetector.decide(
-				new FastDrainState(1000, true, 1000), true, 5, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 400_000);
+				new FastDrainState(1000, true, 1000, 1000), true, 5, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 400_000);
 		assertEquals(CLEARED, calmed.newState());
 
 		final FastDrainDecision restart = FastDrainDetector.decide(
@@ -123,5 +128,70 @@ public class FastDrainDetectorTest {
 		final FastDrainDecision reAlert = FastDrainDetector.decide(
 				restart.newState(), true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000 + SUSTAINED_MS);
 		assertTrue(reAlert.shouldNotify());
+	}
+
+	// --- observation-gap lapse rule ------------------------------------------------------------
+
+	@Test
+	public void lapsedGap_restartsStreakInsteadOfAlerting() {
+		// Streak observed for 4 min, then no usable rate for ~86 min (process death / doze). The next
+		// above-limit reading must start a fresh episode, not alert "for the last 90 minutes".
+		final long lastSeen = 1000 + 4 * MINUTE_MS;
+		final FastDrainState state = new FastDrainState(1000, false, 0, lastSeen);
+		final long now = 1000 + 90 * MINUTE_MS;
+		final FastDrainDecision d = FastDrainDetector.decide(state, true, 22, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(now, d.newState().streakStart());   // fresh episode
+		assertEquals(now, d.newState().lastSeenAbove());
+	}
+
+	@Test
+	public void lapsedGapAfterAlert_startsFreshEpisodeThatCanAlertAgain() {
+		final long alertedAt = 1000 + SUSTAINED_MS;
+		final FastDrainState state = new FastDrainState(1000, true, alertedAt, alertedAt);
+		final long now = 1000 + 120 * MINUTE_MS; // hours later
+		final FastDrainDecision lapsed = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+
+		assertFalse(lapsed.shouldNotify());
+		assertEquals(now, lapsed.newState().streakStart());
+		assertFalse(lapsed.newState().alerted()); // new episode: the first-alert is re-armed
+
+		final FastDrainDecision reAlert = FastDrainDetector.decide(
+				lapsed.newState(), true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now + SUSTAINED_MS);
+		assertTrue(reAlert.shouldNotify());
+	}
+
+	@Test
+	public void gapAtBoundary_continuesStreak() {
+		// A gap of exactly MAX_OBSERVATION_GAP_MS is still continuous; one millisecond more lapses it.
+		final long lastSeen = 1000;
+		final long atBoundary = lastSeen + FastDrainDetector.MAX_OBSERVATION_GAP_MS;
+		final FastDrainState state = new FastDrainState(1000, false, 0, lastSeen);
+
+		final FastDrainDecision continued = FastDrainDetector.decide(
+				state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, atBoundary);
+		assertEquals(1000, continued.newState().streakStart()); // preserved
+
+		final FastDrainDecision lapsed = FastDrainDetector.decide(
+				state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, atBoundary + 1);
+		assertEquals(atBoundary + 1, lapsed.newState().streakStart()); // restarted
+	}
+
+	// --- timing-preference clamp ----------------------------------------------------------------
+
+	@Test
+	public void clampMinutes_inRangeUnchanged() {
+		assertEquals(5 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(5, 1, 30));
+		assertEquals(1 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(1, 1, 30));   // boundaries kept
+		assertEquals(60 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(60, 5, 60));
+	}
+
+	@Test
+	public void clampMinutes_outOfRangeClamped() {
+		// 0 sustained minutes would fire on the first above-limit tick — the spike alarm the design forbids.
+		assertEquals(1 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(0, 1, 30));
+		assertEquals(1 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(-7, 1, 30));
+		assertEquals(30 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(999, 1, 30));
 	}
 }


### PR DESCRIPTION
Closes #109.

> **Stacked on #120 (#108).** Target base is `feat/108-drain-rate`; review/merge that first. This diff shows only the #109 changes on top.

## What
The alerting layer on top of #108's smoothed drain rate. No per-app data needed (it watches the whole-battery %/h), so it's fully buildable by a normal app.

- **`FastDrainDetector`** — fires when the (already smoothed) drain rate stays **at/above the user's limit for a sustained window** (default 5 min). A brief spike breaks the streak. The decision core is a **pure, unit-tested** function; the streak/hysteresis state is **persisted** so it survives process restarts (like `BatteryHealthTracker`).
- **Context-aware repeats, no new timer** (reminders piggyback the battery broadcasts):
  - screen **on and unlocked** → warn **once per episode** (user can see it),
  - screen **off or locked** → **remind every 15 min** (default) while it continues — the highest-value case.
  - Re-arms only after the rate drops back below the limit (hysteresis, like the temperature alert).
- **Only while discharging.** When #108 can't produce a %/h yet (warm-up), the alert **sleeps** rather than firing — fail-quiet.
- **Transparent message**: real measured rate + how long sustained + the user's own limit. Own notification channel + id (never replaces a level/temperature alert); respects quiet-hours / silent / vibrate.
- **Settings**: enable (default on), the **shared** high-drain limit (#108's red line), sustained-minutes, locked-reminder-gap. Screen/lock state via `PowerManager.isInteractive` + `KeyguardManager` (no special permission).

## Testing
- `FastDrainDetectorTest` covers the pure `decide()` core: streak start, not-yet-sustained, first-alert-fires-even-when-used, once-vs-reminder split, gap gating, sleep-on-no-rate, and re-arm-then-re-alert. `testDebugUnitTest` + `lintDebug` green; installed on the Kirin Mate 10 Pro.

## On-device TODO (maintainer)
- Simulate sustained high drain via `adb shell dumpsys battery unplug` + `set level <n>` stepping down, and verify: the streak (fires only after the sustained window), the once-vs-reminder split (lock the phone to get reminders), and that a brief spike stays silent. Restore with `adb shell dumpsys battery reset`.

## Needs review
- **Arabic strings** (`values-ar`) are my drafts.