### PR TITLE
One snapshot per broadcast: derive ChargeSpeed from the BatteryDO in hand (#157)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -1049,7 +1049,7 @@ public final class NotificationService {
 		// can (#125). The ChargeSpeed read (CURRENT_NOW × voltage) is charging-only, so the discharging path
 		// below is untouched; it falls through to the %/h → mA → plain chain when the speed can't be estimated.
 		if (rate.charging()) {
-			final String chargingSpeed = chargingSpeedSegment(context);
+			final String chargingSpeed = chargingSpeedSegment(context, batteryDO);
 			if (nonNull(chargingSpeed)) {
 				return chargingSpeed;
 			}
@@ -1069,12 +1069,16 @@ public final class NotificationService {
 	 * The tier label already reads as "… charging", so it replaces the plain "Charging" status word rather
 	 * than being appended to it. Returns null when the speed can't be estimated (e.g. a device that doesn't
 	 * report {@code CURRENT_NOW}), so the caller falls back to the %/h → mA → plain chain.
+	 * <p>
+	 * The speed is derived from the {@code batteryDO} snapshot, not a fresh hardware read, so this segment
+	 * judges the same reading as the details table and {@link SlowChargeDetector} within one tick (#157).
 	 *
-	 * @param context The application context
+	 * @param context   The application context
+	 * @param batteryDO Current battery snapshot (non-null; the caller already checked)
 	 * @return the formatted charging-speed segment, or null when the charge speed is unknown
 	 */
-	private static String chargingSpeedSegment(final Context context) {
-		final ChargeSpeed speed = SystemService.getChargeSpeed(context);
+	private static String chargingSpeedSegment(final Context context, final BatteryDO batteryDO) {
+		final ChargeSpeed speed = ChargeSpeed.fromMeasurements(batteryDO.getCurrentMicroAmps(), batteryDO.getVoltage());
 		if (!speed.isKnown()) {
 			return null;
 		}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
@@ -99,7 +99,9 @@ public final class SlowChargeDetector {
 			return;
 		}
 
-		final ChargeSpeed speed = SystemService.getChargeSpeed(context);
+		// Judge the snapshot in hand, not a fresh hardware read: every surface in this tick (table row,
+		// notification segment, this detector) must see the same reading (#157).
+		final ChargeSpeed speed = ChargeSpeed.fromMeasurements(batteryDO.getCurrentMicroAmps(), batteryDO.getVoltage());
 		final long now = System.currentTimeMillis();
 		final SlowChargeState previous = loadState(prefs);
 		final SlowChargeDecision decision = decide(previous, speed.isKnown(), speed.getMilliwatts(),

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -297,6 +297,11 @@ public final class SystemService {
 	 * after connection, once the current has stabilised — right at plug-in the current reads 0 or
 	 * noisy. Returns {@link ChargeSpeed#unknown()} when the device doesn't report instantaneous
 	 * current, so callers fall back to a plain "Charging" message.
+	 * <p>
+	 * This is the <em>fresh-read</em> path, meant only for the deliberately-delayed plug-in sample in
+	 * {@link com.almothafar.simplebatterynotifier.receiver.PowerConnectionReceiver} (#122). Surfaces
+	 * reacting to a battery broadcast must instead derive the speed from the {@code BatteryDO} in hand
+	 * ({@link ChargeSpeed#fromMeasurements}), so all of them judge the same reading within a tick (#157).
 	 *
 	 * @param context The application context
 	 *


### PR DESCRIPTION
Closes #157.

Within one battery broadcast, the slow-charge detector and the ongoing notification each did their own fresh `CURRENT_NOW` read (plus a sticky-broadcast re-read for voltage), so they could judge a different instantaneous value than the details table in the same tick — which is what made #152''s symptom look random around borderline values.

## Changes

- `SlowChargeDetector.evaluate` now derives the speed via `ChargeSpeed.fromMeasurements(batteryDO.getCurrentMicroAmps(), batteryDO.getVoltage())` instead of `SystemService.getChargeSpeed(context)`.
- `NotificationService.chargingSpeedSegment` takes the `BatteryDO` (already in scope at the call site) and derives the speed from it the same way.
- `SystemService.getChargeSpeed` javadoc now marks it as the fresh-read path reserved for the deliberately-delayed plug-in sample in `PowerConnectionReceiver` (#122) — which is now its only caller and is untouched.

The snapshot''s `currentMicroAmps` comes from the same `getInstantaneousCurrentMicroAmps` read (through `CurrentUnitCalibrator`), so the Kirin calibration (#152) still applies everywhere.

## Acceptance criteria

- [x] Within one broadcast, the table row, the notification segment, and `SlowChargeDetector` judge the same reading
- [x] No extra `registerReceiver`/`getIntProperty` calls beyond building the `BatteryDO` (removes two sticky re-reads + a binder call per broadcast)
- [x] Delayed plug-in sample path untouched
- [x] Tests: `testDebugUnitTest` passes. No test changes needed — `SlowChargeDetector.decide` (the tested pure core) is unchanged, `NotificationServiceTest` doesn''t cover the charging segment, and `ChargeSpeedTest` already covers `fromMeasurements`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)