### PR TITLE
Health basis honesty + 20–80% charging guidance (#114)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
@@ -30,11 +30,6 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 	private static final String TAG = PowerConnectionReceiver.class.getSimpleName();
 
 	/**
-	 * Battery percentage threshold for healthy charging (charge when battery is low)
-	 */
-	private static final int HEALTHY_CHARGE_THRESHOLD = 20;
-
-	/**
 	 * Delay before sampling the charging current, giving it time to stabilise after plug-in.
 	 * Package-visible so tests can advance the main looper by exactly this amount.
 	 */
@@ -103,18 +98,15 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 	/**
 	 * Handle charger connected event.
 	 * <p>
-	 * Records whether this is a "healthy" charge (started at low battery), determines wired vs
-	 * wireless, and schedules the speed sample + notification for a short delay later.
+	 * Determines wired vs wireless and schedules the speed sample + notification for a short delay
+	 * later. (The old "healthy charge" flag — plugged in at low battery — was retired in #114:
+	 * starting low isn't a virtue under modern 20-80% guidance, so the titles no longer flip on it.)
 	 *
 	 * @param context      The application context
 	 * @param pluggedState The type of charger plugged in
 	 * @param percentage   Current battery percentage
 	 */
 	private void handleChargerConnected(final Context context, final int pluggedState, final int percentage) {
-		// Determine if this is a "healthy" charge (starting at low battery level)
-		final boolean isHealthyCharge = percentage <= HEALTHY_CHARGE_THRESHOLD;
-		NotificationService.setIsHealthy(isHealthyCharge);
-
 		final boolean wireless = pluggedState == BatteryManager.BATTERY_PLUGGED_WIRELESS;
 		final Context appContext = context.getApplicationContext();
 
@@ -125,11 +117,10 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 				return;
 			}
 			final ChargeSpeed speed = SystemService.getChargeSpeed(appContext);
-			NotificationService.notifyChargeConnected(appContext, speed, wireless, isHealthyCharge);
+			NotificationService.notifyChargeConnected(appContext, speed, wireless);
 		});
 
-		Log.i(TAG, String.format("Charger connected (Battery: %d%%, Wireless: %s, Healthy: %s)",
-				percentage, wireless, isHealthyCharge));
+		Log.i(TAG, String.format("Charger connected (Battery: %d%%, Wireless: %s)", percentage, wireless));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -195,6 +195,26 @@ public class BatteryHealthTracker {
 	}
 
 	/**
+	 * Whether the effective cycle count comes from the OS ({@code EXTRA_CYCLE_COUNT}, Android 14+)
+	 * rather than this app's own tracking.
+	 * <p>
+	 * The distinction matters for honesty (#114): the OS count covers the battery's whole life, while
+	 * the app-tracked estimate only counts charge delivered since the app was installed — on an older
+	 * phone it starts at zero and therefore understates real wear. The insights screen labels the
+	 * health basis differently for the two sources.
+	 *
+	 * @param context Application context
+	 *
+	 * @return true when the OS reports a cycle count for this device
+	 */
+	public static boolean isCycleCountFromOs(final Context context) {
+		if (isNull(context)) {
+			return false;
+		}
+		return SystemService.getChargeCycleCount(context) > 0;
+	}
+
+	/**
 	 * Gets the number of debug-injected charge cycles (0 in normal use). Tracked separately from real
 	 * cycles so {@link #resetDebugData} can clear them without touching genuine tracking.
 	 *

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -115,9 +115,6 @@ public final class NotificationService {
 	 */
 	private static WeakReference<Bitmap> cachedLauncherIcon;
 
-	// Thread-safe healthy charge state
-	private static volatile boolean isHealthyCharge;
-
 	private NotificationService() {
 		// Utility class - prevent instantiation
 	}
