### PR TITLE
Slow-charge warning: detect frayed cable / dying charger (#123)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -13,6 +13,7 @@ import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.BatteryRateTracker;
 import com.almothafar.simplebatterynotifier.service.FastDrainDetector;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
+import com.almothafar.simplebatterynotifier.service.SlowChargeDetector;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 
@@ -106,6 +107,10 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 
 		// #109: warn when the (smoothed #108) drain rate stays abnormally high for a sustained time.
 		FastDrainDetector.evaluate(context, batteryDO, rate);
+
+		// #123: warn when charging power stays abnormally low for a sustained time (frayed cable, dirty
+		// port, or dying charger). Independent of the drain rate — it reads the estimated charge wattage.
+		SlowChargeDetector.evaluate(context, batteryDO);
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
@@ -412,6 +412,45 @@ public final class BatteryRateTracker {
 	}
 
 	/**
+	 * Estimated minutes until full from the smoothed charge rate (#124): a capacity-free linear projection,
+	 * {@code (100 − level) / ratePercentPerHour} hours, so it works even where the charge counter is
+	 * unreliable (Kirin). Deliberately simple — it does <b>not</b> model the charge-curve taper above ~80%,
+	 * so it overshoots near full; precision is a non-goal (the OS owns the accurate figure). Callers gate on
+	 * charging + a trustworthy rate + a level below the taper top before showing it. Pure so it is testable.
+	 *
+	 * @param level              current battery level (0-100)
+	 * @param ratePercentPerHour smoothed charge-rate magnitude in %/h
+	 *
+	 * @return estimated minutes to full, or 0 when not computable (non-positive rate, or already at/above full)
+	 */
+	public static int estimateMinutesToFull(final int level, final int ratePercentPerHour) {
+		if (ratePercentPerHour <= 0 || level >= 100) {
+			return 0;
+		}
+		final int remaining = 100 - level;
+		return (int) Math.round(remaining * 60.0 / ratePercentPerHour);
+	}
+
+	/**
+	 * Formats a time-to-full estimate as a compact {@code "~1h 20m"} / {@code "~45m"}, with Western digits
+	 * in every locale (#96). The units stay Latin (h/m), matching {@code battery_rate_value} and
+	 * {@code design_capacity_value}.
+	 *
+	 * @param context      Application context
+	 * @param totalMinutes estimated minutes to full (from {@link #estimateMinutesToFull}); must be &gt; 0
+	 *
+	 * @return the formatted duration string
+	 */
+	public static String formatTimeToFull(final Context context, final int totalMinutes) {
+		final int hours = totalMinutes / 60;
+		final int minutes = totalMinutes % 60;
+		if (hours > 0) {
+			return context.getString(R.string.time_to_full_value_hm, String.valueOf(hours), String.valueOf(minutes));
+		}
+		return context.getString(R.string.time_to_full_value_m, String.valueOf(minutes));
+	}
+
+	/**
 	 * Serializes a window to a compact string ("t:level:currentUa" joined by ';'). Pure and testable.
 	 *
 	 * @param window samples oldest-first

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -69,6 +69,7 @@ public final class NotificationService {
 	private static final String CHANNEL_ID_STATUS = "battery_status";
 	private static final String CHANNEL_ID_TEMPERATURE = "battery_temperature";
 	private static final String CHANNEL_ID_FAST_DRAIN = "battery_fast_drain";
+	private static final String CHANNEL_ID_SLOW_CHARGE = "battery_slow_charge";
 	// Silent, low-importance channel used to deliver an alert quietly during the user's quiet hours:
 	// the alert is still visible but makes no sound or vibration (issue #111).
 	private static final String CHANNEL_ID_ALERTS_SILENT = "battery_alerts_quiet";
@@ -82,6 +83,8 @@ public final class NotificationService {
 	private static final int TEMPERATURE_NOTIFICATION_ID = 1641989;
 	// Separate ID so a fast-drain alert doesn't replace a level or temperature alert (#109)
 	private static final int FAST_DRAIN_NOTIFICATION_ID = 1641990;
+	// Separate ID so a slow-charge warning doesn't replace any other alert (#123)
+	private static final int SLOW_CHARGE_NOTIFICATION_ID = 1641991;
 
 	// Do Not Disturb mode constants
 	private static final String ZEN_MODE = "zen_mode";
@@ -363,6 +366,43 @@ public final class NotificationService {
 	}
 
 	/**
+	 * Warn that charging power has stayed abnormally low — a likely frayed cable, dirty/loose port, or
+	 * dying charger (issue #123).
+	 * <p>
+	 * Surfaced per the user's charge-notification style (#122): a brief toast, a full quiet-hours-aware
+	 * notification on its own channel/id, or nothing when they opted out of charge feedback. The message
+	 * states the measured wattage so it explains itself; it deliberately can't tell cable from port from
+	 * brick (indistinguishable via public APIs), so it advises checking all three.
+	 *
+	 * @param context The application context
+	 * @param watts   The estimated charging power in watts
+	 */
+	public static void sendSlowChargeWarning(final Context context, final int watts) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		final String style = resolveChargeStyle(prefs.getString(
+				context.getString(R.string._pref_key_charge_notification_style), CHARGE_STYLE_TOAST));
+		if (CHARGE_STYLE_NONE.equals(style)) {
+			return; // the user opted out of charge feedback entirely
+		}
+
+		// Western digits in every locale (#96) via String.valueOf.
+		final String content = context.getString(R.string.notification_slow_charge_content, String.valueOf(watts));
+		if (CHARGE_STYLE_TOAST.equals(style)) {
+			showChargeToast(context, content);
+			return;
+		}
+		sendQuietHoursAwareAlert(context, new AlertSpec(
+				"slow-charge",
+				CHANNEL_ID_SLOW_CHARGE,
+				SLOW_CHARGE_NOTIFICATION_ID,
+				R.drawable.ic_stat_device_battery_charging_20,
+				context.getString(R.string.notification_slow_charge_ticker),
+				context.getString(R.string.notification_slow_charge_title),
+				content,
+				context.getString(R.string.notification_slow_charge_content_big, String.valueOf(watts))));
+	}
+
+	/**
 	 * Send an alert on its own channel and notification ID, honouring quiet hours, silent-mode and
 	 * vibrate preferences.
 	 * <p>
@@ -585,6 +625,9 @@ public final class NotificationService {
 		createChannelIfNotExists(manager, CHANNEL_ID_FAST_DRAIN,
 				context.getString(R.string.notification_fast_drain_channel_name),
 				context.getString(R.string.notification_fast_drain_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
+		createChannelIfNotExists(manager, CHANNEL_ID_SLOW_CHARGE,
+				context.getString(R.string.notification_slow_charge_channel_name),
+				context.getString(R.string.notification_slow_charge_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
 		createSilentChannelIfNotExists(manager, CHANNEL_ID_STATUS,
 				context.getString(R.string.notification_status_channel_name),
 				context.getString(R.string.notification_status_channel_description));
@@ -672,6 +715,7 @@ public final class NotificationService {
 		manager.deleteNotificationChannel(CHANNEL_ID_FULL);
 		manager.deleteNotificationChannel(CHANNEL_ID_TEMPERATURE);
 		manager.deleteNotificationChannel(CHANNEL_ID_FAST_DRAIN);
+		manager.deleteNotificationChannel(CHANNEL_ID_SLOW_CHARGE);
 		createNotificationChannels(context);
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -1001,6 +1001,15 @@ public final class NotificationService {
 		if (!showRate) {
 			return statusLabel;
 		}
+		// While charging, humans think in charger speed, not %/h — show the estimated tier + wattage when we
+		// can (#125). The ChargeSpeed read (CURRENT_NOW × voltage) is charging-only, so the discharging path
+		// below is untouched; it falls through to the %/h → mA → plain chain when the speed can't be estimated.
+		if (rate.charging()) {
+			final String chargingSpeed = chargingSpeedSegment(context);
+			if (nonNull(chargingSpeed)) {
+				return chargingSpeed;
+			}
+		}
 		if (rate.hasRate()) {
 			return statusLabel + " " + BatteryRateTracker.formatRateValue(context, rate.percentPerHour());
 		}
@@ -1008,6 +1017,30 @@ public final class NotificationService {
 			return statusLabel + " " + BatteryRateTracker.formatCurrentValue(context, rate.currentMilliAmps());
 		}
 		return statusLabel;
+	}
+
+	/**
+	 * The charging-speed segment for the ongoing status notification — the estimated tier and wattage, e.g.
+	 * "Fast charging · ~18 W", or just the tier ("Slow charging") when the wattage rounds below 1 W (#125).
+	 * The tier label already reads as "… charging", so it replaces the plain "Charging" status word rather
+	 * than being appended to it. Returns null when the speed can't be estimated (e.g. a device that doesn't
+	 * report {@code CURRENT_NOW}), so the caller falls back to the %/h → mA → plain chain.
+	 *
+	 * @param context The application context
+	 * @return the formatted charging-speed segment, or null when the charge speed is unknown
+	 */
+	private static String chargingSpeedSegment(final Context context) {
+		final ChargeSpeed speed = SystemService.getChargeSpeed(context);
+		if (!speed.isKnown()) {
+			return null;
+		}
+		final String tierLabel = context.getString(tierLabelRes(speed.getTier()));
+		final int watts = speed.getWatts();
+		if (watts < 1) {
+			return tierLabel; // sub-watt (e.g. trickle): "~0 W" would read as an error
+		}
+		// %2$s via String.valueOf keeps the wattage in Western digits (0-9) in every locale (#96).
+		return context.getString(R.string.notification_status_charge_power, tierLabel, String.valueOf(watts));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
@@ -1,0 +1,216 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.BatteryManager;
+import androidx.preference.PreferenceManager;
+
+import com.almothafar.simplebatterynotifier.R;
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
+import com.almothafar.simplebatterynotifier.model.ChargeSpeed;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Warns when charging power stays abnormally low for a <em>sustained</em> time (issue #123) — a strong
+ * signal of a frayed cable, a dirty/loose port, or a dying charger.
+ * <p>
+ * The alerting layer on top of the estimated charging power from {@link ChargeSpeed} (#122). Like the
+ * fast-drain alert (#109) it needs no per-app data and adds <b>no new timer</b>: it is evaluated on the
+ * {@code ACTION_BATTERY_CHANGED} broadcasts that already flow while charging.
+ * <p>
+ * <b>Why each guard exists (the false-positive traps):</b>
+ * <ul>
+ *   <li><b>Taper near full</b> — every charger deliberately trickles above ~80%, so the level gate keeps
+ *       this to {@code < 80%}.</li>
+ *   <li><b>Deliberate pauses</b> — thermal throttling and battery-protect caps report {@code NOT_CHARGING}
+ *       rather than {@code CHARGING}; the status gate skips them (they <em>sleep</em>, they don't clear the
+ *       streak).</li>
+ *   <li><b>Unknown charger capability</b> — no API exposes the brick's rating, so the floor sits below the
+ *       weakest legitimate charger (~2.5 W wired): sustained power under it while low basically only means a
+ *       damaged cable / dirty port / dying brick.</li>
+ * </ul>
+ * <b>Once per charge session:</b> it warns a single time, then stays quiet until the power recovers above
+ * the floor (re-arm) or the charger is disconnected (state cleared). The pure {@link #decide} core is
+ * unit-tested; the streak is persisted so it survives process restarts, like {@link FastDrainDetector}.
+ * <p>
+ * v2 — session-relative collapse detection (18 W → 4 W and stuck, which this absolute floor can't see) — is
+ * tracked separately in #132 and deliberately not built here.
+ */
+public final class SlowChargeDetector {
+
+	// Persisted streak/hysteresis state (survives process restarts).
+	private static final String PREF_STREAK_START = "_slow_charge_streak_start";
+	private static final String PREF_ALERTED = "_slow_charge_alerted";
+	private static final String PREF_LAST_SEEN_BELOW = "_slow_charge_last_seen_below";
+
+	// Trickle floor: sustained wired power below this while charging low is the damaged-cable signal. It
+	// sits below the weakest legitimate charger (a 5 W cube at 5 W is fine), so genuine chargers never trip
+	// it — the floor is deliberately conservative to keep v1 nearly false-positive-free.
+	static final int FLOOR_MILLIWATTS = 2_500;   // 2.5 W
+	// Above this level the charger deliberately tapers, so low power is expected — not a fault.
+	static final int MAX_LEVEL_PERCENT = 80;
+	// How long the power must stay below the floor before warning. A constant in v1 (not user-tunable, per
+	// the issue): long enough that a brief post-plug dip or a single noisy reading can't trip it.
+	static final long SUSTAINED_MS = 3L * 60 * 1000;
+
+	// The streak survives a brief data gap but not a long one (process death, doze, an unusable reading):
+	// past this the "sustained" claim is unverifiable, so a fresh episode starts rather than an inflated
+	// duration. Same bound as the rate window, mirroring FastDrainDetector.
+	static final long MAX_OBSERVATION_GAP_MS = BatteryRateTracker.WINDOW_MS;
+
+	private static final SlowChargeState CLEARED = new SlowChargeState(0, false, 0);
+
+	private SlowChargeDetector() {
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Evaluates the slow-charge rule against the current snapshot and warns once per session when charging
+	 * power stays below the floor. Called from
+	 * {@link com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver} on each battery broadcast,
+	 * next to the fast-drain wiring — no timer of its own.
+	 *
+	 * @param context   Application context
+	 * @param batteryDO Current battery snapshot (may be null)
+	 */
+	public static void evaluate(final Context context, final BatteryDO batteryDO) {
+		if (isNull(context) || isNull(batteryDO)) {
+			return;
+		}
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		final boolean enabled = prefs.getBoolean(context.getString(R.string._pref_key_notify_slow_charge), true);
+		final int status = batteryDO.getStatus();
+
+		// Session boundary: only an active or thermally-paused charge is a candidate. Discharging, full,
+		// unknown or unplugged ends the session and re-arms for next time.
+		if (!enabled || (status != BatteryManager.BATTERY_STATUS_CHARGING
+				&& status != BatteryManager.BATTERY_STATUS_NOT_CHARGING)) {
+			clearState(prefs);
+			return;
+		}
+
+		// Not eligible to fire right now, but the session continues → sleep (hold the streak, don't warn):
+		// a thermal/battery-protect pause (NOT_CHARGING), the deliberate taper above 80%, or wireless (v1
+		// judges wired charging only). The observation-gap lapse in decide() still resets a long-stale streak.
+		final int level = Math.round(batteryDO.getBatteryPercentage());
+		final boolean wired = batteryDO.getPlugged() != BatteryManager.BATTERY_PLUGGED_WIRELESS;
+		if (status != BatteryManager.BATTERY_STATUS_CHARGING || !wired || level >= MAX_LEVEL_PERCENT) {
+			return;
+		}
+
+		final ChargeSpeed speed = SystemService.getChargeSpeed(context);
+		final long now = System.currentTimeMillis();
+		final SlowChargeState previous = loadState(prefs);
+		final SlowChargeDecision decision = decide(previous, speed.isKnown(), speed.getMilliwatts(),
+				FLOOR_MILLIWATTS, SUSTAINED_MS, now);
+
+		// Persist only on change: an eligible-but-healthy charge re-decides CLEARED on every broadcast, and
+		// rewriting identical state would churn SharedPreferences for nothing.
+		if (!decision.newState().equals(previous)) {
+			saveState(prefs, decision.newState());
+		}
+		if (decision.shouldNotify()) {
+			NotificationService.sendSlowChargeWarning(context, speed.getWatts());
+		}
+	}
+
+	/**
+	 * Pure decision core, unit-testable with no Android dependencies. The caller has already confirmed
+	 * eligibility (charging, wired, below the taper level); this decides purely on the power vs the floor
+	 * and the sustained streak.
+	 * <ul>
+	 *   <li><b>Power unknown</b> (a device without {@code CURRENT_NOW}, or a blank reading): <em>sleep</em> —
+	 *       no warning, streak untouched, so a brief gap doesn't reset it. The observation-gap lapse still
+	 *       bounds continuity so a long gap can't later fire an inflated duration.</li>
+	 *   <li><b>Power at/above the floor</b>: the charge is healthy → re-arm (clear the streak + alerted), so
+	 *       a later collapse warns again (hysteresis).</li>
+	 *   <li><b>Power below the floor</b>: start the streak if new; once it has held for the window, fire the
+	 *       single warning for this charge session.</li>
+	 * </ul>
+	 *
+	 * @param state       current persisted state
+	 * @param powerKnown  whether the charge power could be estimated this tick
+	 * @param milliwatts  the estimated charge power in mW (valid when {@code powerKnown})
+	 * @param floorMw     the trickle floor in mW
+	 * @param sustainedMs how long the power must stay below the floor before warning
+	 * @param nowMillis   current time in millis
+	 *
+	 * @return whether to warn now, and the new state to persist
+	 */
+	static SlowChargeDecision decide(final SlowChargeState state,
+	                                 final boolean powerKnown,
+	                                 final int milliwatts,
+	                                 final int floorMw,
+	                                 final long sustainedMs,
+	                                 final long nowMillis) {
+		if (!powerKnown) {
+			return new SlowChargeDecision(false, state); // sleep — keep the streak, don't warn
+		}
+		if (milliwatts >= floorMw) {
+			return new SlowChargeDecision(false, CLEARED); // healthy power — re-arm the session
+		}
+
+		// Continuity: after a long observation gap the "sustained" claim has lapsed — start a fresh episode
+		// rather than warn immediately with a duration built on unobserved time.
+		final boolean lapsed = state.streakStart() != 0
+				&& nowMillis - state.lastSeenBelow() > MAX_OBSERVATION_GAP_MS;
+		final long start = (state.streakStart() == 0 || lapsed) ? nowMillis : state.streakStart();
+		final long elapsed = nowMillis - start;
+		boolean alerted = !lapsed && state.alerted();
+		boolean notify = false;
+
+		if (elapsed >= sustainedMs && !alerted) {
+			notify = true;      // the single warning for this charge session
+			alerted = true;
+		}
+		return new SlowChargeDecision(notify, new SlowChargeState(start, alerted, nowMillis));
+	}
+
+	private static SlowChargeState loadState(final SharedPreferences prefs) {
+		return new SlowChargeState(
+				prefs.getLong(PREF_STREAK_START, 0),
+				prefs.getBoolean(PREF_ALERTED, false),
+				prefs.getLong(PREF_LAST_SEEN_BELOW, 0));
+	}
+
+	private static void saveState(final SharedPreferences prefs, final SlowChargeState state) {
+		prefs.edit()
+		     .putLong(PREF_STREAK_START, state.streakStart())
+		     .putBoolean(PREF_ALERTED, state.alerted())
+		     .putLong(PREF_LAST_SEEN_BELOW, state.lastSeenBelow())
+		     .apply();
+	}
+
+	/**
+	 * Clears the streak only when it isn't already clear, so the common non-eligible broadcasts don't churn
+	 * SharedPreferences on every tick.
+	 *
+	 * @param prefs the shared preferences
+	 */
+	private static void clearState(final SharedPreferences prefs) {
+		if (!loadState(prefs).equals(CLEARED)) {
+			saveState(prefs, CLEARED);
+		}
+	}
+
+	/**
+	 * Persisted streak/hysteresis state.
+	 *
+	 * @param streakStart   when the power first dropped below the floor this episode (0 = no active streak)
+	 * @param alerted       whether the one warning has fired this charge session
+	 * @param lastSeenBelow when the power was last observed below the floor; a gap longer than
+	 *                      {@link #MAX_OBSERVATION_GAP_MS} lapses the streak (continuity unverifiable)
+	 */
+	record SlowChargeState(long streakStart, boolean alerted, long lastSeenBelow) {
+	}
+
+	/**
+	 * Result of {@link #decide}: whether to warn now, and the new state to persist.
+	 *
+	 * @param shouldNotify whether to send the warning now
+	 * @param newState     the state to persist
+	 */
+	record SlowChargeDecision(boolean shouldNotify, SlowChargeState newState) {
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -383,10 +383,38 @@ public class BatteryDetailsFragment extends Fragment {
 			valuesMap.put(rateLabel, BatteryRateTracker.formatRateValue(view.getContext(), rate.percentPerHour()));
 			rateValueColor = rateColor(view.getContext(), rate);
 		}
+		addTimeToFullRow(view, rate);
 		if (rate.hasCurrent()) {
 			valuesMap.put(getResources().getString(R.string.battery_current),
 					BatteryRateTracker.formatCurrentValue(view.getContext(), rate.currentMilliAmps()));
 		}
+	}
+
+	/**
+	 * Adds the estimated time-to-full row directly below the charge rate it is derived from (#124). Shown
+	 * only while charging, with a trustworthy rate, and below the taper top (level &lt; 99%) — hidden
+	 * otherwise, so the user never sees a garbage "0m" or a wildly optimistic figure right as the charge
+	 * tapers. The estimate is a rough linear projection (see
+	 * {@link BatteryRateTracker#estimateMinutesToFull}); precision is a non-goal — the OS owns the accurate
+	 * number. Reuses the already-computed {@code rate}; only the level is read here.
+	 *
+	 * @param view The fragment view
+	 * @param rate The already-computed rate for this refresh
+	 */
+	private void addTimeToFullRow(final View view, final BatteryRateTracker.BatteryRate rate) {
+		if (!rate.charging() || !rate.hasRate()) {
+			return;
+		}
+		final int level = Math.round(batteryDO.getBatteryPercentage());
+		if (level >= 99) {
+			return;
+		}
+		final int minutes = BatteryRateTracker.estimateMinutesToFull(level, rate.percentPerHour());
+		if (minutes <= 0) {
+			return;
+		}
+		valuesMap.put(getResources().getString(R.string.time_to_full),
+				BatteryRateTracker.formatTimeToFull(view.getContext(), minutes));
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -121,6 +121,8 @@
     <string name="charge_connected_power">%1$s · %2$s · ~%3$d واط</string>
     <string name="charge_connected_tier">%1$s · %2$s</string>
     <string name="charge_connected_plain">شحن %1$s</string>
+    <!-- #125: إشعار الحالة أثناء الشحن — الفئة + الواط المقدّر، مثل "شحن سريع · ~18 واط" -->
+    <string name="notification_status_charge_power">%1$s · ~%2$s واط</string>
 
     <!-- "Charge notification style" preference (issue #122) -->
     <string name="charge_notification_style_title">أسلوب تنبيه الشحن</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -30,6 +30,8 @@
     <string name="drain_rate">معدل الاستهلاك</string>
     <string name="charge_rate">معدل الشحن</string>
     <string name="battery_current">التيار</string>
+    <!-- #124: الوقت المقدّر حتى اكتمال الشحن -->
+    <string name="time_to_full">الوقت حتى الاكتمال</string>
 
     <string name="battery">على البطارية</string>
     <string name="charger_ac">مقبس طاقة</string>
@@ -154,6 +156,9 @@
     <!-- معدل الشحن/الاستهلاك (#108) -->
     <string name="battery_rate_value">%1$s%%/h</string>
     <string name="battery_current_value">%1$s mA</string>
+    <!-- #124: الوحدات h/m تبقى لاتينية كبقية قيم المعدل -->
+    <string name="time_to_full_value_hm">~%1$sh %2$sm</string>
+    <string name="time_to_full_value_m">~%1$sm</string>
     <string name="pref_cat_title_drain">استهلاك البطارية</string>
     <string name="show_rate_in_notification">إظهار المعدل في إشعار الحالة</string>
     <string name="show_rate_in_notification_summary_on">يعرض الإشعار المستمر معدل الشحن/الاستهلاك المباشر بجانب الحالة</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -180,6 +180,17 @@
     <string name="notification_fast_drain_title">البطارية تُستهلك بسرعة</string>
     <string name="notification_fast_drain_content">يفقد نحو %1$s%% في الساعة خلال آخر %2$s دقيقة (حدّك: %3$s%%/h). قد يكون أحد التطبيقات يستهلك طاقة كبيرة.</string>
 
+    <!-- تحذير الشحن البطيء (#123) -->
+    <string name="notify_slow_charge">تحذير الشحن البطيء</string>
+    <string name="notify_slow_charge_summary_on">ينبّهك عندما تبقى قدرة الشحن منخفضة بشكل غير طبيعي — غالباً بسبب كابل تالف أو منفذ متّسخ أو شاحن معطوب</string>
+    <string name="notify_slow_charge_summary_off">تحذيرات الشحن البطيء معطّلة</string>
+    <string name="notification_slow_charge_channel_name">الشحن البطيء</string>
+    <string name="notification_slow_charge_channel_description">ينبّه عندما تبقى قدرة الشحن منخفضة بشكل غير طبيعي</string>
+    <string name="notification_slow_charge_ticker">الشحن بطيء</string>
+    <string name="notification_slow_charge_title">الشحن بطيء</string>
+    <string name="notification_slow_charge_content">الشحن بطيء (~%1$s واط) — جرّب كابلاً آخر، أو نظّف المنفذ، أو استخدم شاحناً مختلفاً.</string>
+    <string name="notification_slow_charge_content_big">بقيت قدرة الشحن حوالي ~%1$s واط، أقل بكثير مما يقدّمه شاحن سليم. جرّب كابلاً مختلفاً، أو نظّف منفذ الشحن، أو استخدم شاحناً أو مقبساً آخر.</string>
+
     <!-- Battery Insights screen -->
     <string name="battery_insights_title">تحليلات البطارية</string>
     <string name="battery_insights_menu">تحليلات البطارية</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,8 @@
     <string name="drain_rate">Drain rate</string>
     <string name="charge_rate">Charge rate</string>
     <string name="battery_current">Current</string>
+    <!-- #124: estimated time to full, shown below the charge rate while charging -->
+    <string name="time_to_full">Time to full</string>
 
     <string name="battery">On Battery</string>
     <string name="charger_ac">AC Charger</string>
@@ -162,6 +164,10 @@
     <string name="battery_rate_value">%1$s%%/h</string>
     <!-- %1$s is a signed Western-digit number, e.g. "+900" or "−450" -->
     <string name="battery_current_value">%1$s mA</string>
+    <!-- #124: time-to-full duration. %1$s hours, %2$s minutes — Western-digit numbers (String.valueOf);
+         the h/m units stay Latin like the other rate values (#96). -->
+    <string name="time_to_full_value_hm">~%1$sh %2$sm</string>
+    <string name="time_to_full_value_m">~%1$sm</string>
     <string name="pref_cat_title_drain">Battery Drain</string>
     <string name="show_rate_in_notification">Show rate in status notification</string>
     <string name="show_rate_in_notification_summary_on">The ongoing notification shows the live drain/charge rate next to the status</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,6 +192,18 @@
     <!-- %1$s rate, %2$s minutes, %3$s limit — all Western-digit numbers (String.valueOf) for every locale (#96) -->
     <string name="notification_fast_drain_content">Losing ~%1$s%% per hour for the last %2$s minutes (your limit: %3$s%%/h). Something may be using a lot of power.</string>
 
+    <!-- Slow-charge warning (#123) -->
+    <string name="notify_slow_charge">Slow-charging warning</string>
+    <string name="notify_slow_charge_summary_on">Warns you when charging power stays abnormally low — a likely frayed cable, dirty port, or failing charger</string>
+    <string name="notify_slow_charge_summary_off">Slow-charging warnings are disabled</string>
+    <string name="notification_slow_charge_channel_name">Slow Charging</string>
+    <string name="notification_slow_charge_channel_description">Warns when charging power stays abnormally low</string>
+    <string name="notification_slow_charge_ticker">Charging slowly</string>
+    <string name="notification_slow_charge_title">Charging slowly</string>
+    <!-- %1$s is a Western-digit number (String.valueOf), 0-9 in every locale (#96) -->
+    <string name="notification_slow_charge_content">Charging slowly (~%1$s W) — try another cable, clean the port, or use a different charger.</string>
+    <string name="notification_slow_charge_content_big">Charging has stayed around ~%1$s W, well below what a healthy charger delivers. Try a different cable, clean the charging port, or plug into another charger or outlet.</string>
+
     <!-- Battery Insights Screen -->
     <string name="battery_insights_title">Battery Insights</string>
     <string name="battery_insights_menu">Battery Insights</string>
@@ -332,6 +344,8 @@
     <string name="_pref_key_notify_fast_drain" translatable="false">key_notify_fast_drain</string>
     <string name="_pref_key_fast_drain_sustained_minutes" translatable="false">key_fast_drain_sustained_minutes</string>
     <string name="_pref_key_fast_drain_reminder_minutes" translatable="false">key_fast_drain_reminder_minutes</string>
+    <!-- #123: slow-charge warning enable -->
+    <string name="_pref_key_notify_slow_charge" translatable="false">key_notify_slow_charge</string>
     <string name="_pref_key_language" translatable="false">key_language</string>
 
     <string name="_pref_value_temperatures_unit_c" translatable="false">celsius</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,10 @@
     <string name="charge_connected_tier">%1$s · %2$s</string>
     <!-- e.g. "Wired charging" (when the charging speed can't be estimated) -->
     <string name="charge_connected_plain">%1$s charging</string>
+    <!-- #125: ongoing status notification while charging — tier + estimated watts (no wired/wireless
+         source needed here), e.g. "Fast charging · ~18 W". %2$s is Western-digit (String.valueOf), 0-9
+         in every locale (#96). -->
+    <string name="notification_status_charge_power">%1$s · ~%2$s W</string>
 
     <!-- "Charge notification style" preference (issue #122). The summary shows the current choice
          via useSimpleSummaryProvider, so no separate summary string is needed. -->

--- a/app/src/main/res/xml/pref_alerts.xml
+++ b/app/src/main/res/xml/pref_alerts.xml
@@ -181,11 +181,20 @@
 
     </PreferenceCategory>
 
-    <!-- Charging announcements (#122/#127). Future charging alerts (e.g. #123 slow-charge
-         warning) belong in this category too. -->
+    <!-- Charging announcements (#122/#127) and the slow-charge warning (#123). -->
     <PreferenceCategory
         android:title="@string/pref_cat_title_charging"
         app:iconSpaceReserved="false">
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/_pref_key_notify_slow_charge"
+            android:summaryOff="@string/notify_slow_charge_summary_off"
+            android:summaryOn="@string/notify_slow_charge_summary_on"
+            android:switchTextOff="@string/off"
+            android:switchTextOn="@string/on"
+            android:title="@string/notify_slow_charge"
+            app:iconSpaceReserved="false" />
 
         <ListPreference
             android:defaultValue="@string/_pref_value_charge_notification_style_toast"

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
@@ -1,17 +1,23 @@
 package com.almothafar.simplebatterynotifier.service;
 
+import android.content.Context;
 import android.os.BatteryManager;
+
+import androidx.test.core.app.ApplicationProvider;
 
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.service.BatteryRateTracker.BatteryRate;
 import com.almothafar.simplebatterynotifier.service.BatteryRateTracker.Sample;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -249,6 +255,78 @@ public class BatteryRateTrackerTest {
 		@Test
 		public void matchesExpected() {
 			assertEquals(expected, BatteryRateTracker.amberThreshold(limit));
+		}
+	}
+
+	/**
+	 * {@link BatteryRateTracker#estimateMinutesToFull}: the capacity-free linear projection (#124) and its
+	 * not-computable guards. Boundaries: the taper-top levels (99/100), a zero/negative rate, and rounding.
+	 */
+	@RunWith(Parameterized.class)
+	public static class EstimateMinutesToFull {
+
+		@Parameter(0) public String label;
+		@Parameter(1) public int level;
+		@Parameter(2) public int ratePercentPerHour;
+		@Parameter(3) public int expectedMinutes;
+
+		@Parameters(name = "{0}")
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{
+					{"50% at 30%/h -> 100m", 50, 30, 100},        // 50/30 h = 1h40m
+					{"80% at 60%/h -> 20m", 80, 60, 20},          // 20/60 h
+					{"20% at 10%/h -> 480m", 20, 10, 480},        // 80/10 h = 8h
+					{"rounds to nearest minute", 55, 40, 68},     // 45/40 h = 67.5m -> 68
+					{"one point left at 60%/h -> 1m", 99, 60, 1}, // helper allows; the UI gates level >= 99
+					{"zero rate not computable", 50, 0, 0},
+					{"negative rate not computable", 50, -5, 0},
+					{"already full not computable", 100, 30, 0},
+			});
+		}
+
+		@Test
+		public void matchesExpected() {
+			assertEquals(label, expectedMinutes, BatteryRateTracker.estimateMinutesToFull(level, ratePercentPerHour));
+		}
+	}
+
+	/**
+	 * {@link BatteryRateTracker#formatTimeToFull}: the "~1h 20m" / "~45m" rendering and its Western-digit
+	 * guarantee (#96). Context-dependent (string resources), so it runs under Robolectric — unlike the pure
+	 * math above; mirrors how the other Context-backed formatters would be exercised.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class FormatTimeToFull {
+
+		private Context context;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+		}
+
+		@Test
+		public void hoursAndMinutes() {
+			assertEquals("~1h 20m", BatteryRateTracker.formatTimeToFull(context, 80));
+		}
+
+		@Test
+		public void minutesOnly() {
+			assertEquals("~45m", BatteryRateTracker.formatTimeToFull(context, 45));
+		}
+
+		@Test
+		public void wholeHoursStillShowMinutes() {
+			assertEquals("~2h 0m", BatteryRateTracker.formatTimeToFull(context, 120));
+		}
+
+		@Test
+		@Config(qualifiers = "ar")
+		public void keepsWesternDigitsUnderArabicLocale() {
+			// values-ar keeps the "~%1$sh %2$sm" shape and String.valueOf keeps the digits 0-9 (#96), so the
+			// Arabic render is identical — a regression to %d here would surface Arabic-Indic digits.
+			assertEquals("~1h 20m", BatteryRateTracker.formatTimeToFull(context, 80));
 		}
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetectorTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetectorTest.java
@@ -1,0 +1,160 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import com.almothafar.simplebatterynotifier.service.SlowChargeDetector.SlowChargeDecision;
+import com.almothafar.simplebatterynotifier.service.SlowChargeDetector.SlowChargeState;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the pure slow-charge decision core {@link SlowChargeDetector#decide} (issue #123): the
+ * sustained-below-floor trigger, the once-per-session guarantee, the re-arm-on-recovery hysteresis, and
+ * the observation-gap lapse rule. Power in mW; times in millis. States carry a lastSeenBelow close to
+ * "now" where the scenario implies continuous observation — in production every below-floor tick refreshes
+ * it.
+ */
+public class SlowChargeDetectorTest {
+
+	private static final int FLOOR_MW = SlowChargeDetector.FLOOR_MILLIWATTS; // 2500
+	private static final int SLOW_MW = 1_500;   // below the floor
+	private static final int HEALTHY_MW = 8_000; // well above the floor
+	private static final long SUSTAINED_MS = SlowChargeDetector.SUSTAINED_MS; // 3 min
+	private static final long MINUTE_MS = 60_000L;
+
+	private static final SlowChargeState CLEARED = new SlowChargeState(0, false, 0);
+
+	@Test
+	public void powerUnknown_sleepsAndKeepsStreak() {
+		final SlowChargeState state = new SlowChargeState(1000, true, 2000);
+		final SlowChargeDecision d = SlowChargeDetector.decide(state, false, 0, FLOOR_MW, SUSTAINED_MS, 999_999);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(state, d.newState()); // untouched
+	}
+
+	@Test
+	public void powerAtOrAboveFloor_reArmsSession() {
+		final SlowChargeState state = new SlowChargeState(1000, true, 2000);
+		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, HEALTHY_MW, FLOOR_MW, SUSTAINED_MS, 500_000);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(CLEARED, d.newState());
+	}
+
+	@Test
+	public void floorIsInclusiveHealthy_exactlyAtFloorReArms() {
+		// At the floor counts as healthy (re-arm); one milliwatt below starts a slow streak.
+		assertEquals(CLEARED, SlowChargeDetector.decide(CLEARED, true, FLOOR_MW, FLOOR_MW, SUSTAINED_MS, 1000).newState());
+		assertEquals(1000, SlowChargeDetector.decide(CLEARED, true, FLOOR_MW - 1, FLOOR_MW, SUSTAINED_MS, 1000).newState().streakStart());
+	}
+
+	@Test
+	public void belowFloor_startsStreakButDoesNotFireYet() {
+		final SlowChargeDecision d = SlowChargeDetector.decide(CLEARED, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, 1000);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(1000, d.newState().streakStart());
+		assertEquals(1000, d.newState().lastSeenBelow());
+		assertFalse(d.newState().alerted());
+	}
+
+	@Test
+	public void streakNotYetSustained_doesNotFire() {
+		final SlowChargeState state = new SlowChargeState(1000, false, 1000);
+		final long now = 1000 + 2 * MINUTE_MS; // 2 min in, sustained window is 3
+		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(1000, d.newState().streakStart());   // start preserved
+		assertEquals(now, d.newState().lastSeenBelow());  // observation refreshed
+		assertFalse(d.newState().alerted());
+	}
+
+	@Test
+	public void sustained_firesTheOneWarning() {
+		final SlowChargeState state = new SlowChargeState(1000, false, 1000);
+		final long now = 1000 + SUSTAINED_MS;
+		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+
+		assertTrue(d.shouldNotify());
+		assertTrue(d.newState().alerted());
+		assertEquals(1000, d.newState().streakStart());
+	}
+
+	@Test
+	public void afterWarning_staysSilentForTheRestOfTheSession() {
+		final long start = 1000;
+		final long now = start + SUSTAINED_MS + 20 * MINUTE_MS; // long after the warning
+		final SlowChargeState state = new SlowChargeState(start, true, now - MINUTE_MS);
+		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+
+		assertFalse(d.shouldNotify()); // once per charge session — no reminders
+		assertTrue(d.newState().alerted());
+	}
+
+	@Test
+	public void reArmedSession_canWarnAgainLater() {
+		// Power recovers (charge fixed), then collapses again in a later session and warns once more.
+		final SlowChargeDecision recovered = SlowChargeDetector.decide(
+				new SlowChargeState(1000, true, 1000), true, HEALTHY_MW, FLOOR_MW, SUSTAINED_MS, 400_000);
+		assertEquals(CLEARED, recovered.newState());
+
+		final SlowChargeDecision restart = SlowChargeDetector.decide(
+				recovered.newState(), true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, 500_000);
+		assertFalse(restart.shouldNotify());
+		assertEquals(500_000, restart.newState().streakStart());
+
+		final SlowChargeDecision reAlert = SlowChargeDetector.decide(
+				restart.newState(), true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, 500_000 + SUSTAINED_MS);
+		assertTrue(reAlert.shouldNotify());
+	}
+
+	// --- observation-gap lapse rule ------------------------------------------------------------
+
+	@Test
+	public void lapsedGap_restartsStreakInsteadOfWarning() {
+		// Below-floor for a bit, then no usable reading for longer than the window (process death / doze).
+		// The next below-floor reading must start a fresh episode, not warn on unobserved time.
+		final long lastSeen = 1000 + MINUTE_MS;
+		final SlowChargeState state = new SlowChargeState(1000, false, lastSeen);
+		final long now = lastSeen + SlowChargeDetector.MAX_OBSERVATION_GAP_MS + 1;
+		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+
+		assertFalse(d.shouldNotify());
+		assertEquals(now, d.newState().streakStart());   // fresh episode
+		assertEquals(now, d.newState().lastSeenBelow());
+	}
+
+	@Test
+	public void lapsedGapAfterWarning_startsFreshEpisodeThatCanWarnAgain() {
+		final long alertedAt = 1000 + SUSTAINED_MS;
+		final SlowChargeState state = new SlowChargeState(1000, true, alertedAt);
+		final long now = alertedAt + SlowChargeDetector.MAX_OBSERVATION_GAP_MS + 1;
+		final SlowChargeDecision lapsed = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+
+		assertFalse(lapsed.shouldNotify());
+		assertEquals(now, lapsed.newState().streakStart());
+		assertFalse(lapsed.newState().alerted()); // new episode: the warning is re-armed
+
+		final SlowChargeDecision reAlert = SlowChargeDetector.decide(
+				lapsed.newState(), true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now + SUSTAINED_MS);
+		assertTrue(reAlert.shouldNotify());
+	}
+
+	@Test
+	public void gapAtBoundary_continuesStreak() {
+		// A gap of exactly MAX_OBSERVATION_GAP_MS is still continuous; one millisecond more lapses it.
+		final long lastSeen = 1000;
+		final long atBoundary = lastSeen + SlowChargeDetector.MAX_OBSERVATION_GAP_MS;
+		final SlowChargeState state = new SlowChargeState(1000, false, lastSeen);
+
+		final SlowChargeDecision continued = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, atBoundary);
+		assertEquals(1000, continued.newState().streakStart()); // preserved
+
+		final SlowChargeDecision lapsed = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, atBoundary + 1);
+		assertEquals(atBoundary + 1, lapsed.newState().streakStart()); // restarted
+	}
+}


### PR DESCRIPTION
Closes #123. The headline feature of the charger-notification redesign.

> **Top of the stack:** #123 → #149 (#125) → #148 (#124) → #147 (lint). Bases retarget down as each merges.

## What
Warns **once per charge session** when charging power stays abnormally low for a sustained time — a strong signal of a **frayed cable, dirty/loose port, or dying charger**.

## How
New `SlowChargeDetector`, a pattern-copy of `FastDrainDetector` (#109): a pure, unit-tested `decide()` core + persisted streak/hysteresis state, evaluated on the battery broadcasts that already flow (**no new timer**). The signal is the estimated wattage from `ChargeSpeed` (#122, `CURRENT_NOW × voltage`).

**Trigger:** estimated power stays below a conservative trickle floor (**~2.5 W wired**) for a sustained window (**3 min**, a constant in v1) while charging below 80%.

**Three guards keep it nearly false-positive-free** (the traps from the issue):
- **level < 80%** — every charger deliberately tapers above ~80%
- **status == CHARGING** — thermal/battery-protect pauses report `NOT_CHARGING`; skipped (they sleep, they dont clear the streak)
- **wired only** in v1 (wireless excluded)
- plus the #121 **observation-gap lapse rule** so a data gap cant inflate the "sustained" claim

Re-arms when power recovers above the floor or on disconnect.

## Surfacing
Respects the #122 **charge-notification style** (`toast` / `notification` / `none`); the notification path uses the shared **quiet-hours helper** (#131) on its own channel + **id 1641991**. New **enable toggle** (default on) in the Charging settings category. The message is transparent — it states the measured wattage — and deliberately cant name cable vs port vs brick (indistinguishable via public APIs).

## Verified
- `testDebugUnitTest` + `assembleDebug` + `lintDebug` all green. New `SlowChargeDetectorTest` mirrors `FastDrainDetectorTest` (streak, once-per-session, re-arm, observation-gap lapse, floor boundary).
- Installed on the Mate 10 Pro. New strings **Arabic drafted — pending your review**.

## On-device check (your step)
Trickier to see naturally. Easiest with a bad/thin cable, or simulate via `adb shell dumpsys battery set` (level < 80, status charging) — but note the wattage comes from a real `CURRENT_NOW`, which `dumpsys` doesnt fake, so a real weak cable is the true test. ⚠️ On a device that doesnt report a usable `CURRENT_NOW` while charging, the power is unknown and it correctly stays silent (fail-quiet).

## Not here
v2 — session-relative collapse (18 W → 4 W and stuck, which this absolute floor cant see) — stays in **#132**, which was waiting on real-device data from this v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)