### PR TITLE
Kirin CURRENT_NOW misread: display floor for current + plausibility floor for charge power (#152 v1)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/model/ChargeSpeed.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/model/ChargeSpeed.java
@@ -27,6 +27,11 @@ public final class ChargeSpeed {
 	// Above this the reading is implausible for a phone (e.g. a device reporting current in the wrong
 	// unit, or garbage), so we treat it as unknown rather than showing an absurd wattage.
 	static final int MAX_PLAUSIBLE_MW = 200_000;  // 200 W
+	// Below this the reading is implausible in the other direction (#152): a phone that reports CHARGING
+	// is never genuinely taking in under ~0.1 W. Kirin/HiSilicon reports CURRENT_NOW in mA instead of µA,
+	// so a real fast charge computes to ~3-4 mW — without this floor it would classify as a known Trickle
+	// tier and fire the slow-charge warning (#123) on every charge. Mirror of MAX_PLAUSIBLE_MW.
+	static final int MIN_PLAUSIBLE_MW = 100;      // 0.1 W
 
 	private final int milliwatts;
 	private final ChargeSpeedTier tier;
@@ -61,7 +66,8 @@ public final class ChargeSpeed {
 	 * <p>
 	 * Handles the awkward real-world inputs: unsupported readings ({@link Integer#MIN_VALUE}) and the
 	 * discharge-positive sign convention (the magnitude is what matters while charging). Rejects a
-	 * zero/blank current and any implausibly large result as {@link #UNKNOWN_POWER_MW}.
+	 * zero/blank current and any implausible result — too large <em>or</em> too small (#152) — as
+	 * {@link #UNKNOWN_POWER_MW}.
 	 *
 	 * @param currentMicroAmps instantaneous current in µA
 	 * @param voltageMilliVolts battery voltage in mV
@@ -76,7 +82,7 @@ public final class ChargeSpeed {
 		final long currentMagnitudeUa = Math.abs((long) currentMicroAmps);
 		// mW = µA × mV / 1e6. Use long arithmetic: µA×mV can exceed the int range (e.g. 10 A × 5 V).
 		final long milliwatts = currentMagnitudeUa * voltageMilliVolts / 1_000_000L;
-		if (milliwatts <= 0 || milliwatts > MAX_PLAUSIBLE_MW) {
+		if (milliwatts < MIN_PLAUSIBLE_MW || milliwatts > MAX_PLAUSIBLE_MW) {
 			return UNKNOWN_POWER_MW;
 		}
 		return (int) milliwatts;

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
@@ -57,6 +57,11 @@ public final class BatteryRateTracker {
 
 	// A phone never sources/sinks more than a few amps; anything past this is a bad/units-wrong reading.
 	static final int MAX_PLAUSIBLE_CURRENT_MA = 15000;
+	// Floor for the *displayed* current (#152): below this the reading is either glance-noise (a genuine
+	// sub-10 mA draw only happens in deep sleep) or a wrong-unit misread — Kirin/HiSilicon reports
+	// CURRENT_NOW in mA instead of µA, so a real ~800 mA draw arrives as raw -800 and would otherwise
+	// display as a nonsense "−1 mA". Hide rather than mislead, mirroring #94.
+	static final int MIN_DISPLAY_CURRENT_MA = 10;
 	// Above this the derived %/h is garbage (e.g. a wrong-unit current); reject rather than display it.
 	static final int MAX_PLAUSIBLE_RATE_PPH = 500;
 
@@ -251,7 +256,7 @@ public final class BatteryRateTracker {
 	 * (the post-unplug warm-up shows nothing), and never when it rounds to 0 (a static level) or exceeds
 	 * a plausible ceiling (a garbage reading). The current is reported independently, signed by
 	 * direction so it reads negative while discharging and positive while charging regardless of the
-	 * device's raw sign convention.
+	 * device's raw sign convention — and only when it clears {@link #MIN_DISPLAY_CURRENT_MA} (#152).
 	 *
 	 * @param window                 samples oldest-first
 	 * @param capacityMah            measured full capacity in mAh, or 0 when unknown/untrusted (#69)
@@ -264,7 +269,7 @@ public final class BatteryRateTracker {
 	static BatteryRate computeRate(final List<Sample> window, final int capacityMah, final boolean charging,
 	                               final long nowMillis, final int latestCurrentMicroAmps) {
 		final boolean hasCurrent = isPlausibleCurrentMicroAmps(latestCurrentMicroAmps)
-				&& Math.round(Math.abs(latestCurrentMicroAmps) / 1000f) >= 1;
+				&& Math.round(Math.abs(latestCurrentMicroAmps) / 1000f) >= MIN_DISPLAY_CURRENT_MA;
 		final int signedMilliAmps = hasCurrent ? signedCurrentMilliAmps(latestCurrentMicroAmps, charging) : 0;
 
 		final int pph = ratePercentPerHour(window, capacityMah);

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/model/ChargeSpeedTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/model/ChargeSpeedTest.java
@@ -54,6 +54,12 @@ public class ChargeSpeedTest {
 					// Boundary around the plausibility cap (200 W): equal is kept, just above is rejected.
 					{"at plausibility cap", 40_000_000, 5_000, 200_000},
 					{"just over plausibility cap", 41_000_000, 5_000, ChargeSpeed.UNKNOWN_POWER_MW},
+					// Implausibly small (#152): a charging phone never takes in under ~0.1 W — such a
+					// result is a wrong-unit misread (Kirin reports CURRENT_NOW in mA, so a real fast
+					// charge computes to ~3-4 mW), not a real trickle.
+					{"Kirin mA-unit misread (~3.8 mW)", 1_000, 3_800, ChargeSpeed.UNKNOWN_POWER_MW},
+					{"just under plausibility floor", 24_750, 4_000, ChargeSpeed.UNKNOWN_POWER_MW},
+					{"at plausibility floor", 25_000, 4_000, 100},
 			});
 		}
 
@@ -128,6 +134,16 @@ public class ChargeSpeedTest {
 			assertTrue(speed.isKnown());
 			assertEquals(ChargeSpeedTier.TRICKLE, speed.getTier());
 			assertEquals(0, speed.getWatts());
+		}
+
+		@Test
+		public void kirinMisreadCurrent_isUnknownNotTrickle() {
+			// The end-to-end #152 case: Kirin's mA-unit raw (~1000 while fast charging) used to classify
+			// as a known Trickle (~3 mW), mislabeling the tier everywhere and firing the slow-charge
+			// warning (#123) on every charge. It must read as unknown, which keeps both quiet.
+			final ChargeSpeed speed = ChargeSpeed.fromMeasurements(1_000, 3_800);
+			assertFalse(speed.isKnown());
+			assertEquals(ChargeSpeedTier.UNKNOWN, speed.getTier());
 		}
 
 		@Test

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
@@ -156,6 +156,43 @@ public class BatteryRateTrackerTest {
 		}
 
 		@Test
+		public void kirinMisreadCurrent_isHiddenWhileRateStillShown() {
+			// Kirin/HiSilicon reports CURRENT_NOW in mA, not µA (#152): a real ~800 mA draw arrives as
+			// raw -800, which used to display as a nonsense "−1 mA". The display floor hides it; the
+			// level-over-time rate (source B) is unit-independent and stays.
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -800),
+					new Sample(360_000, 47, -800));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 360_000, -800);
+
+			assertTrue(rate.hasRate());
+			assertFalse(rate.hasCurrent());
+		}
+
+		@Test
+		public void currentJustBelowDisplayFloor_isHidden() {
+			// 9.4 mA rounds to 9, one below MIN_DISPLAY_CURRENT_MA (#152).
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -9_400),
+					new Sample(360_000, 47, -9_400));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 360_000, -9_400);
+
+			assertFalse(rate.hasCurrent());
+		}
+
+		@Test
+		public void currentAtDisplayFloor_isShown() {
+			// 9.5 mA rounds to exactly MIN_DISPLAY_CURRENT_MA — the floor is inclusive (#152).
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -9_500),
+					new Sample(360_000, 47, -9_500));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 360_000, -9_500);
+
+			assertTrue(rate.hasCurrent());
+			assertEquals(-10, rate.currentMilliAmps());
+		}
+
+		@Test
 		public void currentZero_isHiddenWhileRateStillShown() {
 			final List<Sample> window = Arrays.asList(
 					new Sample(0, 50, NO_CURRENT),


### PR DESCRIPTION
Fixes the user-visible fallout of the Kirin/HiSilicon `CURRENT_NOW` unit bug (#152): the fuel gauge reports mA instead of µA, so real readings arrive 1000× too small and slipped through every gate that only guarded against too-*large* values.

## v1a — current display floor (`BatteryRateTracker`)
- New `MIN_DISPLAY_CURRENT_MA = 10`; the `hasCurrent` gate in `computeRate` now requires the rounded magnitude to reach it (was `>= 1`).
- Kills "Discharging −1 mA" / "+1 mA" on **both** surfaces (ongoing notification's mA fallback and the details table) — the misread values cap out at ~1–3 "mA".
- On genuine-µA devices, sub-10 mA draw only happens in deep sleep; nothing informative is lost.

## v1b — charge power plausibility floor (`ChargeSpeed`)
- New `MIN_PLAUSIBLE_MW = 100` (0.1 W), mirror of the existing `MAX_PLAUSIBLE_MW` guard: a phone that reports `CHARGING` is never genuinely taking in less.
- Kirin's fake ~3–4 mW estimate now reads as **unknown** instead of a known Trickle, which:
  - stops the wrong "Slow charging" tier in the charge-connected announcement and the ongoing notification (#122/#125) — they fall back to the plain label;
  - stops the guaranteed false slow-charge alarm (#123/#150) — `SlowChargeDetector`'s `powerKnown` gate keeps it asleep.

## Tests
- Boundary tests at the display floor (9.4 mA hidden / 9.5 mA shown) plus the Kirin raw −800 case with the level-over-time rate still shown.
- Boundary tests at the power floor (99 mW unknown / 100 mW known) plus the Kirin ~3.8 mW case end-to-end through `fromMeasurements`.
- `./gradlew :app:testDebugUnitTest` and `:app:lintDebug` pass.

## On-device verification (Mate 10 Pro)
- [ ] No ±1/±2 mA in the notification **or** the table across several plug/unplug cycles (per the 2026-07-16 field observation, check both surfaces)
- [ ] Notification falls back to the plain status label during warm-up
- [ ] No "Charging slowly" warning during a normal wired charge

v2 (unit auto-calibration, showing the *real* current on Kirin) follows as a stacked PR.

Part of #152 — v1 of the two-stage fix; the stacked v2 PR closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)