### PR TITLE
Home: move the threshold slider under the gauge and slim it down

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -39,8 +39,61 @@
             android:layout_height="160dp"
             tools:cpb_subtitle="subtitle"
             tools:cpb_title="Title"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="-2dp"
             android:layout_marginBottom="-10dp" />
+    </LinearLayout>
+
+    <!-- In-fly critical/warning threshold adjuster, placed directly under the gauge it controls.
+         Mirrors the Settings range slider and writes the same preference keys, so changes here
+         update the gauge immediately. -->
+    <LinearLayout
+        android:id="@+id/thresholdSection"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:background="@android:color/white"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp">
+
+        <com.google.android.material.slider.RangeSlider
+            android:id="@+id/thresholdSlider"
+            style="@style/Widget.App.RangeSlider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:stepSize="1"
+            android:valueFrom="10"
+            android:valueTo="50" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="-6dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/thresholdCriticalCaption"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="start"
+                android:textColor="@color/circular_progress_default_progress_alert"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/thresholdWarningCaption"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="end"
+                android:textColor="@color/circular_progress_default_progress_warning"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
     <androidx.fragment.app.FragmentContainerView
@@ -59,56 +112,9 @@
         android:orientation="vertical"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
-        android:paddingTop="16dp"
+        android:paddingTop="8dp"
         android:paddingBottom="@dimen/content_navigation_bar_padding"
         android:background="@android:color/white">
-
-        <!-- In-fly critical/warning threshold adjuster. Mirrors the Settings range slider and
-             writes the same preference keys, so changes here update the gauge immediately. -->
-        <TextView
-            android:id="@+id/thresholdTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/battery_range_title"
-            android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
-            android:textColor="@color/default_text_color" />
-
-        <com.google.android.material.slider.RangeSlider
-            android:id="@+id/thresholdSlider"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:stepSize="1"
-            android:valueFrom="10"
-            android:valueTo="50"
-            app:labelBehavior="floating" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/thresholdCriticalCaption"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:textColor="@color/circular_progress_default_progress_alert"
-                android:textSize="13sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/thresholdWarningCaption"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="end"
-                android:textColor="@color/circular_progress_default_progress_warning"
-                android:textSize="13sp"
-                android:textStyle="bold" />
-
-        </LinearLayout>
 
         <!-- Battery Insights Button - Material3 -->
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/preference_battery_range_slider.xml
+++ b/app/src/main/res/layout/preference_battery_range_slider.xml
@@ -9,33 +9,25 @@
     android:orientation="vertical"
     android:clickable="false"
     android:focusable="false"
-    android:minHeight="64dp"
+    android:minHeight="48dp"
     android:paddingStart="16dp"
     android:paddingEnd="16dp"
-    android:paddingTop="12dp"
-    android:paddingBottom="12dp">
-
-    <TextView
-        android:id="@android:id/title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
-        android:textColor="?android:attr/textColorPrimary"
-        tools:text="Battery Alert Levels" />
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
 
     <com.google.android.material.slider.RangeSlider
         android:id="@+id/battery_range_slider"
+        style="@style/Widget.App.RangeSlider"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
         android:stepSize="1"
         android:valueFrom="10"
-        android:valueTo="50"
-        app:labelBehavior="floating" />
+        android:valueTo="50" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="-6dp"
         android:orientation="horizontal">
 
         <TextView
@@ -45,7 +37,7 @@
             android:layout_weight="1"
             android:gravity="start"
             android:textColor="@color/circular_progress_default_progress_alert"
-            android:textSize="13sp"
+            android:textSize="12sp"
             android:textStyle="bold"
             tools:text="Critical 20%" />
 
@@ -56,7 +48,7 @@
             android:layout_weight="1"
             android:gravity="end"
             android:textColor="@color/circular_progress_default_progress_warning"
-            android:textSize="13sp"
+            android:textSize="12sp"
             android:textStyle="bold"
             tools:text="Warning 40%" />
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -56,7 +56,6 @@
     <string name="alert_start_level">المستوى الحرج يبدأ من</string>
 
     <!-- Combined critical/warning battery range slider -->
