### PR TITLE
Add an "About the app" item to the main overflow menu

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -15,6 +15,7 @@ import android.provider.Settings;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 import com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment;
@@ -101,6 +102,10 @@ public class MainActivity extends BaseActivity {
 		}
 		if (id == R.id.action_feedback) {
 			showFeedbackChooser();
+			return true;
+		}
+		if (id == R.id.action_about) {
+			showAboutDialog();
 			return true;
 		}
 		return super.onOptionsItemSelected(item);
@@ -456,6 +461,38 @@ public class MainActivity extends BaseActivity {
 	private void openBatteryInsights() {
 		final Intent intent = new Intent(this, BatteryInsightsActivity.class);
 		startActivity(intent);
+	}
+
+	/**
+	 * Show the "About the app" dialog: what the app is, the current version, developer credit,
+	 * the open-source license, and a short accuracy/warranty note.
+	 */
+	private void showAboutDialog() {
+		final View content = getLayoutInflater().inflate(R.layout.dialog_about, null);
+
+		final TextView versionView = content.findViewById(R.id.aboutVersion);
+		versionView.setText(getString(R.string.about_version, appVersionName()));
+
+		final TextView developerView = content.findViewById(R.id.aboutDeveloper);
+		developerView.setText(getString(R.string.about_developer, getString(R.string.developer_name)));
+
+		new MaterialAlertDialogBuilder(this)
+				.setView(content)
+				.setPositiveButton(android.R.string.ok, null)
+				.setNeutralButton(R.string.about_view_github, (dialog, which) -> openProjectPage())
+				.show();
+	}
+
+	/**
+	 * Open the project's GitHub page in a browser.
+	 */
+	private void openProjectPage() {
+		final Uri uri = Uri.parse(getString(R.string.about_github_url));
+		try {
+			startActivity(new Intent(Intent.ACTION_VIEW, uri));
+		} catch (ActivityNotFoundException e) {
+			Toast.makeText(this, R.string.no_browser_found, Toast.LENGTH_SHORT).show();
+		}
 	}
 
 	/**

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Content of the "About the app" dialog (see MainActivity#showAboutDialog) -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingTop="24dp"
+        android:paddingBottom="8dp">
+
+        <ImageView
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:layout_gravity="center_horizontal"
+            android:contentDescription="@string/app_name"
+            android:src="@mipmap/ic_launcher" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="12dp"
+            android:text="@string/app_name"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/aboutVersion"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="2dp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp"
+            tools:text="Version 2.0.71" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/about_description"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/aboutDeveloper"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            tools:text="Developed by Al-Mothafar Al-Hasan" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/about_open_source"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/about_disclaimer"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -13,4 +13,9 @@
         android:orderInCategory="200"
         android:title="@string/action_send_feedback"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_about"
+        android:orderInCategory="300"
+        android:title="@string/action_about"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -238,6 +238,17 @@
     <string name="feedback_email_subject">ملاحظات حول تطبيق منبّه البطارية البسيط (v%1$s)</string>
     <string name="no_email_app">لا يوجد تطبيق بريد</string>
 
+    <!-- About the app -->
+    <string name="action_about">حول التطبيق</string>
+    <!-- %1$s is the app version, e.g. 2.0.71 -->
+    <string name="about_version">الإصدار %1$s</string>
+    <string name="about_description">تطبيق خفيف يُبقيك على اطّلاع على حالة بطاريتك — تنبيهات عند المستويين التحذيري والحرج، وإشعارات اكتمال الشحن وارتفاع الحرارة، وسرعة الشحن، ومعلومات عن صحة البطارية. بلا حشو ولا حيل «توفير طاقة» — مجرّد تنبيهات بطارية بسيطة.</string>
+    <!-- %1$s is the developer name -->
+    <string name="about_developer">طوّره %1$s</string>
+    <string name="about_open_source">برنامج حر ومفتوح المصدر، مرخَّص بموجب رخصة Apache 2.0.</string>
+    <string name="about_disclaimer">قراءات البطارية وأرقام الصحة والشحن مصدرها جهازك وهي تقديرية — اعتبرها إرشادية لا قياسات دقيقة. يُقدَّم هذا التطبيق «كما هو» دون أي ضمان من أي نوع.</string>
+    <string name="about_view_github">عرض على GitHub</string>
+
     <!-- App language picker -->
     <string name="pref_language_category">اللغة</string>
     <string name="pref_title_language">لغة التطبيق</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,18 @@
     <string name="feedback_email_subject">Simple Battery Notifier feedback (v%1$s)</string>
     <string name="no_email_app">No email app found</string>
 
+    <!-- About the app -->
+    <string name="action_about">About the app</string>
+    <!-- %1$s is the app version, e.g. 2.0.71 -->
+    <string name="about_version">Version %1$s</string>
+    <string name="about_description">A lightweight app that keeps you informed about your battery — alerts at warning and critical levels, full-charge and high-temperature notifications, charging speed, and battery health insights. No bloat, no “power saver” gimmicks — just simple battery notifications.</string>
+    <!-- %1$s is the developer name -->
+    <string name="about_developer">Developed by %1$s</string>
+    <string name="about_open_source">Free and open-source software, licensed under the Apache License 2.0.</string>
+    <string name="about_disclaimer">Battery readings, health and charging figures come from your device and are estimates — treat them as guidance, not exact measurements. This app is provided “as is”, without warranty of any kind.</string>
+    <string name="about_view_github">View on GitHub</string>
+    <string name="about_github_url" translatable="false">https://github.com/almothafar/SimpleBatteryNotifier</string>
+
     <!-- App language picker -->
     <string name="pref_language_category">Language</string>
     <string name="pref_title_language">App language</string>


### PR DESCRIPTION
Closes #134. Related: #113 (surfaces the app version in-app).

## What

A new **"About the app"** item in the main screen's overflow menu (after "Send feedback") opens a Material dialog with:

- App icon, name, and live **version** (via the existing `appVersionName()`)
- A one-paragraph description of what the app does, in the app's existing voice
- **Developed by Al-Mothafar Al-Hasan** (reuses the existing `developer_name` string, consistent with the signature footer)
- "Free and open-source software, licensed under the Apache License 2.0."
- A short disclaimer: battery/health/charging figures are device-provided estimates — guidance, not exact measurements; the app is provided "as is", without warranty
- A **View on GitHub** button opening the repo (with the existing no-browser fallback toast), and OK to dismiss

Per the discussion in #134, the open-source/license statement is included in-app as a trust signal (and groundwork for the F-Droid listing, #4), while the personal "playground" tone stays in the README.

## Changes

- `res/menu/menu_main.xml` — new `action_about` overflow item
- `ui/MainActivity.java` — menu handler, `showAboutDialog()`, `openProjectPage()`
- `res/layout/dialog_about.xml` — new dialog content layout (scrollable, theme-attribute colors)
- `res/values/strings.xml` + `res/values-ar/strings.xml` — new strings with Arabic translations (Western digits via the version placeholder, per #96)

## Testing

- XML validity and resource references verified; all new strings present in both locales (lint's `MissingTranslation` is an error in this repo)
- Could not build locally in the sandbox (network policy blocks the Gradle distribution; container lacks JDK 25 / Android SDK) — relying on this PR's CI run for build + test verification
- Worth a quick on-device check: menu entry, dialog rendering in Arabic/RTL, GitHub link opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)