### PR TITLE
Live sub-percent battery display: gauge + ongoing notification, one integer policy for alerts (#158)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/model/BatteryDO.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/model/BatteryDO.java
@@ -5,6 +5,12 @@ package com.almothafar.simplebatterynotifier.model;
  * Uses builder pattern for chaining setters
  */
 public final class BatteryDO {
+
+	// The synthesized sub-percent fraction is clamped into the OS whole-percent bucket so the two
+	// sources can't visibly disagree; 0.99 (not 1.0) keeps the two-decimal rendering from rounding
+	// up into the next whole percent (#158).
+	private static final float MAX_SUB_PERCENT_FRACTION = 0.99f;
+
 	private int level;
 	private int plugged;
 	private int scale;
@@ -13,6 +19,9 @@ public final class BatteryDO {
 	private int voltage;
 	private boolean present;
 	private int capacity;
+	// Remaining charge in µAh from BATTERY_PROPERTY_CHARGE_COUNTER, already gated for
+	// trustworthiness at read time (see SystemService); 0 when unavailable or untrusted (#69/#94).
+	private int chargeCounterMicroAmpHours;
 	// Instantaneous current in µA from BATTERY_PROPERTY_CURRENT_NOW; Integer.MIN_VALUE when the device
 	// doesn't report it. Sign convention varies by OEM, so callers derive direction from the status.
 	private int currentMicroAmps = Integer.MIN_VALUE;
@@ -35,6 +44,64 @@ public final class BatteryDO {
 			return 0f;
 		}
 		return (level / (float) scale) * 100;
+	}
+
+	/**
+	 * The battery percentage as an integer, under the app's single rounding policy: <b>truncation</b>.
+	 * <p>
+	 * Every integer consumer — alert thresholds, rate samples, status icons, log lines — must use
+	 * this instead of ad-hoc {@code (int)} casts or {@code Math.round}, so a 19.6% battery reads as
+	 * the same "19" everywhere (#158). Truncation matches threshold semantics: "critical at 20"
+	 * fires as soon as the battery is genuinely below 21, and 20.4% doesn't display as 20 until it
+	 * truly is.
+	 *
+	 * @return Battery percentage truncated to a whole number (0-100)
+	 */
+	public int getBatteryPercentageInt() {
+		return (int) getBatteryPercentage();
+	}
+
+	/**
+	 * Whether {@link #getPrecisePercentage()} carries genuine sub-percent resolution: either the OS
+	 * reports a fine-grained scale (&gt; 100), or a trusted charge counter and full-capacity
+	 * estimate allow the fraction to be synthesized. When false, callers must show the whole
+	 * percent — an artificial ".00" would be fake precision (#69/#94).
+	 *
+	 * @return true when the precise percentage genuinely resolves below one percent
+	 */
+	public boolean hasPrecisePercentage() {
+		return scale > 100 || hasSynthesizedFraction();
+	}
+
+	/**
+	 * The battery percentage with genuine sub-percent resolution where available (#158).
+	 * <p>
+	 * Preference order: the plain {@code level/scale} fraction when the OS scale is finer than
+	 * whole percent; else a fraction synthesized from the charge counter divided by the estimated
+	 * full capacity (AccuBattery-style), clamped into the OS whole-percent bucket
+	 * {@code [percent, percent + 0.99]} (and to 100) so the two sources can't visibly disagree.
+	 * Without a trusted counter it falls back to the whole percent
+	 * ({@link #hasPrecisePercentage()} then reads false).
+	 *
+	 * @return Battery percentage, fractional when genuine sub-percent data exists
+	 */
+	public float getPrecisePercentage() {
+		if (scale > 100 || !hasSynthesizedFraction()) {
+			return getBatteryPercentage();
+		}
+		// capacity is mAh; ×1000 puts it in the counter's µAh unit.
+		final float synthesized = chargeCounterMicroAmpHours / (capacity * 1000f) * 100f;
+		final int whole = getBatteryPercentageInt();
+		final float clamped = Math.max(whole, Math.min(whole + MAX_SUB_PERCENT_FRACTION, synthesized));
+		return Math.min(100f, clamped);
+	}
+
+	/**
+	 * Whether the fraction can be synthesized from the charge counter: a real OS level reading plus
+	 * a trusted counter and full-capacity estimate (both already gated at read time, #69/#94).
+	 */
+	private boolean hasSynthesizedFraction() {
+		return scale > 0 && level >= 0 && chargeCounterMicroAmpHours > 0 && capacity > 0;
 	}
 
 	public String getHealth() {
@@ -124,6 +191,15 @@ public final class BatteryDO {
 
 	public BatteryDO setCapacity(final int capacity) {
 		this.capacity = capacity;
+		return this;
+	}
+
+	public int getChargeCounterMicroAmpHours() {
+		return chargeCounterMicroAmpHours;
+	}
+
+	public BatteryDO setChargeCounterMicroAmpHours(final int chargeCounterMicroAmpHours) {
+		this.chargeCounterMicroAmpHours = chargeCounterMicroAmpHours;
 		return this;
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -81,7 +81,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 			// which silently suppressed genuine low/critical alerts on a transient read failure.
 			return;
 		}
-		final int percentage = (int) batteryDO.getBatteryPercentage();
+		final int percentage = batteryDO.getBatteryPercentageInt();
 
 		// Track battery health and charge cycles
 		BatteryHealthTracker.recordBatteryState(context, percentage, status);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
@@ -8,6 +8,7 @@ import android.os.BatteryManager;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.model.ChargeSpeed;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
 import com.almothafar.simplebatterynotifier.service.SystemService;
@@ -84,7 +85,8 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 
 		final int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
 		final int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
-		final int percentage = (int) ((level / (float) scale) * 100);
+		// Through the single rounding policy (#158) — also guards the scale=-1 default the raw division didn't.
+		final int percentage = new BatteryDO().setLevel(level).setScale(scale).getBatteryPercentageInt();
 
 		if (pluggedState > 0) {
 			// Charger connected

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
@@ -109,7 +109,7 @@ public final class BatteryRateTracker {
 		final boolean sameDirection = sameDirection(prefs, charging);
 		final List<Sample> window = loadWindow(prefs, charging, now);
 
-		final int level = Math.round(batteryDO.getBatteryPercentage());
+		final int level = batteryDO.getBatteryPercentageInt();
 		final List<Sample> updated = appendAndTrim(window, new Sample(now, level, batteryDO.getCurrentMicroAmps()), now);
 
 		// Persist only when something actually changed. ACTION_BATTERY_CHANGED can fire every few seconds

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -28,6 +28,7 @@ import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.model.ChargeSpeed;
 import com.almothafar.simplebatterynotifier.model.ChargeSpeedTier;
 import com.almothafar.simplebatterynotifier.ui.MainActivity;
+import com.almothafar.simplebatterynotifier.util.BatteryPercentFormatter;
 import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 
@@ -1006,11 +1007,14 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Build the content line of the ongoing status notification, e.g. "85% · Discharging 9%/h · 32.0 °C".
+	 * Build the content line of the ongoing status notification, e.g. "85.12% · Discharging 9%/h · 32.0 °C".
 	 * <p>
-	 * The middle segment appends the charge/drain rate to the status label when available, falling back
-	 * to the raw mA, then to the plain label — always showing the best number on hand (issue #108). The
-	 * appended rate is gated by a user setting (default on); the plain label always shows.
+	 * The percentage is the same live value the home gauge shows — two decimals when the device
+	 * genuinely resolves below one percent, whole otherwise (#158); only the level <em>alerts</em>
+	 * (critical/warning) stay integer. The middle segment appends the charge/drain rate to the status
+	 * label when available, falling back to the raw mA, then to the plain label — always showing the
+	 * best number on hand (issue #108). The appended rate is gated by a user setting (default on); the
+	 * plain label always shows.
 	 *
 	 * @param context   The application context
 	 * @param batteryDO Current battery snapshot, or null if unavailable
@@ -1019,7 +1023,7 @@ public final class NotificationService {
 	 */
 	private static String statusText(final Context context, final BatteryDO batteryDO,
 	                                 final BatteryRateTracker.BatteryRate rate) {
-		final int percentage = isNull(batteryDO) ? 0 : Math.round(batteryDO.getBatteryPercentage());
+		final String percentage = BatteryPercentFormatter.formatLive(batteryDO);
 		final String statusLabel = SystemService.getStatusLabel(context, isNull(batteryDO) ? -1 : batteryDO.getStatus());
 		final String temperature = isNull(batteryDO) ? "" : TemperatureUtils.format(context, batteryDO.getTemperature());
 		return context.getString(R.string.notification_status_content, percentage, statusWithRate(context, batteryDO, statusLabel, rate), temperature);
@@ -1106,7 +1110,7 @@ public final class NotificationService {
 		if (batteryDO.getStatus() == BatteryManager.BATTERY_STATUS_CHARGING) {
 			return R.drawable.ic_stat_battery_charging;
 		}
-		return Math.round(batteryDO.getBatteryPercentage()) <= 50
+		return batteryDO.getBatteryPercentageInt() <= 50
 		       ? R.drawable.ic_stat_battery_low
 		       : R.drawable.ic_stat_battery_full;
 	}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
@@ -93,7 +93,7 @@ public final class SlowChargeDetector {
 		// Not eligible to fire right now, but the session continues → sleep (hold the streak, don't warn):
 		// a thermal/battery-protect pause (NOT_CHARGING), the deliberate taper above 80%, or wireless (v1
 		// judges wired charging only). The observation-gap lapse in decide() still resets a long-stale streak.
-		final int level = Math.round(batteryDO.getBatteryPercentage());
+		final int level = batteryDO.getBatteryPercentageInt();
 		final boolean wired = batteryDO.getPlugged() != BatteryManager.BATTERY_PLUGGED_WIRELESS;
 		if (status != BatteryManager.BATTERY_STATUS_CHARGING || !wired || level >= MAX_LEVEL_PERCENT) {
 			return;

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -83,8 +83,9 @@ public final class SystemService {
 		final String chargerType = determineChargerType(extras.plugged, resources);
 		final int batteryCapacity = getBatteryCapacity(context);
 		final int currentMicroAmps = getInstantaneousCurrentMicroAmps(context);
+		final int chargeCounterUah = getTrustedChargeCounterUah(context, batteryCapacity);
 
-		return buildBatteryDataObject(extras, chargerType, batteryCapacity, currentMicroAmps, resources);
+		return buildBatteryDataObject(extras, chargerType, batteryCapacity, currentMicroAmps, chargeCounterUah, resources);
 	}
 
 	/**
@@ -181,10 +182,12 @@ public final class SystemService {
 	/**
 	 * Build the BatteryDO object from extracted data
 	 *
-	 * @param extras          Extracted battery extras
-	 * @param chargerType     Charger type string
-	 * @param batteryCapacity Battery capacity in mAh
-	 * @param resources       Resources for string lookup
+	 * @param extras           Extracted battery extras
+	 * @param chargerType      Charger type string
+	 * @param batteryCapacity  Battery capacity in mAh
+	 * @param currentMicroAmps Instantaneous current in µA
+	 * @param chargeCounterUah Trusted remaining-charge counter in µAh (0 when unavailable/untrusted)
+	 * @param resources        Resources for string lookup
 	 *
 	 * @return Populated BatteryDO object
 	 */
@@ -192,6 +195,7 @@ public final class SystemService {
 	                                                final String chargerType,
 	                                                final int batteryCapacity,
 	                                                final int currentMicroAmps,
+	                                                final int chargeCounterUah,
 	                                                final Resources resources) {
 		final BatteryDO batteryDO = new BatteryDO();
 		batteryDO.setLevel(extras.level)
@@ -205,6 +209,7 @@ public final class SystemService {
 		         .setVoltage(extras.voltage)
 		         .setCapacity(batteryCapacity)
 		         .setCurrentMicroAmps(currentMicroAmps)
+		         .setChargeCounterMicroAmpHours(chargeCounterUah)
 		         .setIntHealth(extras.health);
 
 		// Determine health status and set it on the battery object
@@ -287,6 +292,36 @@ public final class SystemService {
 		final int chargeCounterUah = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CHARGE_COUNTER);
 		final int capacityPercent = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
 		return estimateFullCapacityMah(chargeCounterUah, capacityPercent);
+	}
+
+	/**
+	 * The raw remaining-charge counter ({@link BatteryManager#BATTERY_PROPERTY_CHARGE_COUNTER}, µAh),
+	 * gated for trustworthiness so downstream consumers can synthesize a sub-percent battery fraction
+	 * without showing fake precision (#158):
+	 * <ul>
+	 *   <li>{@code estimatedFullCapacityMah <= 0} — the counter is absent or produced an implausible
+	 *       capacity estimate (the Kirin wrong-unit bug, #69) — returns 0;</li>
+	 *   <li>the estimate is wildly out of line with the user's design capacity (#94) — returns 0;</li>
+	 *   <li>otherwise the counter reading itself, floored at 0.</li>
+	 * </ul>
+	 *
+	 * @param context                 The application context
+	 * @param estimatedFullCapacityMah The already-computed full-capacity estimate in mAh (0 = untrusted)
+	 *
+	 * @return trusted remaining charge in µAh, or 0 when the counter can't be trusted on this device
+	 */
+	private static int getTrustedChargeCounterUah(final Context context, final int estimatedFullCapacityMah) {
+		if (estimatedFullCapacityMah <= 0) {
+			return 0; // Counter unavailable or implausible (#69) — integer display instead of fake decimals.
+		}
+		if (BatteryHealthTracker.isEstimateImplausible(estimatedFullCapacityMah, BatteryHealthTracker.getDesignCapacity(context))) {
+			return 0; // Counter inconsistent with the known design capacity (#94).
+		}
+		final BatteryManager batteryManager = (BatteryManager) context.getSystemService(Context.BATTERY_SERVICE);
+		if (isNull(batteryManager)) {
+			return 0;
+		}
+		return Math.max(0, batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CHARGE_COUNTER));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/MainActivity.java
@@ -36,6 +36,7 @@ import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.PowerConnectionService;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.ui.widget.HorseshoeProgressBar;
+import com.almothafar.simplebatterynotifier.util.BatteryPercentFormatter;
 
 import java.util.List;
 
@@ -55,6 +56,7 @@ public class MainActivity extends BaseActivity {
 	private final Handler handler = new Handler(Looper.getMainLooper());
 
 	private int batteryPercentage;
+	private String batteryPercentageText;
 	private String subTitle;
 	private BatteryDO batteryDO;
 	private ActivityResultLauncher<Intent> settingsLauncher;
@@ -232,11 +234,14 @@ public class MainActivity extends BaseActivity {
 		if (isNull(batteryDO)) {
 			Log.w(TAG, "Unable to retrieve battery information");
 			batteryPercentage = 0;
+			batteryPercentageText = BatteryPercentFormatter.formatLive(null);
 			subTitle = getResources().getString(R.string.unknown);
 			return;
 		}
 
-		batteryPercentage = (int) batteryDO.getBatteryPercentage();
+		batteryPercentage = batteryDO.getBatteryPercentageInt();
+		// Two decimals when the device genuinely resolves below one percent, whole otherwise (#158).
+		batteryPercentageText = BatteryPercentFormatter.formatLive(batteryDO);
 		subTitle = SystemService.getStatusLabel(this, batteryDO.getStatus());
 	}
 
@@ -265,7 +270,7 @@ public class MainActivity extends BaseActivity {
 		final HorseshoeProgressBar gauge = findViewById(R.id.batteryPercentage);
 		fillBatteryInfo();
 		gauge.setLevel(batteryPercentage);
-		gauge.setTitle(batteryPercentage + "%");
+		gauge.setTitle(batteryPercentageText);
 		gauge.setStatusText(subTitle);
 
 		// Drive the gauge motion: charging wave, full-on-charger idle pulse, or discharge wave.
@@ -311,8 +316,10 @@ public class MainActivity extends BaseActivity {
 		// Keep the in-fly slider in sync with values that may have changed in Settings.
 		syncThresholdSlider();
 
+		// The ring still animates whole levels; only the final title carries the decimals (#158).
+		// Intermediate steps count up in whole percent, then the last step lands on the precise text.
 		gauge.animateLevelTo(batteryPercentage, progress -> {
-			gauge.setTitle(progress + "%");
+			gauge.setTitle(progress >= batteryPercentage ? batteryPercentageText : BatteryPercentFormatter.formatWhole(progress));
 			gauge.setStatusText(subTitle);
 		});
 	}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -411,7 +411,7 @@ public class BatteryDetailsFragment extends Fragment {
 		if (!rate.charging() || !rate.hasRate()) {
 			return;
 		}
-		final int level = Math.round(batteryDO.getBatteryPercentage());
+		final int level = batteryDO.getBatteryPercentageInt();
 		if (level >= 99) {
 			return;
 		}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/util/BatteryPercentFormatter.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/util/BatteryPercentFormatter.java
@@ -1,0 +1,73 @@
+package com.almothafar.simplebatterynotifier.util;
+
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
+
+import java.util.Locale;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Formats battery percentages for display (#158).
+ * <p>
+ * One home for the two display forms so the gauge and the ongoing status notification can't drift:
+ * <ul>
+ *   <li><b>Precise</b> — two decimals ({@code 2.01%}, {@code 48.00%}, {@code 88.88%}), no leading
+ *       zero, except a full battery which reads {@code 100%} (never {@code 100.00%}).</li>
+ *   <li><b>Whole</b> — the plain integer form ({@code 48%}) used when the device provides no
+ *       genuine sub-percent resolution, and by every integer surface (alerts, details table).</li>
+ * </ul>
+ * All formatting goes through {@link Locale#ROOT}, keeping Western digits in every locale (#96).
+ */
+public final class BatteryPercentFormatter {
+
+	// At/above this the two-decimal form would render "100.00%"; show the clean "100%" instead.
+	private static final float FULL_DISPLAY_THRESHOLD = 99.995f;
+
+	private BatteryPercentFormatter() {
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * The live percentage for the home gauge and the ongoing status notification: two decimals when
+	 * the snapshot carries genuine sub-percent resolution, the whole percent otherwise — never fake
+	 * precision on unreliable-counter devices (#69/#94).
+	 *
+	 * @param batteryDO Current battery snapshot, or null when unavailable (reads "0%")
+	 *
+	 * @return the formatted percentage, including the trailing '%'
+	 */
+	public static String formatLive(final BatteryDO batteryDO) {
+		if (isNull(batteryDO)) {
+			return formatWhole(0);
+		}
+		return batteryDO.hasPrecisePercentage()
+		       ? formatPrecise(batteryDO.getPrecisePercentage())
+		       : formatWhole(batteryDO.getBatteryPercentageInt());
+	}
+
+	/**
+	 * The two-decimal form, e.g. {@code "2.01%"} / {@code "48.00%"} — except full, which reads
+	 * {@code "100%"}. Negative input is clamped to 0 defensively.
+	 *
+	 * @param percentage the fractional percentage (0-100)
+	 *
+	 * @return the formatted percentage, including the trailing '%'
+	 */
+	public static String formatPrecise(final float percentage) {
+		if (percentage >= FULL_DISPLAY_THRESHOLD) {
+			return formatWhole(100);
+		}
+		return String.format(Locale.ROOT, "%.2f%%", Math.max(0f, percentage));
+	}
+
+	/**
+	 * The whole-percent form, e.g. {@code "48%"}.
+	 *
+	 * @param percentage the whole percentage (0-100)
+	 *
+	 * @return the formatted percentage, including the trailing '%'
+	 */
+	public static String formatWhole(final int percentage) {
+		return String.format(Locale.ROOT, "%d%%", percentage);
+	}
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -141,7 +141,7 @@
     <string name="notification_status_channel_description">حالة البطارية المستمرة أثناء تفعيل المراقبة</string>
     <string name="notification_quiet_channel_name">تنبيهات صامتة</string>
     <string name="notification_quiet_channel_description">تنبيهات البطارية تُعرض بصمت أثناء ساعات الهدوء</string>
-    <string name="notification_status_content">%1$d%% · %2$s · %3$s</string>
+    <string name="notification_status_content">%1$s · %2$s · %3$s</string>
 
     <!-- High temperature alert -->
     <string name="notify_high_temperature">تنبيه ارتفاع الحرارة</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="notification_quiet_channel_name">Quiet Alerts</string>
     <string name="notification_quiet_channel_description">Battery alerts shown silently during your quiet hours</string>
     <!-- e.g. "85% · Discharging · 32.0 °C" -->
-    <string name="notification_status_content">%1$d%% · %2$s · %3$s</string>
+    <string name="notification_status_content">%1$s · %2$s · %3$s</string>
 
     <!-- High temperature alert -->
     <string name="notify_high_temperature">High Temperature Alert</string>

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/model/BatteryDOTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/model/BatteryDOTest.java
@@ -11,7 +11,9 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link BatteryDO} calculation logic and edge cases.
@@ -53,6 +55,102 @@ public class BatteryDOTest {
 		public void matchesExpected() {
 			final float result = new BatteryDO().setLevel(level).setScale(scale).getBatteryPercentage();
 			assertEquals(label, expected, result, 0.01f);
+		}
+	}
+
+	/**
+	 * {@link BatteryDO#getBatteryPercentageInt()} — the app's single rounding policy (#158):
+	 * truncation, so 19.6% reads as 19 for every integer consumer (alerts, rate samples, icons).
+	 */
+	@RunWith(Parameterized.class)
+	public static class GetBatteryPercentageInt {
+
+		@Parameter(0) public String label;
+		@Parameter(1) public int level;
+		@Parameter(2) public int scale;
+		@Parameter(3) public int expected;
+
+		@Parameters(name = "{0}")
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{
+					{"truncates 19.6 to 19 (not 20)", 196, 1000, 19},
+					{"truncates 99.9 to 99", 999, 1000, 99},
+					{"truncates 20.4 to 20", 204, 1000, 20},
+					{"whole 48 stays 48", 48, 100, 48},
+					{"full battery", 100, 100, 100},
+					{"empty battery", 0, 100, 0},
+					{"zero scale guarded", 50, 0, 0},
+					{"negative scale guarded", 50, -1, 0},
+			});
+		}
+
+		@Test
+		public void matchesExpected() {
+			assertEquals(label, expected, new BatteryDO().setLevel(level).setScale(scale).getBatteryPercentageInt());
+		}
+	}
+
+	/**
+	 * {@link BatteryDO#getPrecisePercentage()} / {@link BatteryDO#hasPrecisePercentage()} (#158):
+	 * the free fine-scale path, the synthesized charge-counter path with its clamp into the OS
+	 * whole-percent bucket, and the integer fallback when the counter can't be trusted (#69/#94).
+	 */
+	public static class PrecisePercentage {
+
+		@Test
+		public void fineScale_usesPlainFraction() {
+			final BatteryDO battery = new BatteryDO().setLevel(8888).setScale(10000);
+			assertTrue(battery.hasPrecisePercentage());
+			assertEquals(88.88f, battery.getPrecisePercentage(), 0.001f);
+		}
+
+		@Test
+		public void chargeCounter_synthesizesFractionWithinOsBucket() {
+			// 3,525,000 µAh of a 4000 mAh full capacity = 88.125%, inside the OS bucket [88, 89).
+			final BatteryDO battery = new BatteryDO().setLevel(88).setScale(100)
+					.setCapacity(4000).setChargeCounterMicroAmpHours(3_525_000);
+			assertTrue(battery.hasPrecisePercentage());
+			assertEquals(88.125f, battery.getPrecisePercentage(), 0.001f);
+		}
+
+		@Test
+		public void chargeCounter_belowOsPercent_clampsUpToBucketFloor() {
+			// 3,480,000 µAh / 4000 mAh = 87.0% — below the OS 88 — clamped up to 88.00.
+			final BatteryDO battery = new BatteryDO().setLevel(88).setScale(100)
+					.setCapacity(4000).setChargeCounterMicroAmpHours(3_480_000);
+			assertEquals(88.0f, battery.getPrecisePercentage(), 0.001f);
+		}
+
+		@Test
+		public void chargeCounter_aboveOsBucket_clampsDownToBucketCeiling() {
+			// 3,580,000 µAh / 4000 mAh = 89.5% — above the OS bucket [88, 89) — clamped to 88.99.
+			final BatteryDO battery = new BatteryDO().setLevel(88).setScale(100)
+					.setCapacity(4000).setChargeCounterMicroAmpHours(3_580_000);
+			assertEquals(88.99f, battery.getPrecisePercentage(), 0.001f);
+		}
+
+		@Test
+		public void chargeCounter_atFull_neverExceedsHundred() {
+			// OS says 100; a lagging counter (99.75%) must still read exactly 100, never 100.99.
+			final BatteryDO battery = new BatteryDO().setLevel(100).setScale(100)
+					.setCapacity(4000).setChargeCounterMicroAmpHours(3_990_000);
+			assertEquals(100.0f, battery.getPrecisePercentage(), 0.001f);
+		}
+
+		@Test
+		public void noChargeCounter_fallsBackToWholePercent() {
+			final BatteryDO battery = new BatteryDO().setLevel(88).setScale(100).setCapacity(4000);
+			assertFalse(battery.hasPrecisePercentage());
+			assertEquals(88.0f, battery.getPrecisePercentage(), 0.001f);
+		}
+
+		@Test
+		public void untrustedCapacity_fallsBackToWholePercent() {
+			// Capacity 0 = the counter estimate was implausible (#69) — no fake precision.
+			final BatteryDO battery = new BatteryDO().setLevel(88).setScale(100)
+					.setCapacity(0).setChargeCounterMicroAmpHours(3_525_000);
+			assertFalse(battery.hasPrecisePercentage());
+			assertEquals(88.0f, battery.getPrecisePercentage(), 0.001f);
 		}
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/util/BatteryPercentFormatterTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/util/BatteryPercentFormatterTest.java
@@ -1,0 +1,88 @@
+package com.almothafar.simplebatterynotifier.util;
+
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link BatteryPercentFormatter} (#158): the exact display formats from the issue —
+ * {@code 2.01%} (no leading zero), {@code 48.00%}, {@code 88.88%}, {@code 100%} (never
+ * {@code 100.00%}) — and the whole-percent fallback used when sub-percent data isn't genuine.
+ */
+@RunWith(Enclosed.class)
+public class BatteryPercentFormatterTest {
+
+	/** {@link BatteryPercentFormatter#formatPrecise(float)} across the issue's format table. */
+	@RunWith(Parameterized.class)
+	public static class FormatPrecise {
+
+		@Parameter(0) public String label;
+		@Parameter(1) public float percentage;
+		@Parameter(2) public String expected;
+
+		@Parameters(name = "{0}")
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{
+					{"empty battery", 0f, "0.00%"},
+					{"low, no leading zero", 2.01f, "2.01%"},
+					{"whole value keeps decimals", 48f, "48.00%"},
+					{"mid fraction", 88.88f, "88.88%"},
+					{"just below full", 99.99f, "99.99%"},
+					{"rounds into full shows clean 100", 99.996f, "100%"},
+					{"full, no decimals", 100f, "100%"},
+					{"negative clamped defensively", -1.5f, "0.00%"},
+			});
+		}
+
+		@Test
+		public void matchesExpected() {
+			assertEquals(label, expected, BatteryPercentFormatter.formatPrecise(percentage));
+		}
+	}
+
+	/** Whole-percent form and the live entry point's precise-vs-fallback switching. */
+	public static class Behaviour {
+
+		@Test
+		public void formatWhole_plainInteger() {
+			assertEquals("48%", BatteryPercentFormatter.formatWhole(48));
+			assertEquals("100%", BatteryPercentFormatter.formatWhole(100));
+			assertEquals("0%", BatteryPercentFormatter.formatWhole(0));
+		}
+
+		@Test
+		public void formatLive_nullSnapshot_readsZero() {
+			assertEquals("0%", BatteryPercentFormatter.formatLive(null));
+		}
+
+		@Test
+		public void formatLive_withTrustedCounter_showsTwoDecimals() {
+			// 3,525,000 µAh of 4000 mAh = 88.125% → rendered at two decimals.
+			final BatteryDO battery = new BatteryDO().setLevel(88).setScale(100)
+					.setCapacity(4000).setChargeCounterMicroAmpHours(3_525_000);
+			assertEquals("88.13%", BatteryPercentFormatter.formatLive(battery));
+		}
+
+		@Test
+		public void formatLive_withoutCounter_fallsBackToWholePercent() {
+			final BatteryDO battery = new BatteryDO().setLevel(88).setScale(100);
+			assertEquals("88%", BatteryPercentFormatter.formatLive(battery));
+		}
+
+		@Test
+		public void formatLive_fullBattery_readsCleanHundred() {
+			final BatteryDO battery = new BatteryDO().setLevel(100).setScale(100)
+					.setCapacity(4000).setChargeCounterMicroAmpHours(4_000_000);
+			assertEquals("100%", BatteryPercentFormatter.formatLive(battery));
+		}
+	}
+}


### PR DESCRIPTION
Closes #158.

## Part A — live sub-percent percentage (home gauge + ongoing notification)

The home gauge and the persistent status notification now show the **same live percentage with two decimals**, built from the same `BatteryDO` snapshot so they can't drift. Only the level *alerts* (critical/warning) stay whole-number.

| Situation | Shows |
|---|---|
| Low | `2.01%` (no leading zero) |
| Mid | `48.00%`, `88.88%` |
| Full | `100%` (never `100.00%`) |

**Where the decimals come from** (in preference order):

1. **Free path** — a device whose OS scale is finer than whole percent (`scale > 100`) uses the plain `level/scale` fraction.
2. **Synthesized** — trusted charge counter (µAh) ÷ estimated full capacity (AccuBattery-style), clamped into the OS whole-percent bucket `[percent, percent + 0.99]` (and to 100) so the two sources can never visibly disagree.

**No fake precision**: the counter is gated at read time in `SystemService` — it is only attached to the snapshot when `estimateFullCapacityMah` is plausible (#69) *and* consistent with the user's design capacity (#94). Otherwise both surfaces fall back to the plain integer display.

UI details:

- New `BatteryPercentFormatter` is the single home for both display forms, using `Locale.ROOT` so Western digits hold in every locale (#96).
- The gauge's existing title auto-shrink handles the longer string, including Arabic.
- The intro animation still counts up in whole percent and lands on the precise value; the ring keeps animating integer levels.

## Part B — one rounding policy for every integer consumer

New `BatteryDO.getBatteryPercentageInt()` with **truncation** as the single documented policy (19.6% reads as "19" everywhere — matches threshold semantics: "critical at 20" fires once the battery is genuinely below 21).

All previous ad-hoc conversions now go through it:

- `(int)` casts: `MainActivity`, `BatteryLevelReceiver`, `PowerConnectionReceiver` (which also fixes an unguarded divide by the `scale = -1` default there)
- `Math.round`: `BatteryRateTracker` samples, `SlowChargeDetector` taper gate, `NotificationService` status icon, `BatteryDetailsFragment` time-to-full

The `notification_status_content` format arg changed from `%1$d%%` to `%1$s` (both locales), since the formatted value now carries its own `%`.

## Tests

28 new unit tests (323 total, all green):

- Formatter edge cases: `0`, `2.01`, `48`, `99.99`, `99.996 → 100%`, `100`, negative clamp
- Truncation policy: `19.6 → 19`, `20.4 → 20`, guarded zero/negative scale
- Fallback gating: no counter / untrusted capacity → whole percent, `hasPrecisePercentage() == false`
- Clamping: below bucket, above bucket, at-full never exceeding 100

Related: #96 (digits policy), #69/#94/#152 (unreliable counters), #157 (same-snapshot consistency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)