@@ -164,13 +161,12 @@ public final class NotificationService {
 	 *   <li>{@link #CHARGE_STYLE_NONE} — nothing at all.</li>
 	 * </ul>
 	 *
-	 * @param context   The application context
-	 * @param speed     The estimated charging speed (may be {@link ChargeSpeed#unknown()})
-	 * @param wireless  true when charging over a wireless charger, false when wired
-	 * @param isHealthy true when charging started at a low battery level ("healthy" charge)
+	 * @param context  The application context
+	 * @param speed    The estimated charging speed (may be {@link ChargeSpeed#unknown()})
+	 * @param wireless true when charging over a wireless charger, false when wired
 	 */
 	public static void notifyChargeConnected(final Context context, final ChargeSpeed speed,
-	                                         final boolean wireless, final boolean isHealthy) {
+	                                         final boolean wireless) {
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 		final String style = resolveChargeStyle(prefs.getString(
 				context.getString(R.string._pref_key_charge_notification_style), CHARGE_STYLE_TOAST));
@@ -186,7 +182,7 @@ public final class NotificationService {
 			return;
 		}
 
-		postChargeNotification(context, content, isHealthy);
+		postChargeNotification(context, content);
 	}
 
 	/**
@@ -277,11 +273,10 @@ public final class NotificationService {
 	 * Plugging in during quiet hours shouldn't ding: shown on the silent channel outside the window
 	 * instead of the audible full-battery channel (issue #111).
 	 *
-	 * @param context   The application context
-	 * @param content   The charge message to display
-	 * @param isHealthy true when charging started at a low battery level ("healthy" charge)
+	 * @param context The application context
+	 * @param content The charge message to display
 	 */
-	private static void postChargeNotification(final Context context, final String content, final boolean isHealthy) {
+	private static void postChargeNotification(final Context context, final String content) {
 		if (lacksNotificationPermission(context)) {
 			Log.w(TAG, "Missing POST_NOTIFICATIONS permission, notification not sent");
 			return;
@@ -289,15 +284,9 @@ public final class NotificationService {
 
 		createNotificationChannels(context);
 
-		final String title = isHealthy
-		                     ? context.getString(R.string.notification_charge_started_title_healthy)
-		                     : context.getString(R.string.notification_charge_started_title_regular);
-
+		final String title = context.getString(R.string.notification_charge_started_title);
 		final String ticker = title.concat(", ").concat(content);
-
-		final int iconRes = isHealthy
-		                    ? R.drawable.ic_stat_device_battery_charging_20
-		                    : R.drawable.ic_stat_device_battery_charging_50;
+		final int iconRes = R.drawable.ic_stat_device_battery_charging_50;
 
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 		final boolean withinWindow = isWithinNotificationWindow(context, prefs);
@@ -520,17 +509,6 @@ public final class NotificationService {
 		if (nonNull(manager)) {
 			manager.notify(ONGOING_NOTIFICATION_ID, buildOngoingNotification(context, batteryDO, rate));
 		}
-	}
-
-	/**
-	 * Set healthy charge mode
-	 * <p>
-	 * Thread-safe setter for the healthy charge state flag.
-	 *
-	 * @param healthy true if charging in healthy mode
-	 */
-	public static void setIsHealthy(final boolean healthy) {
-		isHealthyCharge = healthy;
 	}
 
 	/**
@@ -1120,9 +1098,7 @@ public final class NotificationService {
 					this.iconRes = R.drawable.ic_stat_device_battery_charging_full;
 					this.alarmSound = prefs.getString(context.getString(R.string._pref_key_notifications_full_sound_ringtone), defaultSound);
 					this.ticker = context.getString(R.string.notification_full_level_ticker);
-					this.title = isHealthyCharge
-					             ? context.getString(R.string.notification_full_level_title_healthy)
-					             : context.getString(R.string.notification_full_level_title_regular);
+					this.title = context.getString(R.string.notification_full_level_title);
 					this.content = context.getString(R.string.notification_full_level_content);
 					this.bigContent = context.getString(R.string.notification_full_level_content_big);
 				}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -133,8 +133,15 @@ public class BatteryInsightsActivity extends BaseActivity {
 		healthStatusText.setText(BatteryHealthTracker.labelResId(grade));
 		healthStatusText.setTextColor(getHealthColor(grade));
 
-		// Tell the user whether the figure is measured (honest) or a cycle-based estimate
-		healthBasisText.setText(measured ? R.string.health_basis_measured : R.string.health_basis_estimated);
+		// Tell the user what the figure is based on. The cycle-based estimate distinguishes OS-reported
+		// cycles (whole battery life) from cycles this app tracked since install, which understate real
+		// wear on a phone older than the app (#114).
+		final int basisRes = measured
+		                     ? R.string.health_basis_measured
+		                     : BatteryHealthTracker.isCycleCountFromOs(this)
+		                       ? R.string.health_basis_estimated_os
+		                       : R.string.health_basis_estimated_tracked;
+		healthBasisText.setText(basisRes);
 
 		healthDescriptionText.setText(BatteryHealthTracker.describeHealthGrade(this, grade));
 	}

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -105,7 +105,7 @@
                             android:id="@+id/healthBasisText"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/health_basis_estimated"
+                            android:text="@string/health_basis_estimated_os"
                             android:textSize="12sp"
                             android:textColor="@color/battery_details_label_color"
                             android:layout_marginTop="4dp"/>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -2,11 +2,6 @@
     <string name="app_name">منبه البطارية البسيط</string>
     <string name="action_settings">الإعدادات</string>
     <string name="title_activity_settings">الإعدادات</string>
-    <string name="charger_connected">الشاحن موصول</string>
-    <string name="charger_connected_ac">AC charger connected</string>
-    <string name="charger_connected_usb">USB charger connected</string>
-    <string name="charger_connected_wireless">Wireless charger connected</string>
-    <string name="charger_disconnected">Charger Disconnected</string>
     <string name="charging">تشحن</string>
     <string name="discharging">تستهلك</string>
     <string name="not_charging">لا تشحن</string>
@@ -97,23 +92,21 @@
     <string name="critical_ignore_quiet_hours_summary_on">البطارية المنخفضة جداً تنبّهك حتى أثناء ساعات الهدوء</string>
     <string name="critical_ignore_quiet_hours_summary_off">التنبيهات الحرجة تبقى صامتة أثناء ساعات الهدوء</string>
 
-    <string name="notification_critical_ticker">مستوى حرج للبطارية أقل من %1$d%%</string>
-    <string name="notification_critical_title">وقت الشحن الصحي</string>
-    <string name="notification_critical_content">البطارية على وشك النفاذ (%1$d%%)</string>
-    <string name="notification_critical_content_big">البطارية في مستوى حرج وأقل من (%1$d%%)، حان الوقت لشحن الهاتف</string>
-    <string name="notification_warning_ticker">البطارية في منتصف الطريق، أقل من %1$d%%</string>
-    <string name="notification_warning_title">اقتصد في الاستخدام</string>
-    <string name="notification_warning_content">تحتاج فقط للانتباه للبطارية (%1$d%%)</string>
-    <string name="notification_warning_content_big">مستوى البطارية %1$d%%. لا تحتاج للشاحن بعد، لكن انتبه لاستهلاك البطارية</string>
-    <string name="notification_full_level_ticker">البطارية تم شحنها بالكامل، بإمكانك فصل الشاحن</string>
-    <string name="notification_full_level_title_healthy">الشحن الصحي اكتمل</string>
-    <string name="notification_full_level_title_regular">الشحن الاعتيادي اكتمل</string>
-    <string name="notification_full_level_content">استخدم هاتفك بحرية الآن</string>
-    <string name="notification_full_level_content_big">بإمكانك استخدام الهاتف الآن، ولا يضر إن أبقيت الشاحن، لا تخف لن تصاب البطارية بالتخمة 😋</string>
+    <!-- Alert copy reworked in #114: neutral titles and 20-80% guidance -->
+    <string name="notification_critical_ticker">البطارية منخفضة جداً — أقل من %1$d%%</string>
+    <string name="notification_critical_title">البطارية منخفضة جداً</string>
+    <string name="notification_critical_content">البطارية على وشك النفاد (%1$d%%)</string>
+    <string name="notification_critical_content_big">مستوى البطارية أقل من المستوى الحرج (%1$d%%) — حان وقت الشحن.</string>
+    <string name="notification_warning_ticker">البطارية أقل من %1$d%%</string>
+    <string name="notification_warning_title">البطارية بدأت تنخفض</string>
+    <string name="notification_warning_content">البطارية عند %1$d%% — انتبه لاستهلاكك</string>
+    <string name="notification_warning_content_big">مستوى البطارية %1$d%%. لا حاجة للشحن الآن — لكن حين يتيسّر لك، الشحن قبل أن تنخفض البطارية كثيراً أرفق بها.</string>
+    <string name="notification_full_level_ticker">اكتمل شحن البطارية — يمكنك فصل الشاحن الآن</string>
+    <string name="notification_full_level_title">اكتمل شحن البطارية</string>
+    <string name="notification_full_level_content">يمكنك فصل الشاحن الآن</string>
+    <string name="notification_full_level_content_big">اكتمل الشحن — يمكنك فصل الشاحن الآن. تتقادم البطاريات أسرع ما يكون عند إبقائها على 100%، لذا فصل الشاحن قريباً (والبقاء تقريباً بين 20% و80% في الاستخدام اليومي) يساعد بطاريتك على أن تدوم أطول.</string>
 
-    <string name="notification_charge_started_title_healthy">شحن صحي بدأ</string>
-    <string name="notification_charge_started_title_regular">شحن اعتيادي بدأ</string>
-    <string name="notification_charge_started_content">البطارية تشحن بواسطة %1$s</string>
+    <string name="notification_charge_started_title">بدأ الشحن</string>
 
     <!-- Charge-connected message (issue #122): charging speed + wired/wireless -->
     <string name="charge_source_wired">سلكي</string>
@@ -203,13 +196,15 @@
     <string name="clear">مسح</string>
     <string name="error_design_capacity_range">أدخل سعة بين %1$d و %2$d mAh</string>
     <string name="health_basis_measured">مقاسة من السعة المقدّرة</string>
-    <string name="health_basis_estimated">مقدّرة من دورات الشحن</string>
+    <!-- #114: cycle-based estimate labelled by its source -->
+    <string name="health_basis_estimated_os">مقدّرة من دورات الشحن (كما يبلغ عنها أندرويد)</string>
+    <string name="health_basis_estimated_tracked">مقدّرة من الدورات المتتبَّعة منذ التثبيت — التآكل الفعلي قد يكون أعلى</string>
     <!-- #94 unreliable battery-reading copy (drafted by Claude — pending maintainer review) -->
     <string name="battery_reading_unreliable_cd">لماذا قد تكون قراءة البطارية غير موثوقة</string>
     <string name="battery_reading_unreliable_dialog_title">قد تكون قراءة البطارية غير موثوقة</string>
     <string name="battery_reading_unreliable_dialog_message" formatted="false">يُبلّغ هذا الجهاز عن سعة شحن كاملة لا تُطابق السعة المقدّرة التي أدخلتها، لذا لا يمكن الوثوق بالسعة المقاسة — ولا بنسبة الصحة المبنية عليها.\n\nغالباً ما يكون هذا خللاً في عتاد بطارية الهاتف (إذ تُبلّغ بعض المعالجات عن عدّاد الشحن بصورة غير صحيحة)، وليس مشكلة في بطاريتك.\n\nلكن قد يعني ذلك أيضاً أنّ البطارية بدأت تتلف فعلاً. انتبه لهذه العلامات:\n\n• ينطفئ الهاتف أو يُعيد التشغيل تحت الحِمل الثقيل رغم وجود شحن كافٍ\n• ينخفض المستوى فجأة قرب النهاية، فيسلك مستوى 20% وكأنه 2%\n• ينفد الشحن أسرع بكثير من ذي قبل\n\nإذا لاحظت هذه العلامات، ففكّر في استبدال البطارية.</string>
     <string name="how_it_works">كيف يعمل</string>
-    <string name="how_battery_health_works" formatted="false" tools:ignore="TypographyDashes">تُقدَّر صحة البطارية بناءً على دورات الشحن. تُحتسب دورة شحن عندما تُشحن بطاريتك من 20% أو أقل إلى 95% أو أكثر. يبدأ هذا التتبع عند أول استخدام لهذا التطبيق.\n\nتقديرات الصحة:\n• 0–300 دورة: ممتازة (95–100%)\n• 300-500 دورة: جيدة (85-95%)\n• 500-800 دورة: مقبولة (70-85%)\n• 800+ دورة: ضعيفة (&lt;70%)</string>
+    <string name="how_battery_health_works" formatted="false" tools:ignore="TypographyDashes">تُعرض صحة البطارية من أفضل أساس متاح:\n\n• مقاسة — عند إدخال السعة المقدّرة لبطاريتك، تكون الصحة هي السعة الكاملة المقاسة مقسومة على السعة المقدّرة. الأساس الأدق.\n• دورات الشحن (كما يبلغ عنها أندرويد) — بعض الأجهزة تبلغ عن عدد دورات البطارية طوال عمرها؛ عندها تُقدَّر الصحة من منحنى تآكل نموذجي لبطاريات الليثيوم.\n• دورات الشحن (المتتبَّعة بواسطة هذا التطبيق) — خلاف ذلك تُحتسب الدورات من الشحن الموصول منذ تثبيت التطبيق (100 نقطة مئوية = دورة واحدة)، لذا على هاتف أقدم من التطبيق تُقلِّل من التآكل الفعلي.\n\nتستخدم التقديرات المبنية على الدورات منحنى عاماً — العمر الفعلي للدورات يختلف حسب المصنّع والخلية، سواء كانت التسمية Li-ion أو Li-Po:\n• 0–300 دورة: ممتازة (95–100%)\n• 300–500 دورة: جيدة (85–95%)\n• 500–800 دورة: مقبولة (70–85%)\n• 800+ دورة: ضعيفة (&lt;70%)\n\nنصيحة: تدوم بطاريات الليثيوم أطول عند إبقائها تقريباً بين 20% و80% وبعيداً عن الحرارة — الشحن المعتاد إلى 100% والتفريغ العميق كلاهما يزيد التآكل.</string>
     <string name="developed_by">طوّره</string>
     <!-- Proper name — transliteration; maintainer to confirm or keep Latin -->
     <string name="developer_name">المظفّر الحسن</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,11 +2,6 @@
     <string name="app_name">Simple Battery Notifier</string>
     <string name="action_settings">Settings</string>
     <string name="title_activity_settings">Settings</string>
-    <string name="charger_connected">Charger connected</string>
-    <string name="charger_connected_ac">AC charger connected</string>
-    <string name="charger_connected_usb">USB charger connected</string>
-    <string name="charger_connected_wireless">Wireless charger connected</string>
-    <string name="charger_disconnected">Charger Disconnected</string>
     <string name="charging">Charging</string>
     <string name="discharging">Discharging</string>
     <string name="not_charging">Not Charging</string>
@@ -101,23 +96,22 @@
     <string name="critical_ignore_quiet_hours_summary_on">A critically low battery still alerts during quiet hours</string>
     <string name="critical_ignore_quiet_hours_summary_off">Critical alerts stay silent during quiet hours</string>
 
-    <string name="notification_critical_ticker">Your battery in critical level and below %1$d%%</string>
-    <string name="notification_critical_title">Healthy charge time</string>
-    <string name="notification_critical_content">Battery almost run out of power (%1$d%%)</string>
-    <string name="notification_critical_content_big">Your battery level is below critical level (%1$d%%), its time to connect your charger</string>
-    <string name="notification_warning_ticker">Your battery in midway and below %1$d%%</string>
-    <string name="notification_warning_title">Watch your usage</string>
-    <string name="notification_warning_content">You just need to watch your usage (%1$d%%)</string>
-    <string name="notification_warning_content_big">Battery level is at %1$d%%. You just need to watch your usage for your smartphone, but still no need for charger now</string>
-    <string name="notification_full_level_ticker">Your battery fully charged, you can disconnect your charger</string>
-    <string name="notification_full_level_title_healthy">Healthy charge completed</string>
-    <string name="notification_full_level_title_regular">Regular charge completed</string>
-    <string name="notification_full_level_content">You can use your phone</string>
-    <string name="notification_full_level_content_big">You can use your phone, you may disconnect your charger, or keep it and don\'t worry the battery will not get indigestion 😋</string>
+    <!-- Alert copy reworked in #114: neutral titles (the "healthy/regular" flip is retired) and
+         guidance aligned with the 20-80% advice instead of encouraging staying at 100%. -->
+    <string name="notification_critical_ticker">Battery critically low — below %1$d%%</string>
+    <string name="notification_critical_title">Battery critically low</string>
+    <string name="notification_critical_content">Battery almost empty (%1$d%%)</string>
+    <string name="notification_critical_content_big">Your battery is below the critical level (%1$d%%) — time to plug in.</string>
+    <string name="notification_warning_ticker">Battery below %1$d%%</string>
+    <string name="notification_warning_title">Battery getting low</string>
+    <string name="notification_warning_content">Battery at %1$d%% — keep an eye on your usage</string>
+    <string name="notification_warning_content_big">Battery level is at %1$d%%. No need to charge yet — but when it\'s convenient, plugging in before the battery runs very low is easiest on it.</string>
+    <string name="notification_full_level_ticker">Battery fully charged — you can unplug now</string>
+    <string name="notification_full_level_title">Battery fully charged</string>
+    <string name="notification_full_level_content">You can unplug your charger now</string>
+    <string name="notification_full_level_content_big">Charge complete — you can unplug now. Batteries age fastest when kept at 100%, so unplugging soon (and staying roughly between 20% and 80% day to day) helps the battery last longer.</string>
 
-    <string name="notification_charge_started_title_healthy">Healthy charging started</string>
-    <string name="notification_charge_started_title_regular">Regular charging started</string>
-    <string name="notification_charge_started_content">Battery charging with %1$s </string>
+    <string name="notification_charge_started_title">Charging started</string>
 
     <!-- Charge-connected message (issue #122): reports charging speed + wired/wireless instead of
          the old, unreliable "AC charger connected". -->
@@ -212,7 +206,10 @@
     <string name="clear">Clear</string>
     <string name="error_design_capacity_range">Enter a capacity between %1$d and %2$d mAh</string>
     <string name="health_basis_measured">Measured from rated capacity</string>
-    <string name="health_basis_estimated">Estimated from charge cycles</string>
+    <!-- #114: the cycle-based estimate is labelled by its source. OS-reported cycles cover the
+         battery's whole life; app-tracked cycles start at install, so they understate real wear. -->
+    <string name="health_basis_estimated_os">Estimated from charge cycles (reported by Android)</string>
+    <string name="health_basis_estimated_tracked">Estimated from cycles tracked since install — real wear may be higher</string>
 
     <!-- #94: shown when the device's charge counter is too inaccurate to trust the capacity/health reading.
          Shared by the home Capacity row ("Unknown" + info icon) and the insights health figure (warning icon). -->
@@ -230,7 +227,7 @@
     <string name="battery_health_desc_fair">Your battery shows moderate wear. You may notice slightly reduced battery life.</string>
     <string name="battery_health_desc_poor">Your battery has significant wear. Consider battery replacement if experiencing poor performance.</string>
     <string name="how_it_works">How It Works</string>
-    <string name="how_battery_health_works" formatted="false" tools:ignore="TypographyDashes">Battery health is estimated based on charge cycles. A charge cycle counts when your battery charges from 20% or below to 95% or above. This tracking starts when you first use this app.\n\nHealth estimates:\n• 0–300 cycles: Excellent (95–100%)\n• 300-500 cycles: Good (85-95%)\n• 500-800 cycles: Fair (70-85%)\n• 800+ cycles: Poor (&lt;70%)</string>
+    <string name="how_battery_health_works" formatted="false" tools:ignore="TypographyDashes">Battery health is shown from the best available basis:\n\n• Measured — when you set your battery\'s rated capacity, health is the measured full capacity divided by the rated capacity. The most accurate basis.\n• Charge cycles (reported by Android) — some devices report the battery\'s lifetime cycle count; health is then estimated from a typical lithium-ion wear curve.\n• Charge cycles (tracked by this app) — otherwise, cycles are counted from the charge delivered since the app was installed (100 percentage-points = 1 cycle), so on a phone older than the app it understates real wear.\n\nCycle-based estimates use a generic curve — real cycle life varies by manufacturer and cell, whether the label says Li-ion or Li-Po:\n• 0–300 cycles: Excellent (95–100%)\n• 300–500 cycles: Good (85–95%)\n• 500–800 cycles: Fair (70–85%)\n• 800+ cycles: Poor (&lt;70%)\n\nTip: lithium batteries last longest kept roughly between 20% and 80% and away from heat — habitually charging to 100% and deep discharges both add wear.</string>
     <string name="developed_by">Developed by</string>
     <string name="developer_name">Al-Mothafar Al-Hasan</string>
     <string name="developer_link" translatable="false">github.com/almothafar</string>

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiverTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.never;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
- * Robolectric + Mockito tests for {@link PowerConnectionReceiver}: wired/wireless detection, the
- * healthy-charge flag, plugged-state de-duplication, and the disconnect cleanup path. The
+ * Robolectric + Mockito tests for {@link PowerConnectionReceiver}: wired/wireless detection,
+ * plugged-state de-duplication, and the disconnect cleanup path. The
  * {@link NotificationService} static methods are mocked so we can assert what the receiver decides
  * to do from the sticky {@code ACTION_BATTERY_CHANGED} intent.
  * <p>
@@ -59,8 +59,7 @@ public class PowerConnectionReceiverTest {
 			receive();
 			runPendingSample();
 			ns.verify(() -> NotificationService.notifyChargeConnected(any(Context.class),
-					any(ChargeSpeed.class), eq(false), eq(false)));
-			ns.verify(() -> NotificationService.setIsHealthy(false));
+					any(ChargeSpeed.class), eq(false)));
 		}
 	}
 
@@ -72,20 +71,19 @@ public class PowerConnectionReceiverTest {
 			receive();
 			runPendingSample();
 			ns.verify(() -> NotificationService.notifyChargeConnected(any(Context.class),
-					any(ChargeSpeed.class), eq(true), eq(false)));
+					any(ChargeSpeed.class), eq(true)));
 		}
 	}
 
 	@Test
-	public void connectedAtLowBattery_marksChargeHealthy() {
+	public void connectedAtLowBattery_notifiesLikeAnyOtherLevel() {
 		publishBattery(BatteryManager.BATTERY_PLUGGED_USB, 10, 100);
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
 			runPendingSample();
-			ns.verify(() -> NotificationService.setIsHealthy(true));
 			ns.verify(() -> NotificationService.notifyChargeConnected(any(Context.class),
-					any(ChargeSpeed.class), eq(false), eq(true)));
+					any(ChargeSpeed.class), eq(false)));
 		}
 	}
 
@@ -98,7 +96,7 @@ public class PowerConnectionReceiverTest {
 			receive();
 			runPendingSample();
 			ns.verify(() -> NotificationService.notifyChargeConnected(any(Context.class),
-					any(ChargeSpeed.class), anyBoolean(), anyBoolean()), never());
+					any(ChargeSpeed.class), anyBoolean()), never());
 		}
 	}
 
@@ -112,7 +110,7 @@ public class PowerConnectionReceiverTest {
 			runPendingSample();
 			ns.verify(() -> NotificationService.clearNotifications(any(Context.class)));
 			ns.verify(() -> NotificationService.notifyChargeConnected(any(Context.class),
-					any(ChargeSpeed.class), anyBoolean(), anyBoolean()), never());
+					any(ChargeSpeed.class), anyBoolean()), never());
 		}
 	}
 


### PR DESCRIPTION
Closes #114.

## What changed

Both decisions settled with the maintainer in-session (recorded in the issue body).

**Part A — health basis honesty.** The Insights figure already prefers the measured basis (capacity ÷ rated capacity); the misleading case was the cycle fallback, whose app-tracked count starts at zero on install and understates wear on any phone older than the app:

- Basis caption now distinguishes the cycle source: *"Estimated from charge cycles (reported by Android)"* vs *"Estimated from cycles tracked since install — real wear may be higher"* (new `BatteryHealthTracker.isCycleCountFromOs()`).
- "How it works" rewritten: explains all three bases, notes the curve is a generic lithium-ion approximation (real cycle life varies by manufacturer and cell, Li-ion and Li-Po alike — no chemistry branching, `EXTRA_TECHNOLOGY` is unreliable free-text), and adds the 20–80 care tip.

**Part B — retire the "healthy charge" concept.** Plugging in at ≤20% no longer flips notification titles; the plumbing (`HEALTHY_CHARGE_THRESHOLD`, `setIsHealthy`, title pairs) is deleted:

- Neutral titles: "Charging started", "Battery fully charged"; critical title "Healthy charge time" → "Battery critically low".
- Full-charge text now nudges unplugging (the old text encouraged staying plugged at 100%).
- Grammar pass on warning/critical/full copy; six dead pre-#122 charger strings removed.
- All copy mirrored in values-ar. "Unplug at X%" reminder stays out of scope (#115).

## Verification

`PowerConnectionReceiverTest` updated for the simplified `notifyChargeConnected` signature. In-session checks were static (env can't build, #137): no dangling references to removed strings/symbols, values ↔ values-ar parity, XML validity. CI on this PR is the compile + test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)