### PR TITLE
Current row: moment value with windowed average, stable visibility (#173)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
@@ -452,10 +452,11 @@ public final class BatteryRateTracker {
 	}
 
 	/**
-	 * Formats the windowed-average line shown under the instantaneous current, e.g. {@code "avg: −245"}
-	 * (#173): the moment value stays the headline; this line gives it a stable anchor. The average
-	 * repeats the sign but not the unit, to stay compact. Western digits in every locale (#96). The
-	 * caller renders it as a second, smaller line (see {@code BatteryDetailsFragment}).
+	 * Formats the windowed-average line shown under the instantaneous current, e.g.
+	 * {@code "avg: −245 mA"} (#173): the moment value stays the headline; this line gives it a stable
+	 * anchor. The value goes through {@link #formatCurrentValue} so the sign, unit, and Western-digit
+	 * guarantee (#96) can't drift from the instant above it. The caller renders it as a second,
+	 * smaller line (see {@code BatteryDetailsFragment}).
 	 *
 	 * @param context            Application context
 	 * @param signedAvgMilliAmps signed windowed-average current in mA
@@ -463,8 +464,7 @@ public final class BatteryRateTracker {
 	 * @return the formatted average line
 	 */
 	public static String formatAverageCurrentLine(final Context context, final int signedAvgMilliAmps) {
-		final String sign = signedAvgMilliAmps >= 0 ? "+" : "−"; // U+2212, matching formatCurrentValue
-		return context.getString(R.string.battery_current_avg_line, sign + Math.abs(signedAvgMilliAmps));
+		return context.getString(R.string.battery_current_avg_line, formatCurrentValue(context, signedAvgMilliAmps));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
@@ -452,23 +452,19 @@ public final class BatteryRateTracker {
 	}
 
 	/**
-	 * Formats the instantaneous current with its windowed average, e.g. {@code "−208 mA (avg: −245)"}
-	 * (#173): the moment value stays the headline, the average gives the number a stable anchor. The
-	 * average repeats the sign but not the unit, to keep the row compact. Western digits in every
-	 * locale (#96).
+	 * Formats the windowed-average line shown under the instantaneous current, e.g. {@code "avg: −245"}
+	 * (#173): the moment value stays the headline; this line gives it a stable anchor. The average
+	 * repeats the sign but not the unit, to stay compact. Western digits in every locale (#96). The
+	 * caller renders it as a second, smaller line (see {@code BatteryDetailsFragment}).
 	 *
-	 * @param context             Application context
-	 * @param signedMilliAmps     signed instantaneous current in mA
-	 * @param signedAvgMilliAmps  signed windowed-average current in mA
+	 * @param context            Application context
+	 * @param signedAvgMilliAmps signed windowed-average current in mA
 	 *
-	 * @return the formatted current string
+	 * @return the formatted average line
 	 */
-	public static String formatCurrentWithAverage(final Context context,
-	                                              final int signedMilliAmps,
-	                                              final int signedAvgMilliAmps) {
-		final String avgSign = signedAvgMilliAmps >= 0 ? "+" : "−";
-		return context.getString(R.string.battery_current_value_with_avg,
-				formatCurrentValue(context, signedMilliAmps), avgSign + Math.abs(signedAvgMilliAmps));
+	public static String formatAverageCurrentLine(final Context context, final int signedAvgMilliAmps) {
+		final String sign = signedAvgMilliAmps >= 0 ? "+" : "−"; // U+2212, matching formatCurrentValue
+		return context.getString(R.string.battery_current_avg_line, sign + Math.abs(signedAvgMilliAmps));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
@@ -257,6 +257,11 @@ public final class BatteryRateTracker {
 	 * a plausible ceiling (a garbage reading). The current is reported independently, signed by
 	 * direction so it reads negative while discharging and positive while charging regardless of the
 	 * device's raw sign convention — and only when it clears {@link #MIN_DISPLAY_CURRENT_MA} (#152).
+	 * <p>
+	 * The windowed <em>average</em> current is reported alongside the instant (#173), and when available
+	 * it also takes over the floor gate: the average moves slowly, so the row's visibility is stable —
+	 * a momentary dip below the floor no longer blinks the row out, while sustained-garbage readings
+	 * (whose average is also below the floor) stay hidden.
 	 *
 	 * @param window                 samples oldest-first
 	 * @param capacityMah            measured full capacity in mAh, or 0 when unknown/untrusted (#69)
@@ -268,14 +273,52 @@ public final class BatteryRateTracker {
 	 */
 	static BatteryRate computeRate(final List<Sample> window, final int capacityMah, final boolean charging,
 	                               final long nowMillis, final int latestCurrentMicroAmps) {
+		// Floor-gate on the windowed average when available (#173): the average moves slowly, so the
+		// row's visibility can't flicker with a momentary dip, and sustained garbage (Kirin pre-#152-v2
+		// calibration averages ~1 mA) stays hidden. The instant gates itself only while the window is
+		// still too fresh to average.
+		final int avgMicroAmps = averagedCurrentMicroAmps(window);
+		final boolean hasAvg = avgMicroAmps != PROPERTY_UNSUPPORTED;
+		final int floorGateMicroAmps = hasAvg ? avgMicroAmps : latestCurrentMicroAmps;
 		final boolean hasCurrent = isPlausibleCurrentMicroAmps(latestCurrentMicroAmps)
-				&& Math.round(Math.abs(latestCurrentMicroAmps) / 1000f) >= MIN_DISPLAY_CURRENT_MA;
+				&& Math.round(Math.abs(floorGateMicroAmps) / 1000f) >= MIN_DISPLAY_CURRENT_MA;
 		final int signedMilliAmps = hasCurrent ? signedCurrentMilliAmps(latestCurrentMicroAmps, charging) : 0;
+		final boolean hasAvgCurrent = hasCurrent && hasAvg;
+		final int signedAvgMilliAmps = hasAvgCurrent ? signedCurrentMilliAmps(avgMicroAmps, charging) : 0;
 
 		final int pph = ratePercentPerHour(window, capacityMah);
 		final boolean hasRate = pph >= 1 && pph <= MAX_PLAUSIBLE_RATE_PPH;
 
-		return new BatteryRate(hasRate, hasRate ? pph : 0, charging, hasCurrent, signedMilliAmps);
+		return new BatteryRate(hasRate, hasRate ? pph : 0, charging, hasCurrent, signedMilliAmps, hasAvgCurrent, signedAvgMilliAmps);
+	}
+
+	/**
+	 * The averaged instantaneous current over the window in µA, or {@link Integer#MIN_VALUE} when the
+	 * window doesn't yet hold enough spaced plausible readings — the same smoothing criteria source A
+	 * uses ({@link #MIN_CURRENT_SAMPLES} readings spanning {@link #MIN_SPAN_CURRENT_MS}), extracted so
+	 * the rate source and the displayed average (#173) can't disagree. Pure so it is unit-testable.
+	 *
+	 * @param window samples oldest-first
+	 *
+	 * @return averaged current in µA, or {@link Integer#MIN_VALUE} when not enough data yet
+	 */
+	static int averagedCurrentMicroAmps(final List<Sample> window) {
+		if (window.size() < 2) {
+			return PROPERTY_UNSUPPORTED;
+		}
+		final long spanMs = window.get(window.size() - 1).timeMillis() - window.get(0).timeMillis();
+		double sumMicroAmps = 0;
+		int currentSamples = 0;
+		for (final Sample s : window) {
+			if (isPlausibleCurrentMicroAmps(s.currentMicroAmps())) {
+				sumMicroAmps += s.currentMicroAmps();
+				currentSamples++;
+			}
+		}
+		if (currentSamples < MIN_CURRENT_SAMPLES || spanMs < MIN_SPAN_CURRENT_MS) {
+			return PROPERTY_UNSUPPORTED;
+		}
+		return (int) Math.round(sumMicroAmps / currentSamples);
 	}
 
 	/**
@@ -296,18 +339,10 @@ public final class BatteryRateTracker {
 		final Sample last = window.get(window.size() - 1);
 		final long spanMs = last.timeMillis() - first.timeMillis();
 
-		// Source A: averaged current / capacity.
-		double sumMilliAmps = 0;
-		int currentSamples = 0;
-		for (final Sample s : window) {
-			if (isPlausibleCurrentMicroAmps(s.currentMicroAmps())) {
-				sumMilliAmps += s.currentMicroAmps() / 1000.0;
-				currentSamples++;
-			}
-		}
-		if (capacityMah > 0 && currentSamples >= MIN_CURRENT_SAMPLES && spanMs >= MIN_SPAN_CURRENT_MS) {
-			final double avgMilliAmps = sumMilliAmps / currentSamples;
-			return (int) Math.round(Math.abs(avgMilliAmps) / capacityMah * 100.0);
+		// Source A: averaged current / capacity (average shared with the displayed avg current, #173).
+		final int avgMicroAmps = averagedCurrentMicroAmps(window);
+		if (capacityMah > 0 && avgMicroAmps != PROPERTY_UNSUPPORTED) {
+			return (int) Math.round(Math.abs(avgMicroAmps / 1000.0) / capacityMah * 100.0);
 		}
 
 		// Source B: level change over time (capacity-free).
@@ -414,6 +449,26 @@ public final class BatteryRateTracker {
 	public static String formatCurrentValue(final Context context, final int signedMilliAmps) {
 		final String sign = signedMilliAmps >= 0 ? "+" : "−"; // U+2212 MINUS SIGN reads cleaner than '-'
 		return context.getString(R.string.battery_current_value, sign + Math.abs(signedMilliAmps));
+	}
+
+	/**
+	 * Formats the instantaneous current with its windowed average, e.g. {@code "−208 mA (avg: −245)"}
+	 * (#173): the moment value stays the headline, the average gives the number a stable anchor. The
+	 * average repeats the sign but not the unit, to keep the row compact. Western digits in every
+	 * locale (#96).
+	 *
+	 * @param context             Application context
+	 * @param signedMilliAmps     signed instantaneous current in mA
+	 * @param signedAvgMilliAmps  signed windowed-average current in mA
+	 *
+	 * @return the formatted current string
+	 */
+	public static String formatCurrentWithAverage(final Context context,
+	                                              final int signedMilliAmps,
+	                                              final int signedAvgMilliAmps) {
+		final String avgSign = signedAvgMilliAmps >= 0 ? "+" : "−";
+		return context.getString(R.string.battery_current_value_with_avg,
+				formatCurrentValue(context, signedMilliAmps), avgSign + Math.abs(signedAvgMilliAmps));
 	}
 
 	/**
@@ -525,19 +580,23 @@ public final class BatteryRateTracker {
 
 	/**
 	 * Result of a rate computation: the smoothed %/h and the signed instantaneous current, each with a
-	 * flag saying whether it is trustworthy enough to display.
+	 * flag saying whether it is trustworthy enough to display, plus the windowed average current shown
+	 * next to the instant (#173).
 	 *
-	 * @param hasRate         whether a trustworthy %/h is available
-	 * @param percentPerHour  rate magnitude in %/h (valid only when {@code hasRate})
-	 * @param charging        direction: true charging (charge rate), false discharging (drain rate)
-	 * @param hasCurrent      whether a trustworthy instantaneous current is available
-	 * @param currentMilliAmps signed current in mA (valid only when {@code hasCurrent})
+	 * @param hasRate             whether a trustworthy %/h is available
+	 * @param percentPerHour      rate magnitude in %/h (valid only when {@code hasRate})
+	 * @param charging            direction: true charging (charge rate), false discharging (drain rate)
+	 * @param hasCurrent          whether a trustworthy instantaneous current is available
+	 * @param currentMilliAmps    signed current in mA (valid only when {@code hasCurrent})
+	 * @param hasAvgCurrent       whether the windowed average current is available for display
+	 * @param avgCurrentMilliAmps signed windowed-average current in mA (valid only when {@code hasAvgCurrent})
 	 */
 	public record BatteryRate(boolean hasRate, int percentPerHour, boolean charging,
-	                          boolean hasCurrent, int currentMilliAmps) {
+	                          boolean hasCurrent, int currentMilliAmps,
+	                          boolean hasAvgCurrent, int avgCurrentMilliAmps) {
 
 		static BatteryRate empty() {
-			return new BatteryRate(false, 0, false, false, 0);
+			return new BatteryRate(false, 0, false, false, 0, false, 0);
 		}
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -385,8 +385,12 @@ public class BatteryDetailsFragment extends Fragment {
 		}
 		addTimeToFullRow(view, rate);
 		if (rate.hasCurrent()) {
-			valuesMap.put(getResources().getString(R.string.battery_current),
-					BatteryRateTracker.formatCurrentValue(view.getContext(), rate.currentMilliAmps()));
+			// #173: the moment value stays the headline; the windowed average rides along in parentheses
+			// once the window has enough data, anchoring the ticking instant to a stable figure.
+			final String currentValue = rate.hasAvgCurrent()
+					? BatteryRateTracker.formatCurrentWithAverage(view.getContext(), rate.currentMilliAmps(), rate.avgCurrentMilliAmps())
+					: BatteryRateTracker.formatCurrentValue(view.getContext(), rate.currentMilliAmps());
+			valuesMap.put(getResources().getString(R.string.battery_current), currentValue);
 		}
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -7,6 +7,10 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.RelativeSizeSpan;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -47,8 +51,11 @@ public class BatteryDetailsFragment extends Fragment {
 	private static final int SCROLL_HINT_BOB_COUNT = 2;       // how many bobs
 	private static final int SCROLL_HINT_REVEAL_DP = 96;      // max peek distance
 
+	// #173: the avg line under the Current value renders at this fraction of the cell's text size.
+	private static final float AVG_LINE_SIZE_RATIO = 0.8f;
+
 	private BatteryDO batteryDO;
-	private Map<String, String> valuesMap;
+	private Map<String, CharSequence> valuesMap;
 	private View viewRef;
 
 	// #94: when this device's charge counter can't be trusted, the Capacity row shows "Unknown" with a
@@ -210,7 +217,7 @@ public class BatteryDetailsFragment extends Fragment {
 	 *
 	 * @return The created table row
 	 */
-	private TableRow createTableRow(final View view, final String label, final String value,
+	private TableRow createTableRow(final View view, final String label, final CharSequence value,
 	                                final int cellPadding, final int cellPaddingTop,
 	                                final boolean valueUnreliable, final int valueColor) {
 		final TableRow row = new TableRow(view.getContext());
@@ -290,7 +297,7 @@ public class BatteryDetailsFragment extends Fragment {
 	 * @return The created TextView
 	 */
 	private TextView createValueTextView(final View view,
-	                                     final String text,
+	                                     final CharSequence text,
 	                                     final int cellPadding,
 	                                     final int cellPaddingTop,
 	                                     final boolean unreliable,
@@ -385,12 +392,7 @@ public class BatteryDetailsFragment extends Fragment {
 		}
 		addTimeToFullRow(view, rate);
 		if (rate.hasCurrent()) {
-			// #173: the moment value stays the headline; the windowed average rides along in parentheses
-			// once the window has enough data, anchoring the ticking instant to a stable figure.
-			final String currentValue = rate.hasAvgCurrent()
-					? BatteryRateTracker.formatCurrentWithAverage(view.getContext(), rate.currentMilliAmps(), rate.avgCurrentMilliAmps())
-					: BatteryRateTracker.formatCurrentValue(view.getContext(), rate.currentMilliAmps());
-			valuesMap.put(getResources().getString(R.string.battery_current), currentValue);
+			valuesMap.put(getResources().getString(R.string.battery_current), currentValueText(view, rate));
 		}
 	}
 
@@ -419,6 +421,32 @@ public class BatteryDetailsFragment extends Fragment {
 		}
 		valuesMap.put(getResources().getString(R.string.time_to_full),
 				BatteryRateTracker.formatTimeToFull(view.getContext(), minutes));
+	}
+
+	/**
+	 * The Current row's value (#173): the moment value as the headline, and — once the window has
+	 * enough data — the windowed average on its own second line, rendered smaller and in the label
+	 * colour so it reads as a quiet anchor under the ticking instant. A second line (rather than an
+	 * inline "(avg: …)") because the inline form wrapped mid-parenthesis in narrow columns, larger
+	 * font scales, and Arabic.
+	 *
+	 * @param view The fragment view
+	 * @param rate The already-computed rate for this refresh
+	 *
+	 * @return the styled value text for the Current row
+	 */
+	private CharSequence currentValueText(final View view, final BatteryRateTracker.BatteryRate rate) {
+		final String instant = BatteryRateTracker.formatCurrentValue(view.getContext(), rate.currentMilliAmps());
+		if (!rate.hasAvgCurrent()) {
+			return instant;
+		}
+		final String avgLine = BatteryRateTracker.formatAverageCurrentLine(view.getContext(), rate.avgCurrentMilliAmps());
+		final SpannableString styled = new SpannableString(instant + "\n" + avgLine);
+		final int avgStart = instant.length() + 1;
+		styled.setSpan(new RelativeSizeSpan(AVG_LINE_SIZE_RATIO), avgStart, styled.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+		styled.setSpan(new ForegroundColorSpan(GeneralHelper.getColor(getResources(), R.color.battery_details_label_color)),
+				avgStart, styled.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+		return styled;
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -158,6 +158,8 @@
     <!-- معدل الشحن/الاستهلاك (#108) -->
     <string name="battery_rate_value">%1$s%%/h</string>
     <string name="battery_current_value">%1$s mA</string>
+    <!-- #173: القيمة اللحظية مع متوسط النافذة -->
+    <string name="battery_current_value_with_avg">%1$s (المتوسط: %2$s)</string>
     <!-- #124: الوحدات h/m تبقى لاتينية كبقية قيم المعدل -->
     <string name="time_to_full_value_hm">~%1$sh %2$sm</string>
     <string name="time_to_full_value_m">~%1$sm</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -158,8 +158,9 @@
     <!-- معدل الشحن/الاستهلاك (#108) -->
     <string name="battery_rate_value">%1$s%%/h</string>
     <string name="battery_current_value">%1$s mA</string>
-    <!-- #173: سطر المتوسط الأصغر تحت القيمة اللحظية -->
-    <string name="battery_current_avg_line">المتوسط: %1$s</string>
+    <!-- #173: سطر المتوسط الأصغر تحت القيمة اللحظية. "avg" تبقى لاتينية عمداً (قرار المشرف): السطر
+         خليط لاتيني أصلاً (الإشارة والوحدة mA)، وتعريبها وحدها يكسر اتجاه النص. يعاد النظر لاحقاً. -->
+    <string name="battery_current_avg_line">avg: %1$s</string>
     <!-- #124: الوحدات h/m تبقى لاتينية كبقية قيم المعدل -->
     <string name="time_to_full_value_hm">~%1$sh %2$sm</string>
     <string name="time_to_full_value_m">~%1$sm</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -158,8 +158,8 @@
     <!-- معدل الشحن/الاستهلاك (#108) -->
     <string name="battery_rate_value">%1$s%%/h</string>
     <string name="battery_current_value">%1$s mA</string>
-    <!-- #173: القيمة اللحظية مع متوسط النافذة -->
-    <string name="battery_current_value_with_avg">%1$s (المتوسط: %2$s)</string>
+    <!-- #173: سطر المتوسط الأصغر تحت القيمة اللحظية -->
+    <string name="battery_current_avg_line">المتوسط: %1$s</string>
     <!-- #124: الوحدات h/m تبقى لاتينية كبقية قيم المعدل -->
     <string name="time_to_full_value_hm">~%1$sh %2$sm</string>
     <string name="time_to_full_value_m">~%1$sm</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,9 +168,9 @@
     <string name="battery_rate_value">%1$s%%/h</string>
     <!-- %1$s is a signed Western-digit number, e.g. "+900" or "−450" -->
     <string name="battery_current_value">%1$s mA</string>
-    <!-- #173: instant current with its windowed average. %1$s is the formatted battery_current_value
-         ("−208 mA"), %2$s a signed Western-digit number ("−245") — sign repeated, unit not, for compactness -->
-    <string name="battery_current_value_with_avg">%1$s (avg: %2$s)</string>
+    <!-- #173: the windowed average, rendered as its own smaller line under the instant current.
+         %1$s is a signed Western-digit number ("−245") — sign repeated, unit not, for compactness -->
+    <string name="battery_current_avg_line">avg: %1$s</string>
     <!-- #124: time-to-full duration. %1$s hours, %2$s minutes — Western-digit numbers (String.valueOf);
          the h/m units stay Latin like the other rate values (#96). -->
     <string name="time_to_full_value_hm">~%1$sh %2$sm</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,6 +168,9 @@
     <string name="battery_rate_value">%1$s%%/h</string>
     <!-- %1$s is a signed Western-digit number, e.g. "+900" or "−450" -->
     <string name="battery_current_value">%1$s mA</string>
+    <!-- #173: instant current with its windowed average. %1$s is the formatted battery_current_value
+         ("−208 mA"), %2$s a signed Western-digit number ("−245") — sign repeated, unit not, for compactness -->
+    <string name="battery_current_value_with_avg">%1$s (avg: %2$s)</string>
     <!-- #124: time-to-full duration. %1$s hours, %2$s minutes — Western-digit numbers (String.valueOf);
          the h/m units stay Latin like the other rate values (#96). -->
     <string name="time_to_full_value_hm">~%1$sh %2$sm</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,7 +169,7 @@
     <!-- %1$s is a signed Western-digit number, e.g. "+900" or "−450" -->
     <string name="battery_current_value">%1$s mA</string>
     <!-- #173: the windowed average, rendered as its own smaller line under the instant current.
-         %1$s is a signed Western-digit number ("−245") — sign repeated, unit not, for compactness -->
+         %1$s is the formatted battery_current_value ("−245 mA") -->
     <string name="battery_current_avg_line">avg: %1$s</string>
     <!-- #124: time-to-full duration. %1$s hours, %2$s minutes — Western-digit numbers (String.valueOf);
          the h/m units stay Latin like the other rate values (#96). -->

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
@@ -156,6 +156,50 @@ public class BatteryRateTrackerTest {
 		}
 
 		@Test
+		public void momentaryDipBelowFloor_staysShownViaAverageGate() {
+			// #173: a real ~278 mA draw whose latest instant dips to 6 mA — the windowed average carries
+			// the floor gate, so the row doesn't blink out; the instant stays the displayed headline.
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -278_000),
+					new Sample(30_000, 50, -278_000),
+					new Sample(60_000, 50, -278_000));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 60_000, -6_000);
+
+			assertTrue(rate.hasCurrent());
+			assertEquals(-6, rate.currentMilliAmps());
+			assertTrue(rate.hasAvgCurrent());
+			assertEquals(-278, rate.avgCurrentMilliAmps());
+		}
+
+		@Test
+		public void sustainedSubFloorAverage_isHidden() {
+			// #173: when the *average* is also below the floor (Kirin pre-calibration garbage, deep
+			// sleep), the row stays hidden — the stable gate hides sustained noise, not just instants.
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -800),
+					new Sample(30_000, 50, -800),
+					new Sample(60_000, 50, -800));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 60_000, -800);
+
+			assertFalse(rate.hasCurrent());
+			assertFalse(rate.hasAvgCurrent());
+		}
+
+		@Test
+		public void freshWindow_instantGatesItselfWithoutAverage() {
+			// Two samples can't average yet (#173): the instant carries the floor gate alone and the
+			// avg segment is absent.
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -208_000),
+					new Sample(20_000, 50, -208_000));
+			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 20_000, -208_000);
+
+			assertTrue(rate.hasCurrent());
+			assertEquals(-208, rate.currentMilliAmps());
+			assertFalse(rate.hasAvgCurrent());
+		}
+
+		@Test
 		public void kirinMisreadCurrent_isHiddenWhileRateStillShown() {
 			// Kirin/HiSilicon reports CURRENT_NOW in mA, not µA (#152): a real ~800 mA draw arrives as
 			// raw -800, which used to display as a nonsense "−1 mA". The display floor hides it; the
@@ -211,6 +255,53 @@ public class BatteryRateTrackerTest {
 			final BatteryRate rate = BatteryRateTracker.computeRate(window, 0, false, 360_000, NO_CURRENT);
 
 			assertFalse(rate.hasCurrent());
+		}
+	}
+
+	/**
+	 * {@link BatteryRateTracker#averagedCurrentMicroAmps}: the shared windowed average (#173) — needs
+	 * enough spaced plausible readings, skips implausible ones, and signals "not yet" otherwise.
+	 */
+	public static class AveragedCurrent {
+
+		@Test
+		public void enoughSamples_returnsMean() {
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -300_000),
+					new Sample(30_000, 50, -200_000),
+					new Sample(60_000, 50, -250_000));
+
+			assertEquals(-250_000, BatteryRateTracker.averagedCurrentMicroAmps(window));
+		}
+
+		@Test
+		public void implausibleSamplesAreSkipped() {
+			// The NO_CURRENT sentinel doesn't drag the mean; but with it skipped only 2 plausible
+			// readings remain, below MIN_CURRENT_SAMPLES -> not yet.
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -300_000),
+					new Sample(30_000, 50, NO_CURRENT),
+					new Sample(60_000, 50, -200_000));
+
+			assertEquals(NO_CURRENT, BatteryRateTracker.averagedCurrentMicroAmps(window));
+		}
+
+		@Test
+		public void shortSpan_isNotEnough() {
+			// 3 readings but only 30s of span (< MIN_SPAN_CURRENT_MS): a burst, not a smoothed average.
+			final List<Sample> window = Arrays.asList(
+					new Sample(0, 50, -300_000),
+					new Sample(15_000, 50, -200_000),
+					new Sample(30_000, 50, -250_000));
+
+			assertEquals(NO_CURRENT, BatteryRateTracker.averagedCurrentMicroAmps(window));
+		}
+
+		@Test
+		public void tooFewSamples_isNotEnough() {
+			assertEquals(NO_CURRENT, BatteryRateTracker.averagedCurrentMicroAmps(List.of()));
+			assertEquals(NO_CURRENT, BatteryRateTracker.averagedCurrentMicroAmps(
+					List.of(new Sample(0, 50, -300_000))));
 		}
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
@@ -475,18 +475,18 @@ public class BatteryRateTrackerTest {
 
 		@Test
 		public void dischargingSignsNegative() {
-			assertEquals("avg: −245", BatteryRateTracker.formatAverageCurrentLine(context, -245));
+			assertEquals("avg: −245 mA", BatteryRateTracker.formatAverageCurrentLine(context, -245));
 		}
 
 		@Test
 		public void chargingSignsPositive() {
-			assertEquals("avg: +900", BatteryRateTracker.formatAverageCurrentLine(context, 900));
+			assertEquals("avg: +900 mA", BatteryRateTracker.formatAverageCurrentLine(context, 900));
 		}
 
 		@Test
 		@Config(qualifiers = "ar")
 		public void arabicLabelKeepsWesternDigits() {
-			assertEquals("المتوسط: −245", BatteryRateTracker.formatAverageCurrentLine(context, -245));
+			assertEquals("المتوسط: −245 mA", BatteryRateTracker.formatAverageCurrentLine(context, -245));
 		}
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
@@ -459,6 +459,38 @@ public class BatteryRateTrackerTest {
 	}
 
 	/**
+	 * {@link BatteryRateTracker#formatAverageCurrentLine}: the "avg: −245" line under the Current value
+	 * (#173) — signed like the instant, unitless for compactness, Western digits in every locale (#96).
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class FormatAverageCurrentLine {
+
+		private Context context;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+		}
+
+		@Test
+		public void dischargingSignsNegative() {
+			assertEquals("avg: −245", BatteryRateTracker.formatAverageCurrentLine(context, -245));
+		}
+
+		@Test
+		public void chargingSignsPositive() {
+			assertEquals("avg: +900", BatteryRateTracker.formatAverageCurrentLine(context, 900));
+		}
+
+		@Test
+		@Config(qualifiers = "ar")
+		public void arabicLabelKeepsWesternDigits() {
+			assertEquals("المتوسط: −245", BatteryRateTracker.formatAverageCurrentLine(context, -245));
+		}
+	}
+
+	/**
 	 * {@link BatteryRateTracker#isChargingDirection}: charging and full map to the charging direction.
 	 */
 	@RunWith(Parameterized.class)

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryRateTrackerTest.java
@@ -485,8 +485,10 @@ public class BatteryRateTrackerTest {
 
 		@Test
 		@Config(qualifiers = "ar")
-		public void arabicLabelKeepsWesternDigits() {
-			assertEquals("المتوسط: −245 mA", BatteryRateTracker.formatAverageCurrentLine(context, -245));
+		public void arabicKeepsLatinAvgLabel() {
+			// Deliberately identical to English (maintainer decision): the line is Latin-heavy already
+			// (sign + mA), so a lone Arabic word would just break the text direction. Revisit later.
+			assertEquals("avg: −245 mA", BatteryRateTracker.formatAverageCurrentLine(context, -245));
 		}
 	}
 


### PR DESCRIPTION
Follow-up to the #152 fixes, from on-device testing on the Mate 10 Pro. Base is master (#169/#170 merged; branch rebased).

The Current row blinked in and out whenever the instantaneous reading dipped below the 10 mA display floor, and each surface showed its own instant. Maintainer direction: keep the **moment value** as the headline (no smoothing it away, no show/hide flapping, no "—" placeholder) and show the windowed average alongside.

## What it looks like now
```
Current : −208 mA
          avg: −245 mA      ← second line, 0.8× size, label colour
```
- The average gets its **own smaller, dimmer line** under the moment value (the earlier inline `(avg: −245)` wrapped mid-parenthesis in narrow columns, larger font scales, and Arabic).
- The avg value goes through the same `formatCurrentValue` as the instant, so sign style, `mA` unit, and the Western-digit guarantee (#96) can't drift.
- **Arabic deliberately keeps the Latin "avg" label** (maintainer decision): the line is Latin-heavy already (sign + mA), and a lone Arabic word would break the text direction. Wording may be revisited later.

## Behavior
- **Average**: the same rolling 10-minute window the %/h rate uses (≥ 3 plausible readings over ≥ 45 s, extracted into a shared `averagedCurrentMicroAmps` helper so rate source A and the displayed average can't disagree). Resets on plug/unplug like the rate; until it's ready the row shows the instant alone.
- **Stable visibility**: the 10 mA floor gate runs on the **average** when available, instant-only while the window is fresh. The average moves slowly → the row's presence is stable; a momentary dip no longer hides it, while sustained garbage (pre-calibration Kirin ~1 mA averages) stays hidden as before.
- **Notification**: mA fallback unchanged (instant only — the line is already long); it inherits the stable gate via `hasCurrent`.
- `BatteryRate` gains `hasAvgCurrent`/`avgCurrentMilliAmps`; table cells accept `CharSequence` so the styled value flows through; new string `battery_current_avg_line`.

## Tests
Dip-below-floor stays shown via the avg gate; sustained sub-floor average hidden; fresh window gates on the instant without the avg line; `averagedCurrentMicroAmps` boundaries (mean, implausible-skip, short span, too few); `formatAverageCurrentLine` under en + ar. `testDebugUnitTest` + `lintDebug` green.

## On-device
Watch the Current row through a normal session — it should tick but never blink out, with the avg line appearing ~45 s into a steady window and tracking the sustained draw.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)