### PR TITLE
Fix lintDebug: formatted="false" on notification_full_level_content_big (#146)

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -104,7 +104,7 @@
     <string name="notification_full_level_ticker">اكتمل شحن البطارية — يمكنك فصل الشاحن الآن</string>
     <string name="notification_full_level_title">اكتمل شحن البطارية</string>
     <string name="notification_full_level_content">يمكنك فصل الشاحن الآن</string>
-    <string name="notification_full_level_content_big">اكتمل الشحن — يمكنك فصل الشاحن الآن. تتقادم البطاريات أسرع ما يكون عند إبقائها على 100%، لذا فصل الشاحن قريباً (والبقاء تقريباً بين 20% و80% في الاستخدام اليومي) يساعد بطاريتك على أن تدوم أطول.</string>
+    <string name="notification_full_level_content_big" formatted="false">اكتمل الشحن — يمكنك فصل الشاحن الآن. تتقادم البطاريات أسرع ما يكون عند إبقائها على 100%، لذا فصل الشاحن قريباً (والبقاء تقريباً بين 20% و80% في الاستخدام اليومي) يساعد بطاريتك على أن تدوم أطول.</string>
 
     <string name="notification_charge_started_title">بدأ الشحن</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,7 +109,7 @@
     <string name="notification_full_level_ticker">Battery fully charged — you can unplug now</string>
     <string name="notification_full_level_title">Battery fully charged</string>
     <string name="notification_full_level_content">You can unplug your charger now</string>
-    <string name="notification_full_level_content_big">Charge complete — you can unplug now. Batteries age fastest when kept at 100%, so unplugging soon (and staying roughly between 20% and 80% day to day) helps the battery last longer.</string>
+    <string name="notification_full_level_content_big" formatted="false">Charge complete — you can unplug now. Batteries age fastest when kept at 100%, so unplugging soon (and staying roughly between 20% and 80% day to day) helps the battery last longer.</string>
 
     <string name="notification_charge_started_title">Charging started</string>
 


### PR DESCRIPTION
Fixes #146.

`./gradlew lintDebug` is currently **red on master** — 4 `StringFormatInvalid` errors, a regression from #114.

## Cause
`notification_full_level_content_big` is shown via `NotificationService` → `getString(...)` with **no format args**, so its literal `%` signs (100%, 20%, 80%) should print verbatim. Lint reads them as malformed format specifiers.

Its two siblings from the same #114 PR — `how_battery_health_works` and `battery_reading_unreliable_dialog_message` — already carry `formatted="false"` for the identical "20% and 80%" wording. This one just missed it.

## Fix
Add `formatted="false"` in both `values/strings.xml` and `values-ar/strings.xml`. One attribute, two lines, no wording/behaviour change.

## Verified
- `./gradlew lintDebug` → **BUILD SUCCESSFUL** (was 4 errors)

## Note (out of scope)
CI runs tests + `assembleDebug` + `assembleRelease` but **not** `lintDebug`, which is why this slipped through. Adding lint to CI is a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)