### PR TITLE
Details table: slightly smaller font (#174)

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -56,7 +56,10 @@
         <item name="android:windowTranslucentNavigation">false</item>
     </style>
 
+    <!-- Details-table cells (labels + values, its only users). TextAppearance.Medium's 18sp read a
+         touch large on-device (#174); 16sp — tune here if it needs another nudge. -->
     <style name="DefaultTextStyle" parent="@android:style/TextAppearance.Medium">
+        <item name="android:textSize">16sp</item>
     </style>
 
     <!-- SeekBar Preference style with better touch targets -->


### PR DESCRIPTION
Maintainer request while device-testing #152: the details-table text was a touch large.

`DefaultTextStyle` (inheriting 18sp from `TextAppearance.Medium`) is used only by the table's label and value cells, so an explicit `android:textSize` of **16sp** there resizes exactly the table and nothing else. Trivially tunable to 17sp if 16 looks too small on-device.

`lintDebug` green. On-device check: table readable in both English and Arabic.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)