-    <string name="battery_range_title">مستويات تنبيه البطارية</string>
     <string name="battery_range_caption_critical">حرج %1$d%%</string>
     <string name="battery_range_caption_warning">تحذير %1$d%%</string>
     <string name="battery_range_summary">حرج %1$d%% • تحذير %2$d%%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,7 +58,6 @@
     <string name="alert_start_level">Critical Level Start From</string>
 
     <!-- Combined critical/warning battery range slider -->
-    <string name="battery_range_title">Battery Alert Levels</string>
     <string name="battery_range_caption_critical">Critical %1$d%%</string>
     <string name="battery_range_caption_warning">Warning %1$d%%</string>
     <string name="battery_range_summary">Critical %1$d%% • Warning %2$d%%</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -67,4 +67,20 @@
         <item name="android:minHeight">64dp</item>
         <item name="seekBarIncrement">1</item>
     </style>
+
+    <!-- Shared look for the critical/warning RangeSlider (Home + Settings) so size/color tweaks
+         live in one place. Material 1.14's slider defaults to tall bar thumbs and draws a tick dot
+         per step (40 dots over 10-50), which looks noisy; here we hide the ticks, use a compact
+         round thumb snug to the track, drop the floating bubble (the captions show the values),
+         and keep a comfortable touch target. -->
+    <style name="Widget.App.RangeSlider" parent="Widget.Material3.Slider">
+        <item name="labelBehavior">gone</item>
+        <item name="tickVisible">false</item>
+        <item name="thumbWidth">16dp</item>
+        <item name="thumbHeight">16dp</item>
+        <item name="thumbTrackGapSize">0dp</item>
+        <item name="trackHeight">4dp</item>
+        <item name="trackStopIndicatorSize">0dp</item>
+        <item name="minTouchTargetSize">40dp</item>
+    </style>
 </resources>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -38,7 +38,6 @@
         <com.almothafar.simplebatterynotifier.ui.preference.BatteryRangeSliderPreference
             android:key="@string/_pref_key_battery_level_range"
             android:persistent="false"
-            android:title="@string/battery_range_title"
             app:criticalKey="@string/_pref_key_critical_battery_level"
             app:warningKey="@string/_pref_key_warn_battery_level"
             app:sliderFrom="10"


### PR DESCRIPTION
Closes #135.

On the Mate 10 Pro home screen the critical/warning RangeSlider block sat at the bottom and ate vertical space, squeezing the scrollable details table.

### Changes
- **Move** the threshold block (slider + Critical/Warning captions) from the bottom section up to directly under the battery gauge it controls, so the details table gets the reclaimed room. IDs are unchanged, so `MainActivity` needs no edits.
- **Shared style**: add `Widget.App.RangeSlider`, applied to both the home slider and the Settings `BatteryRangeSliderPreference`, so the two stay in sync. Material 1.14 defaults to tall bar thumbs and a tick dot per step (40 over 10–50), which looked noisy; the style hides ticks and end stop-indicators, uses a compact round thumb snug to the track, and drops the floating value bubble (the captions already show the values).
- **Settings**: remove the redundant "Battery Alert Levels" title (the category header "Battery Level Thresholds" already labels it) and delete the now-unused `battery_range_title` string (en + ar). Shrink the captions and tuck them closer to the slider.
- **Gauge box**: the `CircularProgressBar` measures as a square taller than the bottom-open horseshoe, so the old `+10/-10dp` margins left more empty space above the arc than below. Retune the top margin so top/bottom spacing matches, without overlapping the toolbar.

### Testing
Built and installed on a Huawei Mate 10 Pro (Android 10). Verified on-device: slider sits under the gauge and adjusts thresholds live (gauge colors + captions update), the details table is more visible, Settings matches the home slider, the gauge is vertically balanced, and Arabic RTL looks correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)