### PR TITLE
Pause the gauge pulse when the app is backgrounded, not just on destroy (#129)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -186,16 +186,26 @@ public class MainActivity extends BaseActivity {
 		initializeFirstValues();
 
 		startUpdateTimer();
+
+		// Resume the pulse paused in onPause(); restarts only if the battery state still
+		// warrants it (charging or critical).
+		final CircularProgressBar progressBar = findViewById(R.id.batteryPercentage);
+		progressBar.resumePulseAnimation();
 	}
 
 	/**
-	 * Stop the refresh loop while the activity is not in the foreground so it doesn't keep
-	 * polling the battery (and draining it) in the background.
+	 * Stop the refresh loop and pause the decorative pulse while the activity is not in the
+	 * foreground, so neither keeps running (and draining the battery) in the background.
 	 */
 	@Override
 	protected void onPause() {
 		super.onPause();
 		stopUpdateTimer();
+
+		// The pulse is only auto-stopped when the view is destroyed (onDetachedFromWindow),
+		// not on backgrounding, so pause it here for the same reason we stop the timer.
+		final CircularProgressBar progressBar = findViewById(R.id.batteryPercentage);
+		progressBar.pausePulseAnimation();
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/widget/CircularProgressBar.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/widget/CircularProgressBar.java
@@ -369,6 +369,28 @@ public class CircularProgressBar extends ProgressBar {
 	}
 
 	/**
+	 * Pause the ongoing pulse animation when the host activity leaves the foreground.
+	 * <p>
+	 * The pulse is purely decorative, so there is no reason to keep it invalidating on the
+	 * main thread while nobody can see it. Counterpart to {@link #resumePulseAnimation()},
+	 * called from the activity's {@code onPause()}.
+	 */
+	public void pausePulseAnimation() {
+		stopPulseAnimation();
+	}
+
+	/**
+	 * Resume the pulse animation when the host activity returns to the foreground.
+	 * <p>
+	 * Restarts the pulse only if the current battery state still calls for it (charging or
+	 * critical); otherwise it stays off. Counterpart to {@link #pausePulseAnimation()},
+	 * called from the activity's {@code onResume()}.
+	 */
+	public void resumePulseAnimation() {
+		updateAnimationState();
+	}
+
+	/**
 	 * Draw the circular progress bar
 	 *
 	 * @param canvas The canvas to draw on


### PR DESCRIPTION
Fixes #129.

## Problem

The low-battery/charging **pulse** on the circular gauge is an `INFINITE` `ValueAnimator`. It was only stopped when the view is *destroyed* (`CircularProgressBar.onDetachedFromWindow`) — **not** when the activity is backgrounded.

`MainActivity.onPause()` already stops the battery-polling timer *for exactly this reason*, but it never paused the pulse. So opening the app (e.g. at critical) and switching away without swiping it closed left the pulse invalidating ~60×/s on the main thread for a view nobody can see, as long as the screen stayed on.

## Fix

Mirror the existing timer handling on both lifecycle sides:

- `MainActivity.onPause` → `pausePulseAnimation()`
- `MainActivity.onPostResume` → `resumePulseAnimation()` (restarts only if still charging or critical)

New public `pausePulseAnimation()` / `resumePulseAnimation()` on `CircularProgressBar` make the lifecycle intent explicit, rather than relying on the refresh loop to restart the pulse as a side effect.

## Not changed

- **Foreground behavior is identical** — the gauge still breathes when the app is open at critical/charging, and still breathes after leaving and returning. This only removes wasted background work.
- No new user-facing strings, so **no `values-ar` work** needed.

## Verification

- ✅ `:app:compileDebugJavaWithJavac` passes.
- On-device (pending): set the **critical** threshold above the current level so the gauge goes critical immediately, then confirm the pulse (1) shows when the app is open, and (2) still animates correctly after Home → other app → return. Same with the charger plugged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
