### PR TITLE
Combine critical/warning sliders into one range slider (Settings + Home)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -15,13 +15,17 @@ import android.provider.Settings;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.TextView;
 import android.widget.Toast;
 import com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment;
+import com.almothafar.simplebatterynotifier.ui.preference.BatteryRangeSliderHelper;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.slider.RangeSlider;
 import com.google.android.material.snackbar.Snackbar;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentManager;
@@ -32,6 +36,8 @@ import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.PowerConnectionService;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.ui.widget.CircularProgressBar;
+
+import java.util.List;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -56,6 +62,7 @@ public class MainActivity extends BaseActivity {
 
 	// UI elements
 	private MaterialButton batteryInsightsButton;
+	private RangeSlider thresholdSlider;
 
 	// Self-reposting refresh loop, bound to the foreground lifecycle (started in onPostResume,
 	// stopped in onPause) so it never stacks across resumes or keeps polling in the background.
@@ -155,6 +162,9 @@ public class MainActivity extends BaseActivity {
 
 		// Set up button click listeners
 		batteryInsightsButton.setOnClickListener(v -> openBatteryInsights());
+
+		// Wire the in-fly critical/warning threshold slider (portrait home screen).
+		setupThresholdSlider();
 
 		// Best-effort: auto-fill the battery design capacity from the device on first run, so the
 		// measured health/capacity works without the user having to look up and type it in (#104).
@@ -269,6 +279,10 @@ public class MainActivity extends BaseActivity {
 		final CircularProgressBar progressBar = findViewById(R.id.batteryPercentage);
 		progressBar.setWarningLevel(sharedPref.getInt(getString(R.string._pref_key_warn_battery_level), 40));
 		progressBar.setCriticalLevel(sharedPref.getInt(getString(R.string._pref_key_critical_battery_level), 20));
+
+		// Keep the in-fly slider in sync with values that may have changed in Settings.
+		syncThresholdSlider();
+
 		progressBar.animateProgressTo(0, batteryPercentage, new CircularProgressBar.ProgressAnimationListener() {
 
 			@Override
@@ -287,6 +301,91 @@ public class MainActivity extends BaseActivity {
 				progressBar.setSubTitle(subTitle);
 			}
 		});
+	}
+
+	/**
+	 * Wire the in-fly critical/warning threshold slider on the home screen.
+	 * <p>
+	 * The control is portrait-only (absent from the landscape layout), so this no-ops when the
+	 * slider isn't present. Captions update live while dragging; the new values are persisted to the
+	 * same preference keys Settings uses — and the gauge refreshed — only when the drag ends.
+	 */
+	private void setupThresholdSlider() {
+		thresholdSlider = findViewById(R.id.thresholdSlider);
+		if (isNull(thresholdSlider)) {
+			return;
+		}
+		BatteryRangeSliderHelper.configure(thresholdSlider,
+				BatteryRangeSliderHelper.LEVEL_FROM,
+				BatteryRangeSliderHelper.LEVEL_TO,
+				BatteryRangeSliderHelper.MIN_SEPARATION);
+
+		final TextView criticalCaption = findViewById(R.id.thresholdCriticalCaption);
+		final TextView warningCaption = findViewById(R.id.thresholdWarningCaption);
+
+		thresholdSlider.addOnChangeListener((slider, value, fromUser) -> {
+			final List<Float> values = slider.getValues();
+			updateThresholdCaptions(criticalCaption, warningCaption,
+					Math.round(values.get(0)), Math.round(values.get(1)));
+		});
+
+		thresholdSlider.addOnSliderTouchListener(new RangeSlider.OnSliderTouchListener() {
+			@Override
+			public void onStartTrackingTouch(@NonNull final RangeSlider slider) {
+				// No-op: applied on release.
+			}
+
+			@Override
+			public void onStopTrackingTouch(@NonNull final RangeSlider slider) {
+				final List<Float> values = slider.getValues();
+				final int critical = Math.round(values.get(0));
+				final int warning = Math.round(values.get(1));
+
+				PreferenceManager.getDefaultSharedPreferences(MainActivity.this).edit()
+						.putInt(getString(R.string._pref_key_critical_battery_level), critical)
+						.putInt(getString(R.string._pref_key_warn_battery_level), warning)
+						.apply();
+
+				final CircularProgressBar progressBar = findViewById(R.id.batteryPercentage);
+				progressBar.setCriticalLevel(critical);
+				progressBar.setWarningLevel(warning);
+				progressBar.invalidate();
+			}
+		});
+
+		syncThresholdSlider();
+	}
+
+	/**
+	 * Load the persisted critical/warning levels onto the in-fly slider and captions, clamping into
+	 * the slider's bounds so values set elsewhere (e.g. Settings) are always displayable.
+	 */
+	private void syncThresholdSlider() {
+		if (isNull(thresholdSlider)) {
+			return;
+		}
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+		final int critical = prefs.getInt(getString(R.string._pref_key_critical_battery_level),
+				BatteryRangeSliderHelper.DEFAULT_CRITICAL);
+		final int warning = prefs.getInt(getString(R.string._pref_key_warn_battery_level),
+				BatteryRangeSliderHelper.DEFAULT_WARNING);
+		final int[] pair = BatteryRangeSliderHelper.clampPair(critical, warning,
+				BatteryRangeSliderHelper.LEVEL_FROM, BatteryRangeSliderHelper.LEVEL_TO,
+				BatteryRangeSliderHelper.MIN_SEPARATION);
+
+		thresholdSlider.setValues((float) pair[0], (float) pair[1]);
+		updateThresholdCaptions(findViewById(R.id.thresholdCriticalCaption),
+				findViewById(R.id.thresholdWarningCaption), pair[0], pair[1]);
+	}
+
+	private void updateThresholdCaptions(final TextView criticalCaption, final TextView warningCaption,
+	                                     final int critical, final int warning) {
+		if (nonNull(criticalCaption)) {
+			criticalCaption.setText(getString(R.string.battery_range_caption_critical, critical));
+		}
+		if (nonNull(warningCaption)) {
+			warningCaption.setText(getString(R.string.battery_range_caption_warning, warning));
+		}
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
-import android.view.View;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -33,7 +32,6 @@ import com.almothafar.simplebatterynotifier.ui.preference.RingtonePreference;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 import com.almothafar.simplebatterynotifier.ui.preference.TimePickerPreference;
 import com.almothafar.simplebatterynotifier.ui.preference.TimePickerPreferenceDialogFragmentCompat;
-import com.google.android.material.snackbar.Snackbar;
 
 import java.util.Set;
 
@@ -51,10 +49,6 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 		implements SharedPreferences.OnSharedPreferenceChangeListener {
 
 	private static final String TAG = "GenericPreferenceFrag";
-
-	// Default battery level values (from pref_general.xml)
-	private static final int DEFAULT_WARNING_BATTERY_LEVEL = 40;
-	private static final int DEFAULT_CRITICAL_BATTERY_LEVEL = 20;
 
 	private RingtonePreference currentRingtonePreference;
 	private ActivityResultLauncher<Intent> ringtonePickerLauncher;
@@ -350,16 +344,14 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 	/**
 	 * Update summary for SeekBarPreference
 	 * <p>
-	 * Adds percentage suffix for battery level preferences.
+	 * Adds the temperature-unit suffix for the high-temperature threshold.
 	 */
 	private void updateSeekBarPreferenceSummary(final SeekBarPreference seekBarPref) {
 		final String key = seekBarPref.getKey();
 		if (isNull(key)) {
 			return;
 		}
-		if (isBatteryLevelPreference(key)) {
-			seekBarPref.setSummary(seekBarPref.getValue() + "%");
-		} else if (key.equals(getString(R.string._pref_key_high_temperature_threshold))) {
+		if (key.equals(getString(R.string._pref_key_high_temperature_threshold))) {
 			seekBarPref.setSummary(seekBarPref.getValue() + temperatureUnitSuffix(TemperatureUtils.isFahrenheit(requireContext())));
 		}
 	}
@@ -424,17 +416,6 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 	}
 
 	/**
-	 * Check if a preference key is for battery level configuration
-	 *
-	 * @param key The preference key to check
-	 * @return true if the key is for warning or critical battery level
-	 */
-	private boolean isBatteryLevelPreference(final String key) {
-		return key.equals(getString(R.string._pref_key_warn_battery_level)) ||
-		       key.equals(getString(R.string._pref_key_critical_battery_level));
-	}
-
-	/**
 	 * Initialize summaries for all preferences
 	 * <p>
 	 * Called when the fragment is resumed to ensure all preference summaries
@@ -471,11 +452,6 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 			if (p instanceof final RingtonePreference ringtonePref) {
 				setupRingtonePreferenceListener(ringtonePref);
 			}
-
-			// Set up validation for battery level preferences
-			if (p instanceof SeekBarPreference && isBatteryLevelPreference(p.getKey())) {
-				setupBatteryLevelValidation(sharedPreferences, p);
-			}
 		}
 	}
 
@@ -495,80 +471,4 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 		});
 	}
 
-	/**
-	 * Set up validation for battery level SeekBarPreferences
-	 * <p>
-	 * Ensures warning level is always higher than critical level and vice versa.
-	 * Shows accessible error message via Snackbar if validation fails.
-	 *
-	 * @param sharedPreferences The SharedPreferences containing current values
-	 * @param pref              The battery level preference to validate
-	 */
-	private void setupBatteryLevelValidation(final SharedPreferences sharedPreferences, final Preference pref) {
-		pref.setOnPreferenceChangeListener((preference, newValue) -> {
-			if (newValue instanceof Integer) {
-				final int value = (Integer) newValue;
-				final String key = preference.getKey();
-
-				// Validate the new value
-				final String errorMessage = validateBatteryLevel(key, value, sharedPreferences);
-				if (nonNull(errorMessage)) {
-					showValidationError(errorMessage);
-					return false; // Reject the change
-				}
-
-				// Update summary with new value
-				preference.setSummary(value + "%");
-			}
-			return true;
-		});
-	}
-
-	/**
-	 * Validate battery level change
-	 * <p>
-	 * Ensures warning level is always higher than critical level.
-	 *
-	 * @param key               The preference key being changed
-	 * @param newValue          The new value to validate
-	 * @param sharedPreferences The SharedPreferences containing current values
-	 * @return Error message if validation fails, null if valid
-	 */
-	private String validateBatteryLevel(final String key, final int newValue, final SharedPreferences sharedPreferences) {
-		if (key.equals(getString(R.string._pref_key_warn_battery_level))) {
-			// Changing warning level - ensure it's higher than critical
-			final int criticalLevel = sharedPreferences.getInt(
-					getString(R.string._pref_key_critical_battery_level),
-					DEFAULT_CRITICAL_BATTERY_LEVEL);
-			if (newValue <= criticalLevel) {
-				return getString(R.string.error_warning_level_too_low, criticalLevel);
-			}
-		} else if (key.equals(getString(R.string._pref_key_critical_battery_level))) {
-			// Changing critical level - ensure it's lower than warning
-			final int warningLevel = sharedPreferences.getInt(
-					getString(R.string._pref_key_warn_battery_level),
-					DEFAULT_WARNING_BATTERY_LEVEL);
-			if (newValue >= warningLevel) {
-				return getString(R.string.error_critical_level_too_high, warningLevel);
-			}
-		}
-		return null; // Valid
-	}
-
-	/**
-	 * Show validation error message using Snackbar for accessibility
-	 * <p>
-	 * Snackbar is preferred over Toast because:
-	 * - It's accessible to TalkBack users
-	 * - It's more visible and can contain actions
-	 * - It follows Material Design guidelines
-	 *
-	 * @param message The error message to display
-	 */
-	private void showValidationError(final String message) {
-		final View view = getView();
-		if (nonNull(view)) {
-			Snackbar.make(view, message, Snackbar.LENGTH_SHORT).show();
-		}
-	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/BatteryRangeSliderHelper.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/BatteryRangeSliderHelper.java
@@ -1,0 +1,74 @@
+package com.almothafar.simplebatterynotifier.ui.preference;
+
+import com.almothafar.simplebatterynotifier.R;
+import com.google.android.material.slider.RangeSlider;
+
+/**
+ * Shared configuration for the combined critical/warning battery-level {@link RangeSlider}.
+ * <p>
+ * The same two-thumb control appears in two places — the settings screen
+ * ({@link BatteryRangeSliderPreference}) and the in-fly control on the home screen — so the
+ * bounds, step, minimum thumb separation, and the "{@code N%}" label formatting live here as the
+ * single source of truth. The left thumb is the critical level, the right thumb is the warning
+ * level, and {@link #MIN_SEPARATION} guarantees critical always stays below warning.
+ */
+public final class BatteryRangeSliderHelper {
+
+	/** Lowest value the critical thumb can reach (the combined track's start). */
+	public static final int LEVEL_FROM = 10;
+	/** Highest value the warning thumb can reach (the combined track's end). */
+	public static final int LEVEL_TO = 50;
+	/** Minimum gap kept between the critical and warning thumbs, in percent. */
+	public static final int MIN_SEPARATION = 5;
+	/** Default critical level, matching the historical {@code SeekBarPreference} default. */
+	public static final int DEFAULT_CRITICAL = 20;
+	/** Default warning level, matching the historical {@code SeekBarPreference} default. */
+	public static final int DEFAULT_WARNING = 40;
+
+	private BatteryRangeSliderHelper() {
+		// Utility class
+	}
+
+	/**
+	 * Apply the shared bounds, integer step, minimum thumb separation, and a "{@code N%}" label
+	 * formatter to a slider. Does not set the thumb values — callers set those after clamping via
+	 * {@link #clampPair(int, int, int, int, int)}.
+	 *
+	 * @param slider        the range slider to configure
+	 * @param from          combined track start (critical floor)
+	 * @param to            combined track end (warning ceiling)
+	 * @param minSeparation minimum gap between the two thumbs, in value units
+	 */
+	public static void configure(final RangeSlider slider, final int from, final int to, final int minSeparation) {
+		slider.setValueFrom(from);
+		slider.setValueTo(to);
+		slider.setStepSize(1f);
+		slider.setMinSeparationValue(minSeparation);
+		// Show the dragged thumb's value as a whole percentage (e.g. "20%") instead of "20.0".
+		slider.setLabelFormatter(value ->
+				slider.getContext().getString(R.string.battery_level_percent, Math.round(value)));
+	}
+
+	/**
+	 * Clamp a (critical, warning) pair into {@code [from, to]} while keeping them at least
+	 * {@code minSeparation} apart, so persisted or corrupted values can always be shown on the
+	 * slider without tripping its validation.
+	 *
+	 * @return a two-element array {@code {critical, warning}}
+	 */
+	public static int[] clampPair(final int critical, final int warning,
+	                              final int from, final int to, final int minSeparation) {
+		int low = clamp(critical, from, to);
+		int high = clamp(warning, from, to);
+		if (high - low < minSeparation) {
+			// Push the warning thumb up first; if that hits the ceiling, pull critical back down.
+			high = Math.min(to, low + minSeparation);
+			low = Math.max(from, high - minSeparation);
+		}
+		return new int[]{low, high};
+	}
+
+	private static int clamp(final int value, final int lo, final int hi) {
+		return Math.max(lo, Math.min(hi, value));
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/BatteryRangeSliderPreference.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/BatteryRangeSliderPreference.java
@@ -1,0 +1,169 @@
+package com.almothafar.simplebatterynotifier.ui.preference;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import com.almothafar.simplebatterynotifier.R;
+import com.google.android.material.slider.RangeSlider;
+
+import java.util.List;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+/**
+ * A settings preference that combines the critical and warning battery levels into a single
+ * two-thumb {@link RangeSlider} — the left thumb is the critical level, the right thumb is the
+ * warning level. It replaces the two separate {@code SeekBarPreference}s and enforces
+ * "critical &lt; warning" structurally via the slider's minimum thumb separation (so the old
+ * cross-field validation is no longer needed).
+ * <p>
+ * The preference is non-persistent: it writes each thumb to its own existing SharedPreferences key
+ * ({@code criticalKey} / {@code warningKey}) so {@code BatteryLevelReceiver} and the home gauge keep
+ * reading the same keys unchanged. Bounds, step, separation, and label formatting come from
+ * {@link BatteryRangeSliderHelper}.
+ */
+public class BatteryRangeSliderPreference extends Preference {
+
+	private String criticalKey;
+	private String warningKey;
+	private int from = BatteryRangeSliderHelper.LEVEL_FROM;
+	private int to = BatteryRangeSliderHelper.LEVEL_TO;
+	private int minSeparation = BatteryRangeSliderHelper.MIN_SEPARATION;
+	private int criticalDefault = BatteryRangeSliderHelper.DEFAULT_CRITICAL;
+	private int warningDefault = BatteryRangeSliderHelper.DEFAULT_WARNING;
+
+	public BatteryRangeSliderPreference(final Context context, final AttributeSet attrs,
+	                                    final int defStyleAttr, final int defStyleRes) {
+		super(context, attrs, defStyleAttr, defStyleRes);
+		init(attrs);
+	}
+
+	public BatteryRangeSliderPreference(final Context context, final AttributeSet attrs, final int defStyleAttr) {
+		super(context, attrs, defStyleAttr);
+		init(attrs);
+	}
+
+	public BatteryRangeSliderPreference(final Context context, final AttributeSet attrs) {
+		super(context, attrs);
+		init(attrs);
+	}
+
+	public BatteryRangeSliderPreference(final Context context) {
+		super(context);
+		init(null);
+	}
+
+	private void init(final AttributeSet attrs) {
+		setLayoutResource(R.layout.preference_battery_range_slider);
+		// The slider handles its own touch; the row itself is not clickable and we persist by hand.
+		setSelectable(false);
+		setPersistent(false);
+
+		// Sensible defaults; overridable from XML so the bounds/keys stay declarative.
+		criticalKey = getContext().getString(R.string._pref_key_critical_battery_level);
+		warningKey = getContext().getString(R.string._pref_key_warn_battery_level);
+
+		if (nonNull(attrs)) {
+			final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.BatteryRangeSliderPreference);
+			criticalKey = orDefault(a.getString(R.styleable.BatteryRangeSliderPreference_criticalKey), criticalKey);
+			warningKey = orDefault(a.getString(R.styleable.BatteryRangeSliderPreference_warningKey), warningKey);
+			from = a.getInt(R.styleable.BatteryRangeSliderPreference_sliderFrom, from);
+			to = a.getInt(R.styleable.BatteryRangeSliderPreference_sliderTo, to);
+			minSeparation = a.getInt(R.styleable.BatteryRangeSliderPreference_sliderMinSeparation, minSeparation);
+			criticalDefault = a.getInt(R.styleable.BatteryRangeSliderPreference_criticalDefault, criticalDefault);
+			warningDefault = a.getInt(R.styleable.BatteryRangeSliderPreference_warningDefault, warningDefault);
+			a.recycle();
+		}
+	}
+
+	@Override
+	public void onBindViewHolder(@NonNull final PreferenceViewHolder holder) {
+		super.onBindViewHolder(holder);
+
+		final RangeSlider slider = (RangeSlider) holder.findViewById(R.id.battery_range_slider);
+		final TextView criticalCaption = (TextView) holder.findViewById(R.id.battery_range_critical_caption);
+		final TextView warningCaption = (TextView) holder.findViewById(R.id.battery_range_warning_caption);
+		if (isNull(slider)) {
+			return;
+		}
+
+		BatteryRangeSliderHelper.configure(slider, from, to, minSeparation);
+
+		// Drop any listeners left over from a previous bind (this view can be recycled) before
+		// seeding values, so the initial setValues() can't fire a stale listener.
+		slider.clearOnChangeListeners();
+		slider.clearOnSliderTouchListeners();
+
+		final int[] pair = readClampedValues();
+		slider.setValues((float) pair[0], (float) pair[1]);
+		updateCaptions(criticalCaption, warningCaption, pair[0], pair[1]);
+
+		// Update the captions live while dragging; persist only when the drag ends to avoid a burst
+		// of writes and readers seeing half-applied intermediate values.
+		slider.addOnChangeListener((s, value, fromUser) -> {
+			final int[] current = currentValues(s);
+			updateCaptions(criticalCaption, warningCaption, current[0], current[1]);
+		});
+
+		slider.addOnSliderTouchListener(new RangeSlider.OnSliderTouchListener() {
+			@Override
+			public void onStartTrackingTouch(@NonNull final RangeSlider s) {
+				// No-op: we persist on release.
+			}
+
+			@Override
+			public void onStopTrackingTouch(@NonNull final RangeSlider s) {
+				final int[] current = currentValues(s);
+				persist(current[0], current[1]);
+			}
+		});
+	}
+
+	/**
+	 * Read the persisted critical/warning values (falling back to the defaults) and clamp them into
+	 * the slider's bounds and separation so they can always be applied safely.
+	 */
+	private int[] readClampedValues() {
+		final SharedPreferences prefs = getSharedPreferences();
+		final int critical = nonNull(prefs) ? prefs.getInt(criticalKey, criticalDefault) : criticalDefault;
+		final int warning = nonNull(prefs) ? prefs.getInt(warningKey, warningDefault) : warningDefault;
+		return BatteryRangeSliderHelper.clampPair(critical, warning, from, to, minSeparation);
+	}
+
+	private void persist(final int critical, final int warning) {
+		final SharedPreferences prefs = getSharedPreferences();
+		if (nonNull(prefs)) {
+			prefs.edit()
+					.putInt(criticalKey, critical)
+					.putInt(warningKey, warning)
+					.apply();
+		}
+	}
+
+	private void updateCaptions(final TextView criticalCaption, final TextView warningCaption,
+	                            final int critical, final int warning) {
+		if (nonNull(criticalCaption)) {
+			criticalCaption.setText(getContext().getString(R.string.battery_range_caption_critical, critical));
+		}
+		if (nonNull(warningCaption)) {
+			warningCaption.setText(getContext().getString(R.string.battery_range_caption_warning, warning));
+		}
+	}
+
+	private static int[] currentValues(final RangeSlider slider) {
+		final List<Float> values = slider.getValues();
+		return new int[]{Math.round(values.get(0)), Math.round(values.get(1))};
+	}
+
+	private static String orDefault(final String value, final String fallback) {
+		return nonNull(value) ? value : fallback;
+	}
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -63,6 +63,53 @@
         android:paddingBottom="@dimen/content_navigation_bar_padding"
         android:background="@android:color/white">
 
+        <!-- In-fly critical/warning threshold adjuster. Mirrors the Settings range slider and
+             writes the same preference keys, so changes here update the gauge immediately. -->
+        <TextView
+            android:id="@+id/thresholdTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/battery_range_title"
+            android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+            android:textColor="@color/default_text_color" />
+
+        <com.google.android.material.slider.RangeSlider
+            android:id="@+id/thresholdSlider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:stepSize="1"
+            android:valueFrom="10"
+            android:valueTo="50"
+            app:labelBehavior="floating" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/thresholdCriticalCaption"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="start"
+                android:textColor="@color/circular_progress_default_progress_alert"
+                android:textSize="13sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/thresholdWarningCaption"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="end"
+                android:textColor="@color/circular_progress_default_progress_warning"
+                android:textSize="13sp"
+                android:textStyle="bold" />
+
+        </LinearLayout>
+
         <!-- Battery Insights Button - Material3 -->
         <com.google.android.material.button.MaterialButton
             android:id="@+id/batteryInsightsButton"

--- a/app/src/main/res/layout/preference_battery_range_slider.xml
+++ b/app/src/main/res/layout/preference_battery_range_slider.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Custom layout for BatteryRangeSliderPreference: a two-thumb RangeSlider (left = critical,
+     right = warning) with a colored, always-on value caption under each end. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:clickable="false"
+    android:focusable="false"
+    android:minHeight="64dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp">
+
+    <TextView
+        android:id="@android:id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        android:textColor="?android:attr/textColorPrimary"
+        tools:text="Battery Alert Levels" />
+
+    <com.google.android.material.slider.RangeSlider
+        android:id="@+id/battery_range_slider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:stepSize="1"
+        android:valueFrom="10"
+        android:valueTo="50"
+        app:labelBehavior="floating" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/battery_range_critical_caption"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="start"
+            android:textColor="@color/circular_progress_default_progress_alert"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            tools:text="Critical 20%" />
+
+        <TextView
+            android:id="@+id/battery_range_warning_caption"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="end"
+            android:textColor="@color/circular_progress_default_progress_warning"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            tools:text="Warning 40%" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -50,6 +50,12 @@
 
     <string name="warn_start_level">مستوى التحذير يبدأ من</string>
     <string name="alert_start_level">المستوى الحرج يبدأ من</string>
+
+    <!-- Combined critical/warning battery range slider -->
+    <string name="battery_range_title">مستويات تنبيه البطارية</string>
+    <string name="battery_range_caption_critical">حرج %1$d%%</string>
+    <string name="battery_range_caption_warning">تحذير %1$d%%</string>
+    <string name="battery_range_summary">حرج %1$d%% • تحذير %2$d%%</string>
     <string name="temperature_unit">وحدة الحرارة</string>
     <string name="off">إطفاء</string>
     <string name="on">تشغيل</string>
@@ -102,10 +108,6 @@
     <string name="notification_charge_started_title_healthy">شحن صحي بدأ</string>
     <string name="notification_charge_started_title_regular">شحن اعتيادي بدأ</string>
     <string name="notification_charge_started_content">البطارية تشحن بواسطة %1$s</string>
-
-    <!-- Validation error messages -->
-    <string name="error_warning_level_too_low">يجب أن يكون مستوى التحذير أعلى من المستوى الحرج (%d%%)</string>
-    <string name="error_critical_level_too_high">يجب أن يكون المستوى الحرج أقل من مستوى التحذير (%d%%)</string>
 
     <!-- Accessibility -->
     <string name="battery_progress_description">البطارية عند %1$d بالمئة</string>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -12,4 +12,16 @@
         <attr name="cpb_subtitleTextSize" format="integer"/>
         <attr name="cpb_strokeWidth" format="integer"/>
     </declare-styleable>
+
+    <declare-styleable name="BatteryRangeSliderPreference">
+        <!-- SharedPreferences keys the two thumbs persist to -->
+        <attr name="criticalKey" format="string"/>
+        <attr name="warningKey" format="string"/>
+        <!-- Combined track bounds and the minimum gap kept between the two thumbs -->
+        <attr name="sliderFrom" format="integer"/>
+        <attr name="sliderTo" format="integer"/>
+        <attr name="sliderMinSeparation" format="integer"/>
+        <attr name="criticalDefault" format="integer"/>
+        <attr name="warningDefault" format="integer"/>
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,13 @@
 
     <string name="warn_start_level">Warning Level Start From</string>
     <string name="alert_start_level">Critical Level Start From</string>
+
+    <!-- Combined critical/warning battery range slider -->
+    <string name="battery_range_title">Battery Alert Levels</string>
+    <string name="battery_range_caption_critical">Critical %1$d%%</string>
+    <string name="battery_range_caption_warning">Warning %1$d%%</string>
+    <string name="battery_range_summary">Critical %1$d%% • Warning %2$d%%</string>
+    <string name="battery_level_percent" translatable="false">%1$d%%</string>
     <string name="temperature_unit">Temperature Unit</string>
     <string name="off">OFF</string>
     <string name="on">ON</string>
@@ -217,6 +224,7 @@
 
     <string name="_pref_key_warn_battery_level" translatable="false">key_warn_battery_level</string>
     <string name="_pref_key_critical_battery_level" translatable="false">key_critical_battery_level</string>
+    <string name="_pref_key_battery_level_range" translatable="false">key_battery_level_range</string>
     <string name="_pref_key_notifications_sticky" translatable="false">key_notifications_sticky</string>
     <string name="_pref_key_temperatures_unit" translatable="false">key_temperatures_unit</string>
     <string name="_pref_key_notifications_vibrate" translatable="false">key_notifications_vibrate</string>
@@ -239,10 +247,6 @@
     <string name="_pref_value_temperatures_unit_f" translatable="false">fahrenheit</string>
     <string name="_pref_value_notifications_time_range_end" translatable="false">23:30</string>
     <string name="_pref_value_notifications_time_range_start" translatable="false">06:30</string>
-
-    <!-- Validation error messages -->
-    <string name="error_warning_level_too_low">Warning level must be higher than critical level (%d%%)</string>
-    <string name="error_critical_level_too_high">Critical level must be lower than warning level (%d%%)</string>
 
     <!-- Notification service -->
     <string name="_default_notification_sound_uri" translatable="false">content://settings/system/notification_sound</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -35,26 +35,17 @@
         android:title="@string/pref_cat_title_thresholds"
         app:iconSpaceReserved="false">
 
-        <SeekBarPreference
-            android:defaultValue="40"
-            android:key="@string/_pref_key_warn_battery_level"
-            android:min="30"
-            android:max="50"
-            android:title="@string/warn_start_level"
-            style="@style/PreferenceSeekBar"
-            app:showSeekBarValue="true"
-            app:adjustable="true"
-            app:iconSpaceReserved="false" />
-
-        <SeekBarPreference
-            android:defaultValue="20"
-            android:key="@string/_pref_key_critical_battery_level"
-            android:min="10"
-            android:max="20"
-            android:title="@string/alert_start_level"
-            style="@style/PreferenceSeekBar"
-            app:showSeekBarValue="true"
-            app:adjustable="true"
+        <com.almothafar.simplebatterynotifier.ui.preference.BatteryRangeSliderPreference
+            android:key="@string/_pref_key_battery_level_range"
+            android:persistent="false"
+            android:title="@string/battery_range_title"
+            app:criticalKey="@string/_pref_key_critical_battery_level"
+            app:warningKey="@string/_pref_key_warn_battery_level"
+            app:sliderFrom="10"
+            app:sliderTo="50"
+            app:sliderMinSeparation="5"
+            app:criticalDefault="20"
+            app:warningDefault="40"
             app:iconSpaceReserved="false" />
 
     </PreferenceCategory>

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/ui/preference/BatteryRangeSliderHelperTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/ui/preference/BatteryRangeSliderHelperTest.java
@@ -1,0 +1,85 @@
+package com.almothafar.simplebatterynotifier.ui.preference;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the pure (context-free) clamping logic in {@link BatteryRangeSliderHelper}, which
+ * guarantees the critical/warning pair is always inside the slider's bounds and at least
+ * {@link BatteryRangeSliderHelper#MIN_SEPARATION} apart — the invariant that replaces the old
+ * cross-field validation.
+ */
+@RunWith(Enclosed.class)
+public class BatteryRangeSliderHelperTest {
+
+	private static final int FROM = BatteryRangeSliderHelper.LEVEL_FROM;
+	private static final int TO = BatteryRangeSliderHelper.LEVEL_TO;
+	private static final int SEP = BatteryRangeSliderHelper.MIN_SEPARATION;
+
+	/**
+	 * {@link BatteryRangeSliderHelper#clampPair(int, int, int, int, int)} maps representative
+	 * (critical, warning) inputs — valid, out-of-range, inverted, and too-close — to the expected
+	 * clamped pair.
+	 */
+	@RunWith(Parameterized.class)
+	public static class ClampPair {
+
+		@Parameter(0) public int critical;
+		@Parameter(1) public int warning;
+		@Parameter(2) public int expectedCritical;
+		@Parameter(3) public int expectedWarning;
+
+		@Parameters(name = "clampPair({0},{1}) = [{2},{3}]")
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{
+					{20, 40, 20, 40},   // already-valid defaults, untouched
+					{10, 50, 10, 50},   // full range, untouched
+					{5, 40, 10, 40},    // critical below floor -> raised to floor
+					{20, 60, 20, 50},   // warning above ceiling -> lowered to ceiling
+					{30, 30, 30, 35},   // equal -> warning pushed up to keep the gap
+					{40, 20, 40, 45},   // inverted -> warning pushed above critical
+					{48, 49, 45, 50},   // too close near the ceiling -> both shifted down
+					{2, 4, 10, 15},     // both below floor
+					{60, 70, 45, 50},   // both above ceiling
+			});
+		}
+
+		@Test
+		public void clampsToExpectedPair() {
+			final int[] result = BatteryRangeSliderHelper.clampPair(critical, warning, FROM, TO, SEP);
+			assertEquals("critical", expectedCritical, result[0]);
+			assertEquals("warning", expectedWarning, result[1]);
+		}
+	}
+
+	/**
+	 * Whatever the input — including corrupted values far outside the range — the result must always
+	 * be a usable pair the slider can accept without tripping its own validation.
+	 */
+	public static class Invariants {
+
+		@Test
+		public void everyInputYieldsAValidPair() {
+			for (int critical = -20; critical <= 80; critical++) {
+				for (int warning = -20; warning <= 80; warning++) {
+					final int[] r = BatteryRangeSliderHelper.clampPair(critical, warning, FROM, TO, SEP);
+					final String at = "(" + critical + "," + warning + ")";
+					assertTrue("critical in range at " + at, r[0] >= FROM && r[0] <= TO);
+					assertTrue("warning in range at " + at, r[1] >= FROM && r[1] <= TO);
+					assertTrue("separation kept at " + at, r[1] - r[0] >= SEP);
+					assertTrue("critical below warning at " + at, r[0] < r[1]);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #126.

Replaces the two separate warning/critical `SeekBarPreference`s with a single two-thumb Material `RangeSlider` — **left thumb = critical, right thumb = warning** — shown both in **Settings** and as an in-fly control on the **home** screen.

## What changed

**New**
- `ui/preference/BatteryRangeSliderHelper.java` — single source of truth for bounds (**10–50**), integer step, **5% minimum thumb separation**, defaults (critical 20 / warning 40), and the `N%` label formatter. Also the `clampPair(…)` logic that keeps any stored/corrupt pair inside bounds and correctly ordered.
- `ui/preference/BatteryRangeSliderPreference.java` — a non-persistent `Preference` hosting the slider. It writes each thumb to the **existing** `key_critical_battery_level` / `key_warn_battery_level` keys, so `BatteryLevelReceiver` and the gauge read the same values with **no logic change**.
- `res/layout/preference_battery_range_slider.xml` — title + slider + colored end captions.

**Changed**
- `res/xml/pref_general.xml` — the two `SeekBarPreference`s → the new preference.
- `ui/fragment/GenericPreferenceFragment.java` — removed the now-dead battery-level cross-field validation/summary code (the slider's `minSeparation` enforces `critical < warning` structurally). Temperature-threshold handling is untouched.
- `res/layout/activity_main.xml` + `ui/MainActivity.java` — in-fly `RangeSlider` on the portrait home screen. Persists on release, refreshes the gauge live, and re-syncs from preferences on resume so Settings and Home stay in agreement. (Landscape omitted — the details fragment fills the width there.)
- Strings for the captions/title in **EN + AR**; removed the two unused validation error strings.

## Design decisions (from #126)
- **Range 10–50**, step 1, min separation 5 — union of the old bands, "not 0–100".
- **Neutral thumbs + colored captions**: stock `RangeSlider` can't color thumbs individually, so the red **Critical** / amber **Warning** captions carry the color coding (both colors already in `colors.xml`).
- **Value display**: floating bubble while dragging **plus** always-on captions that update live.

## Testing
- Added `BatteryRangeSliderHelperTest` — a parameterized test for the representative clamp cases plus an exhaustive sweep asserting every input yields an in-range, ≥5-apart, correctly-ordered pair (matches the repo's boundary-test style).
- Verified the clamp math independently over an exhaustive input sweep; validated all changed XML for well-formedness.
- Note: this environment has no Android SDK, so the full Gradle build/instrumentation runs in CI rather than locally.

## Notes
- **Time range** was raised in discussion — it already exists as the quiet-hours window (start/end `TimePickerPreference`s). No change made there; flagged only for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)