### PR TITLE
CURRENT_NOW unit auto-calibration: show the real current on mA-unit devices (#152 v2)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/model/ChargeSpeed.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/model/ChargeSpeed.java
@@ -27,6 +27,11 @@ public final class ChargeSpeed {
 	// Above this the reading is implausible for a phone (e.g. a device reporting current in the wrong
 	// unit, or garbage), so we treat it as unknown rather than showing an absurd wattage.
 	static final int MAX_PLAUSIBLE_MW = 200_000;  // 200 W
+	// Below this the reading is implausible in the other direction (#152): a phone that reports CHARGING
+	// is never genuinely taking in under ~0.1 W. Kirin/HiSilicon reports CURRENT_NOW in mA instead of µA,
+	// so a real fast charge computes to ~3-4 mW — without this floor it would classify as a known Trickle
+	// tier and fire the slow-charge warning (#123) on every charge. Mirror of MAX_PLAUSIBLE_MW.
+	static final int MIN_PLAUSIBLE_MW = 100;      // 0.1 W
 
 	private final int milliwatts;
 	private final ChargeSpeedTier tier;
@@ -61,7 +66,8 @@ public final class ChargeSpeed {
 	 * <p>
 	 * Handles the awkward real-world inputs: unsupported readings ({@link Integer#MIN_VALUE}) and the
 	 * discharge-positive sign convention (the magnitude is what matters while charging). Rejects a
-	 * zero/blank current and any implausibly large result as {@link #UNKNOWN_POWER_MW}.
+	 * zero/blank current and any implausible result — too large <em>or</em> too small (#152) — as
+	 * {@link #UNKNOWN_POWER_MW}.
 	 *
 	 * @param currentMicroAmps instantaneous current in µA
 	 * @param voltageMilliVolts battery voltage in mV
@@ -76,7 +82,7 @@ public final class ChargeSpeed {
 		final long currentMagnitudeUa = Math.abs((long) currentMicroAmps);
 		// mW = µA × mV / 1e6. Use long arithmetic: µA×mV can exceed the int range (e.g. 10 A × 5 V).
 		final long milliwatts = currentMagnitudeUa * voltageMilliVolts / 1_000_000L;
-		if (milliwatts <= 0 || milliwatts > MAX_PLAUSIBLE_MW) {
+		if (milliwatts < MIN_PLAUSIBLE_MW || milliwatts > MAX_PLAUSIBLE_MW) {
 			return UNKNOWN_POWER_MW;
 		}
 		return (int) milliwatts;

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
@@ -57,6 +57,11 @@ public final class BatteryRateTracker {
 
 	// A phone never sources/sinks more than a few amps; anything past this is a bad/units-wrong reading.
 	static final int MAX_PLAUSIBLE_CURRENT_MA = 15000;
+	// Floor for the *displayed* current (#152): below this the reading is either glance-noise (a genuine
+	// sub-10 mA draw only happens in deep sleep) or a wrong-unit misread — Kirin/HiSilicon reports
+	// CURRENT_NOW in mA instead of µA, so a real ~800 mA draw arrives as raw -800 and would otherwise
+	// display as a nonsense "−1 mA". Hide rather than mislead, mirroring #94.
+	static final int MIN_DISPLAY_CURRENT_MA = 10;
 	// Above this the derived %/h is garbage (e.g. a wrong-unit current); reject rather than display it.
 	static final int MAX_PLAUSIBLE_RATE_PPH = 500;
 
@@ -251,7 +256,7 @@ public final class BatteryRateTracker {
 	 * (the post-unplug warm-up shows nothing), and never when it rounds to 0 (a static level) or exceeds
 	 * a plausible ceiling (a garbage reading). The current is reported independently, signed by
 	 * direction so it reads negative while discharging and positive while charging regardless of the
-	 * device's raw sign convention.
+	 * device's raw sign convention — and only when it clears {@link #MIN_DISPLAY_CURRENT_MA} (#152).
 	 *
 	 * @param window                 samples oldest-first
 	 * @param capacityMah            measured full capacity in mAh, or 0 when unknown/untrusted (#69)
@@ -264,7 +269,7 @@ public final class BatteryRateTracker {
 	static BatteryRate computeRate(final List<Sample> window, final int capacityMah, final boolean charging,
 	                               final long nowMillis, final int latestCurrentMicroAmps) {
 		final boolean hasCurrent = isPlausibleCurrentMicroAmps(latestCurrentMicroAmps)
-				&& Math.round(Math.abs(latestCurrentMicroAmps) / 1000f) >= 1;
+				&& Math.round(Math.abs(latestCurrentMicroAmps) / 1000f) >= MIN_DISPLAY_CURRENT_MA;
 		final int signedMilliAmps = hasCurrent ? signedCurrentMilliAmps(latestCurrentMicroAmps, charging) : 0;
 
 		final int pph = ratePercentPerHour(window, capacityMah);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/CurrentUnitCalibrator.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/CurrentUnitCalibrator.java
@@ -1,0 +1,166 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import androidx.preference.PreferenceManager;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Auto-detects devices that report {@code BATTERY_PROPERTY_CURRENT_NOW} in <b>mA instead of µA</b>
+ * and rescales their readings, so the app can show the <em>real</em> current instead of hiding a
+ * 1000&times;-too-small one (issue #152 v2 — the Kirin/HiSilicon fuel-gauge unit bug, sibling of the
+ * charge-counter bug in #69/#94).
+ * <p>
+ * <b>How the conclusion is reached.</b> The maximum |raw| reading ever observed is tracked
+ * persistently, across sessions and charge/discharge alike. A genuine-µA device exceeds
+ * {@link #MICRO_AMP_FLOOR_RAW} (20&nbsp;mA as µA) within moments of normal awake use — screen-on
+ * draw alone is 100&nbsp;000+ µA. A mA-unit device physically cannot reach it: that would mean a
+ * sustained 20+ A. So once enough spaced readings have been observed
+ * ({@link #MIN_OBSERVED_SAMPLES} at {@link #MIN_COUNT_SPACING_MS} apart, &ge; 1 h of cumulative
+ * observation) with the maximum still below the floor, the device is concluded to report mA and
+ * every reading is scaled &times;1000.
+ * <p>
+ * <b>Self-correcting, never oscillating.</b> Observation always records the <em>raw</em> value
+ * (before scaling), so scaled outputs can't feed back into the decision. If a large raw reading
+ * ever arrives on a device previously concluded as mA (e.g. a firmware update fixes the unit), the
+ * persisted maximum rises past the floor in the same call and scaling stops immediately and
+ * permanently. That ordering also bounds the scaled result: scaling only ever applies to a |raw|
+ * below the floor, so the &times;1000 product stays far inside int range.
+ * <p>
+ * <b>Bounded preference churn.</b> The maximum plateaus after the first minutes of use on any
+ * device, and counting stops for good at {@link #MIN_OBSERVED_SAMPLES}; after warm-up the common
+ * path writes nothing. The pure helpers carry the correctness and are unit-tested without Android.
+ */
+public final class CurrentUnitCalibrator {
+
+	// Persisted observation state (survives process restarts, like BatteryRateTracker's window).
+	private static final String PREF_MAX_ABS_RAW = "_current_unit_max_abs_raw";
+	private static final String PREF_OBSERVED_COUNT = "_current_unit_observed_count";
+	private static final String PREF_LAST_OBSERVED_AT = "_current_unit_last_observed_at";
+
+	// A genuine-µA device exceeds this raw magnitude (20 mA as µA) within any awake minute; a mA-unit
+	// device would need a sustained 20+ A to reach it. Kirin's mA-unit raw peaks around ~2000 charging.
+	static final int MICRO_AMP_FLOOR_RAW = 20_000;
+	// How many spaced readings must be observed before concluding mA units. With the spacing below this
+	// is >= 1 h of cumulative awake observation (across sessions) — enough to have seen real load, so a
+	// quiet first minute can't mislabel a genuine-µA device.
+	static final int MIN_OBSERVED_SAMPLES = 60;
+	// Minimum spacing between counted readings, so a burst of plug-in broadcasts can't inflate the
+	// count into a premature conclusion. The maximum is still updated on every reading regardless.
+	static final long MIN_COUNT_SPACING_MS = 60L * 1000;
+
+	static final int MICRO_AMPS_PER_MILLI_AMP = 1000;
+
+	// getIntProperty returns this for an unsupported property (same sentinel BatteryRateTracker gates on).
+	private static final int PROPERTY_UNSUPPORTED = Integer.MIN_VALUE;
+
+	private CurrentUnitCalibrator() {
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Records a raw {@code CURRENT_NOW} reading into the persistent observation and returns it in µA —
+	 * scaled &times;1000 when the device has been concluded to report mA, unchanged otherwise. The single
+	 * entry point, called from {@link SystemService#getInstantaneousCurrentMicroAmps(Context)} so every
+	 * consumer (the rate tracker, the Current row, {@link com.almothafar.simplebatterynotifier.model.ChargeSpeed})
+	 * sees the same corrected value.
+	 *
+	 * @param context    Application context
+	 * @param rawCurrent the raw {@code getIntProperty(BATTERY_PROPERTY_CURRENT_NOW)} value
+	 *
+	 * @return the reading in µA; sentinels ({@link Integer#MIN_VALUE}/{@link Integer#MAX_VALUE}) and a
+	 *         blank 0 pass through untouched
+	 */
+	public static int observeAndScale(final Context context, final int rawCurrent) {
+		if (isNull(context) || rawCurrent == PROPERTY_UNSUPPORTED || rawCurrent == Integer.MAX_VALUE || rawCurrent == 0) {
+			return rawCurrent; // sentinel or blank: nothing to learn, nothing to scale
+		}
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		final Observation previous = loadObservation(prefs);
+		final Observation updated = observe(previous, rawCurrent, System.currentTimeMillis());
+
+		// Persist only on change: after warm-up (max plateaued, count capped) this writes nothing.
+		if (!updated.equals(previous)) {
+			saveObservation(prefs, updated);
+		}
+		// Decide from the *updated* observation: a first-ever large reading voids a stale mA conclusion
+		// in this same call, which also guarantees any scaled |raw| is below the floor (no overflow).
+		return scaledMicroAmps(rawCurrent, isMilliAmpUnits(updated));
+	}
+
+	/**
+	 * Folds one raw reading into the observation. Pure so it is unit-testable. The maximum is updated on
+	 * every reading; the count only for readings spaced {@link #MIN_COUNT_SPACING_MS} apart, and stops
+	 * for good at {@link #MIN_OBSERVED_SAMPLES} (bounding lifetime preference writes). Returns the same
+	 * instance when nothing changed, so the caller can skip the persist.
+	 *
+	 * @param previous   the observation so far
+	 * @param rawCurrent a real (non-sentinel, nonzero) raw reading
+	 * @param nowMillis  current time in millis
+	 *
+	 * @return the updated observation, or {@code previous} itself when unchanged
+	 */
+	static Observation observe(final Observation previous, final int rawCurrent, final long nowMillis) {
+		final int maxAbsRaw = Math.max(previous.maxAbsRaw(), Math.abs(rawCurrent));
+		final boolean countable = previous.observedCount() < MIN_OBSERVED_SAMPLES
+				&& nowMillis - previous.lastObservedAt() >= MIN_COUNT_SPACING_MS;
+		if (countable) {
+			return new Observation(maxAbsRaw, previous.observedCount() + 1, nowMillis);
+		}
+		if (maxAbsRaw != previous.maxAbsRaw()) {
+			return new Observation(maxAbsRaw, previous.observedCount(), previous.lastObservedAt());
+		}
+		return previous;
+	}
+
+	/**
+	 * Whether the observation concludes the device reports mA instead of µA: enough spaced readings
+	 * seen, and the maximum |raw| still below the µA floor. Pure so the boundary is unit-testable.
+	 *
+	 * @param observation the observation so far
+	 *
+	 * @return true when the device's {@code CURRENT_NOW} unit is concluded to be mA
+	 */
+	static boolean isMilliAmpUnits(final Observation observation) {
+		return observation.observedCount() >= MIN_OBSERVED_SAMPLES
+				&& observation.maxAbsRaw() < MICRO_AMP_FLOOR_RAW;
+	}
+
+	/**
+	 * The reading in µA under a unit conclusion. Pure so the scaling is unit-testable.
+	 *
+	 * @param rawCurrent    a real raw reading
+	 * @param milliAmpUnits whether the device is concluded to report mA
+	 *
+	 * @return {@code rawCurrent} &times; 1000 under mA units, else {@code rawCurrent} unchanged
+	 */
+	static int scaledMicroAmps(final int rawCurrent, final boolean milliAmpUnits) {
+		return milliAmpUnits ? rawCurrent * MICRO_AMPS_PER_MILLI_AMP : rawCurrent;
+	}
+
+	private static Observation loadObservation(final SharedPreferences prefs) {
+		return new Observation(
+				prefs.getInt(PREF_MAX_ABS_RAW, 0),
+				prefs.getInt(PREF_OBSERVED_COUNT, 0),
+				prefs.getLong(PREF_LAST_OBSERVED_AT, 0));
+	}
+
+	private static void saveObservation(final SharedPreferences prefs, final Observation observation) {
+		prefs.edit()
+		     .putInt(PREF_MAX_ABS_RAW, observation.maxAbsRaw())
+		     .putInt(PREF_OBSERVED_COUNT, observation.observedCount())
+		     .putLong(PREF_LAST_OBSERVED_AT, observation.lastObservedAt())
+		     .apply();
+	}
+
+	/**
+	 * The persistent unit-observation state.
+	 *
+	 * @param maxAbsRaw      the largest |raw| reading ever observed (0 = nothing observed yet)
+	 * @param observedCount  how many spaced readings have been counted, capped at {@link #MIN_OBSERVED_SAMPLES}
+	 * @param lastObservedAt when the last counted reading was observed, for the spacing rule
+	 */
+	record Observation(int maxAbsRaw, int observedCount, long lastObservedAt) {
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -315,9 +315,11 @@ public final class SystemService {
 	 * Read the live instantaneous battery current from {@link BatteryManager#BATTERY_PROPERTY_CURRENT_NOW}
 	 * (µA), used to derive the charge/drain rate and the signed "Current" row (issue #108).
 	 * <p>
-	 * The raw value is returned unfiltered: {@code getIntProperty} yields {@link Integer#MIN_VALUE} when
-	 * the property is unsupported, and the sign convention varies by OEM. Callers gate plausibility and
-	 * derive direction from the charging status (see {@link BatteryRateTracker}).
+	 * The reading passes through {@link CurrentUnitCalibrator}, which rescales it on devices concluded to
+	 * report mA instead of µA (the Kirin unit bug, #152) — the single read point, so every consumer sees
+	 * the same corrected value. Otherwise it is unfiltered: {@code getIntProperty} yields
+	 * {@link Integer#MIN_VALUE} when the property is unsupported, and the sign convention varies by OEM.
+	 * Callers gate plausibility and derive direction from the charging status (see {@link BatteryRateTracker}).
 	 *
 	 * @param context The application context
 	 *
@@ -329,7 +331,7 @@ public final class SystemService {
 			Log.w(TAG, "BatteryManager service unavailable");
 			return Integer.MIN_VALUE;
 		}
-		return batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW);
+		return CurrentUnitCalibrator.observeAndScale(context, batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW));
 	}
 
 	/**

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/model/ChargeSpeedTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/model/ChargeSpeedTest.java
@@ -54,6 +54,12 @@ public class ChargeSpeedTest {
 					// Boundary around the plausibility cap (200 W): equal is kept, just above is rejected.
 					{"at plausibility cap", 40_000_000, 5_000, 200_000},
 					{"just over plausibility cap", 41_000_000, 5_000, ChargeSpeed.UNKNOWN_POWER_MW},
+					// Implausibly small (#152): a charging phone never takes in under ~0.1 W — such a
+					// result is a wrong-unit misread (Kirin reports CURRENT_NOW in mA, so a real fast
+					// charge computes to ~3-4 mW), not a real trickle.
+					{"Kirin mA-unit misread (~3.8 mW)", 1_000, 3_800, ChargeSpeed.UNKNOWN_POWER_MW},
+					{"just under plausibility floor", 24_750, 4_000, ChargeSpeed.UNKNOWN_POWER_MW},
+					{"at plausibility floor", 25_000, 4_000, 100},
 			});
 		}
 
@@ -128,6 +134,16 @@ public class ChargeSpeedTest {
 			assertTrue(speed.isKnown());
 			assertEquals(ChargeSpeedTier.TRICKLE, speed.getTier());
 			assertEquals(0, speed.getWatts());
+		}
+
+		@Test
+		public void kirinMisreadCurrent_isUnknownNotTrickle() {
+			// The end-to-end #152 case: Kirin's mA-unit raw (~1000 while fast charging) used to classify
+			// as a known Trickle (~3 mW), mislabeling the tier everywhere and firing the slow-charge
+			// warning (#123) on every charge. It must read as unknown, which keeps both quiet.
+			final ChargeSpeed speed = ChargeSpeed.fromMeasurements(1_000, 3_800);
+			assertFalse(speed.isKnown());
+			assertEquals(ChargeSpeedTier.UNKNOWN, speed.getTier());
 		}
 
 		@Test

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
@@ -156,6 +156,43 @@ public class BatteryRateTrackerTest {
 		}
 
 		@Test
+		public void kirinMisreadCurrent_isHiddenWhileRateStillShown() {
+			// Kirin/HiSilicon reports CURRENT_NOW in mA, not µA (#152): a real ~800 mA draw arrives as
+			// raw -800, which used to display as a nonsense "−1 mA". The display floor hides it; the
+			// level-over-time rate (source B) is unit-independent and stays.
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -800),
+					new Sample(360_000, 47, -800));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 360_000, -800);
+
+			assertTrue(rate.hasRate());
+			assertFalse(rate.hasCurrent());
+		}
+
+		@Test
+		public void currentJustBelowDisplayFloor_isHidden() {
+			// 9.4 mA rounds to 9, one below MIN_DISPLAY_CURRENT_MA (#152).
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -9_400),
+					new Sample(360_000, 47, -9_400));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 360_000, -9_400);
+
+			assertFalse(rate.hasCurrent());
+		}
+
+		@Test
+		public void currentAtDisplayFloor_isShown() {
+			// 9.5 mA rounds to exactly MIN_DISPLAY_CURRENT_MA — the floor is inclusive (#152).
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -9_500),
+					new Sample(360_000, 47, -9_500));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 360_000, -9_500);
+
+			assertTrue(rate.hasCurrent());
+			assertEquals(-10, rate.currentMilliAmps());
+		}
+
+		@Test
 		public void currentZero_isHiddenWhileRateStillShown() {
 			final List<Sample> window = Arrays.asList(
 					new Sample(0, 50, NO_CURRENT),

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/CurrentUnitCalibratorTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/CurrentUnitCalibratorTest.java
@@ -1,0 +1,191 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.almothafar.simplebatterynotifier.service.CurrentUnitCalibrator.Observation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the CURRENT_NOW unit auto-calibration (issue #152 v2). The pure helpers — the
+ * observation fold, the mA-units conclusion, and the scaling — carry the feature's correctness;
+ * currents are raw {@code getIntProperty} values, times in millis.
+ */
+@RunWith(Enclosed.class)
+public class CurrentUnitCalibratorTest {
+
+	private static final int SAMPLES = CurrentUnitCalibrator.MIN_OBSERVED_SAMPLES;
+	private static final int FLOOR = CurrentUnitCalibrator.MICRO_AMP_FLOOR_RAW;
+	private static final long SPACING = CurrentUnitCalibrator.MIN_COUNT_SPACING_MS;
+
+	/**
+	 * {@link CurrentUnitCalibrator#observe}: the max-tracking, the count spacing rule, the count cap,
+	 * and the unchanged-instance contract the persist-on-change relies on.
+	 */
+	public static class Observe {
+
+		@Test
+		public void firstReadingCountsAndSetsMax() {
+			final Observation result = CurrentUnitCalibrator.observe(new Observation(0, 0, 0), -800, SPACING);
+
+			assertEquals(new Observation(800, 1, SPACING), result);
+		}
+
+		@Test
+		public void maxTracksMagnitudeRegardlessOfSign() {
+			final Observation result = CurrentUnitCalibrator.observe(new Observation(800, 1, 0), -1_500, SPACING);
+
+			assertEquals(1_500, result.maxAbsRaw());
+		}
+
+		@Test
+		public void closelySpacedReadingIsNotCounted() {
+			final Observation previous = new Observation(800, 1, 100_000);
+			final Observation result = CurrentUnitCalibrator.observe(previous, -700, 100_000 + SPACING - 1);
+
+			assertEquals(1, result.observedCount());
+		}
+
+		@Test
+		public void closelySpacedReadingStillRaisesMax() {
+			// The max must never miss a large reading, even inside the count-spacing window — it is
+			// what protects a genuine-µA device from being mislabeled.
+			final Observation previous = new Observation(800, 1, 100_000);
+			final Observation result = CurrentUnitCalibrator.observe(previous, -250_000, 100_000 + 1);
+
+			assertEquals(250_000, result.maxAbsRaw());
+			assertEquals(1, result.observedCount());
+		}
+
+		@Test
+		public void spacedReadingIsCounted() {
+			final Observation previous = new Observation(800, 1, 100_000);
+			final Observation result = CurrentUnitCalibrator.observe(previous, -700, 100_000 + SPACING);
+
+			assertEquals(2, result.observedCount());
+			assertEquals(100_000 + SPACING, result.lastObservedAt());
+		}
+
+		@Test
+		public void countStopsAtTheCap() {
+			// Once concluded-or-not, counting stops for good — this is what bounds lifetime pref writes.
+			final Observation previous = new Observation(800, SAMPLES, 100_000);
+			final Observation result = CurrentUnitCalibrator.observe(previous, -700, 100_000 + 10 * SPACING);
+
+			assertSame(previous, result);
+		}
+
+		@Test
+		public void unchangedObservationReturnsSameInstance() {
+			final Observation previous = new Observation(800, 1, 100_000);
+			final Observation result = CurrentUnitCalibrator.observe(previous, -700, 100_000 + 1);
+
+			assertSame(previous, result); // caller skips the persist
+		}
+	}
+
+	/**
+	 * {@link CurrentUnitCalibrator#isMilliAmpUnits}: the conclusion needs both enough spaced readings
+	 * and a maximum still below the µA floor.
+	 */
+	@RunWith(Parameterized.class)
+	public static class IsMilliAmpUnits {
+
+		@Parameter(0) public String label;
+		@Parameter(1) public int maxAbsRaw;
+		@Parameter(2) public int observedCount;
+		@Parameter(3) public boolean expected;
+
+		@Parameters(name = "{0}")
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{
+					{"Kirin-like max after full observation", 2_000, SAMPLES, true},
+					{"just below the floor after full observation", FLOOR - 1, SAMPLES, true},
+					{"at the floor: genuine µA", FLOOR, SAMPLES, false},
+					{"typical µA device (screen-on draw)", 250_000, SAMPLES, false},
+					{"not enough observation yet", 2_000, SAMPLES - 1, false},
+					{"nothing observed", 0, 0, false},
+			});
+		}
+
+		@Test
+		public void matchesExpected() {
+			assertEquals(label, expected,
+					CurrentUnitCalibrator.isMilliAmpUnits(new Observation(maxAbsRaw, observedCount, 0)));
+		}
+	}
+
+	/**
+	 * {@link CurrentUnitCalibrator#scaledMicroAmps}: &times;1000 under a mA conclusion, untouched otherwise.
+	 */
+	public static class ScaledMicroAmps {
+
+		@Test
+		public void milliAmpUnitsScaleUp() {
+			assertEquals(-800_000, CurrentUnitCalibrator.scaledMicroAmps(-800, true));
+			assertEquals(1_500_000, CurrentUnitCalibrator.scaledMicroAmps(1_500, true));
+		}
+
+		@Test
+		public void microAmpUnitsPassThrough() {
+			assertEquals(-800_000, CurrentUnitCalibrator.scaledMicroAmps(-800_000, false));
+		}
+	}
+
+	/**
+	 * {@link CurrentUnitCalibrator#observeAndScale}: the Context-backed entry point — sentinel/blank
+	 * passthrough and the not-yet-concluded default. The decision/scaling math is covered by the pure
+	 * tests above; this exercises the wiring under Robolectric like the other Context-backed helpers.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class ObserveAndScale {
+
+		private Context context;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+		}
+
+		@Test
+		public void unsupportedSentinelPassesThrough() {
+			assertEquals(Integer.MIN_VALUE, CurrentUnitCalibrator.observeAndScale(context, Integer.MIN_VALUE));
+			assertEquals(Integer.MAX_VALUE, CurrentUnitCalibrator.observeAndScale(context, Integer.MAX_VALUE));
+		}
+
+		@Test
+		public void blankZeroPassesThrough() {
+			assertEquals(0, CurrentUnitCalibrator.observeAndScale(context, 0));
+		}
+
+		@Test
+		public void freshDeviceIsNotScaled() {
+			// No conclusion without observation: the very first reading returns unscaled µA.
+			assertEquals(-800, CurrentUnitCalibrator.observeAndScale(context, -800));
+		}
+
+		@Test
+		public void typicalMicroAmpReadingStaysUnscaled() {
+			assertEquals(-250_000, CurrentUnitCalibrator.observeAndScale(context, -250_000));
+		}
+	}
+}


### PR DESCRIPTION
**Stacked on #169** (v1 floors) — review/merge that first; this PR's diff is just the calibration commit.

v1 stops the Kirin garbage from being *displayed*; this makes the readings *correct* there instead of hidden.

## How it works
New `CurrentUnitCalibrator`, hooked into the single read point `SystemService.getInstantaneousCurrentMicroAmps`, so the rate tracker, the Current row, and `ChargeSpeed` all see the same corrected value:

- Persistently tracks the **maximum |raw|** `CURRENT_NOW` value ever observed (across sessions, charging and discharging alike).
- A genuine-µA device exceeds 20,000 (20 mA) within moments of awake use — screen-on draw alone is 100,000+. A mA-unit device physically can't reach it (that would be a sustained 20+ A).
- After **60 readings spaced ≥ 1 min apart** (≥ 1 h cumulative observation) with the max still below the floor → conclude mA units → scale readings ×1000.

Safety properties:
- Observation records the **raw** value (pre-scaling), so scaled outputs can't feed back into the decision — no oscillation.
- A later large reading (e.g. firmware fixes the unit) voids the conclusion **in the same call**, immediately and permanently. That ordering also caps any scaled value at < 20,000,000 µA — no int overflow.
- Preference churn is bounded: the max plateaus in minutes, counting stops for good at the cap; the steady-state path writes nothing.
- Sentinels (`Integer.MIN_VALUE`/`MAX_VALUE`) and blank 0 pass through untouched.

Side benefit: once calibrated, source A of the %/h rate (current ÷ capacity) works automatically with scaled current on any such device where capacity is known.

Known transient: at the moment the conclusion first flips on, the rate window still holds pre-scaling samples for up to 10 minutes; on Kirin source A is off anyway (capacity 0), so this is harmless and self-heals.

## Tests
Pure helpers fully covered (`observe` fold: max tracking, spacing throttle, count cap, unchanged-instance contract; `isMilliAmpUnits` boundaries at the floor and the sample cap; scaling incl. sign) plus Robolectric passthrough tests for the entry point. `testDebugUnitTest` + `lintDebug` pass.

## On-device verification needed before merging (Mate 10 Pro)
- [ ] Confirm raw magnitudes match expectation (~200–2000 discharging, ~1000–2000 charging) — e.g. temporarily log `getIntProperty(CURRENT_NOW)`
- [ ] After ~1 h of use, the Current row/notification shows realistic values (hundreds of mA, not ±1)
- [ ] Charging tier + wattage look sane while charging; no false slow-charge warning

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)