### PR TITLE
Never-throwing quiet-hours time parsing: corrupt pref falls back to the default window (#154)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -919,13 +919,11 @@ public final class NotificationService {
 		// fresh install that never opened Time Settings alert around the clock, so quiet hours silently
 		// did nothing (issue #111). Now quiet hours apply by default (06:30–23:30).
 		final boolean limitedTime = prefs.getBoolean(context.getString(R.string._pref_key_notifications_time_range), true);
-		final String startTime = prefs.getString(
-				context.getString(R.string._pref_key_notifications_time_range_start),
-				context.getString(R.string._pref_value_notifications_time_range_start));
-		final String endTime = prefs.getString(
-				context.getString(R.string._pref_key_notifications_time_range_end),
-				context.getString(R.string._pref_value_notifications_time_range_end));
-		return isWithinTime(startTime, endTime) || !limitedTime;
+		final String defaultStartTime = context.getString(R.string._pref_value_notifications_time_range_start);
+		final String defaultEndTime = context.getString(R.string._pref_value_notifications_time_range_end);
+		final String startTime = prefs.getString(context.getString(R.string._pref_key_notifications_time_range_start), defaultStartTime);
+		final String endTime = prefs.getString(context.getString(R.string._pref_key_notifications_time_range_end), defaultEndTime);
+		return isWithinTime(startTime, endTime, defaultStartTime, defaultEndTime) || !limitedTime;
 	}
 
 	/**
@@ -970,18 +968,46 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Check if current time is within notification time range
+	 * Check if current time is within notification time range. Never throws: this runs on the
+	 * broadcast path of every alert, and a corrupt stored bound must not turn alerting into a crash
+	 * loop (issue #154) — a malformed bound falls back to that bound's default instead.
 	 *
-	 * @param startTime Start time string (HH:mm format)
-	 * @param endTime   End time string (HH:mm format)
+	 * @param startTime        Start time string (HH:mm format)
+	 * @param endTime          End time string (HH:mm format)
+	 * @param defaultStartTime Default window start, used when {@code startTime} is malformed
+	 * @param defaultEndTime   Default window end, used when {@code endTime} is malformed
 	 * @return true if current time is within range
 	 */
-	private static boolean isWithinTime(final String startTime, final String endTime) {
+	private static boolean isWithinTime(
+			final String startTime,
+			final String endTime,
+			final String defaultStartTime,
+			final String defaultEndTime) {
 		final LocalTime now = LocalTime.now();
 		final int nowMinutes = now.getHour() * 60 + now.getMinute();
-		final int startMinutes = GeneralHelper.getHour(startTime) * 60 + GeneralHelper.getMinute(startTime);
-		final int endMinutes = GeneralHelper.getHour(endTime) * 60 + GeneralHelper.getMinute(endTime);
+		final int startMinutes = boundOrDefaultMinutes(startTime, defaultStartTime);
+		final int endMinutes = boundOrDefaultMinutes(endTime, defaultEndTime);
 		return isWithinTimeRange(nowMinutes, startMinutes, endMinutes);
+	}
+
+	/**
+	 * A quiet-hours window bound as minutes since midnight, falling back to the bound's default when
+	 * the stored value is malformed (backup/restore corruption, prefs damage — issue #154). The
+	 * fallback is logged: a corrupt pref is unexpected and should be visible, just never fatal.
+	 *
+	 * @param storedTime  the persisted "HH:MM" bound
+	 * @param defaultTime the bound's default from resources, expected to always parse
+	 * @return the bound in minutes since midnight
+	 */
+	static int boundOrDefaultMinutes(final String storedTime, final String defaultTime) {
+		final int minutes = GeneralHelper.parseTimeToMinutes(storedTime);
+		if (minutes >= 0) {
+			return minutes;
+		}
+		Log.w(TAG, "Malformed quiet-hours time \"" + storedTime + "\"; using default " + defaultTime);
+		// The default is a compile-time resource constant, so this parse can't realistically fail;
+		// floor at midnight rather than propagate -1 into the range check just in case.
+		return Math.max(0, GeneralHelper.parseTimeToMinutes(defaultTime));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreference.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreference.java
@@ -5,8 +5,8 @@ import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.util.Log;
 import androidx.preference.DialogPreference;
+import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 /**
@@ -40,50 +40,34 @@ public class TimePickerPreference extends DialogPreference {
 	 * @return Time in "HH:MM" format
 	 */
 	public String getTime() {
-		return String.format("%02d:%02d", hour, minute);
+		return GeneralHelper.formatTime(hour, minute);
 	}
 
 	/**
 	 * Set the time from a formatted string
+	 * <p>
+	 * The value is our own persisted "HH:MM", so anything that doesn't parse is unexpected
+	 * corruption — reset to 00:00 and log. The shared {@link GeneralHelper#parseTimeToMinutes}
+	 * accepts Eastern Arabic digits, so values written by older versions under the Arabic locale
+	 * (via default-locale formatting) are kept and re-persisted in the canonical Western-digit
+	 * form instead of being reset (issue #154).
 	 *
 	 * @param time Time string in "HH:MM" format
 	 */
-	public void setTime(String time) {
-		if (isNull(time) || time.isEmpty()) {
-			time = "00:00";
-		}
-
-		// The value is our own persisted "HH:MM", so anything that doesn't validate is unexpected
-		// corruption — validate the parts (no exception-as-control-flow) and log if we have to reset.
-		final String[] parts = time.split(":");
-		if (parts.length == 2 && isTimePart(parts[0], 23) && isTimePart(parts[1], 59)) {
-			hour = Integer.parseInt(parts[0]);   // safe: isTimePart matched \d{1,2}
-			minute = Integer.parseInt(parts[1]);
+	public void setTime(final String time) {
+		final int minutes = GeneralHelper.parseTimeToMinutes(time);
+		if (minutes >= 0) {
+			hour = minutes / 60;
+			minute = minutes % 60;
 		} else {
 			Log.w(TAG, "Malformed persisted time \"" + time + "\"; defaulting to 00:00");
 			hour = 0;
 			minute = 0;
 		}
 
-		final String timeStr = String.format("%02d:%02d", hour, minute);
+		final String timeStr = GeneralHelper.formatTime(hour, minute);
 		persistString(timeStr);
 		setSummary(timeStr);
-	}
-
-	/**
-	 * Whether {@code part} is a 1-2 digit number within {@code 0..max}. Pre-validates so the
-	 * subsequent {@link Integer#parseInt} can't throw or overflow — no catch needed.
-	 *
-	 * @param part candidate hour/minute component
-	 * @param max  inclusive upper bound (23 for hours, 59 for minutes)
-	 *
-	 * @return true when {@code part} is a valid time component
-	 */
-	private static boolean isTimePart(final String part, final int max) {
-		if (!part.matches("\\d{1,2}")) {
-			return false;
-		}
-		return Integer.parseInt(part) <= max; // safe: matched \d{1,2}, fits in an int
 	}
 
 	public int getHour() {

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/util/GeneralHelper.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/util/GeneralHelper.java
@@ -3,6 +3,8 @@ package com.almothafar.simplebatterynotifier.util;
 import android.content.res.Resources;
 import android.util.TypedValue;
 
+import java.util.Locale;
+
 import static java.util.Objects.isNull;
 
 /**
@@ -45,38 +47,68 @@ public final class GeneralHelper {
 	}
 
 	/**
-	 * Extract hour from time string in format "HH:MM"
+	 * Parse a persisted "HH:MM" time into minutes since midnight, without ever throwing.
+	 * <p>
+	 * The stored value can be corrupt (backup/restore across versions, prefs file damage — issue
+	 * #154) and this runs on the broadcast path of every alert, so malformed input must be a value,
+	 * not an exception: the caller decides the fallback. Digits are matched via
+	 * {@link Character#digit(char, int)}, which also accepts Eastern Arabic numerals — values written
+	 * by older versions under the Arabic locale keep working (see {@link #formatTime(int, int)}).
 	 *
-	 * @param time Time string in format "HH:MM"
-	 * @return The hour component
-	 * @throws IllegalArgumentException if time format is invalid
+	 * @param time Time string in "HH:MM" form (1-2 digit components)
+	 * @return minutes since midnight (0-1439), or -1 if {@code time} is not a valid time
 	 */
-	public static int getHour(final String time) {
-		if (isNull(time) || time.isEmpty()) {
-			throw new IllegalArgumentException("Time string cannot be null or empty");
+	public static int parseTimeToMinutes(final String time) {
+		if (isNull(time)) {
+			return -1;
 		}
-		final String[] pieces = time.split(":");
-		if (pieces.length < 2) {
-			throw new IllegalArgumentException("Invalid time format. Expected HH:MM");
+		final int colon = time.indexOf(':');
+		if (colon < 0 || colon != time.lastIndexOf(':')) {
+			return -1;
 		}
-		return Integer.parseInt(pieces[0]);
+		final int hour = parseTimeComponent(time.substring(0, colon), 23);
+		final int minute = parseTimeComponent(time.substring(colon + 1), 59);
+		if (hour < 0 || minute < 0) {
+			return -1;
+		}
+		return hour * 60 + minute;
 	}
 
 	/**
-	 * Extract minute from time string in format "HH:MM"
+	 * Parse a 1-2 digit hour/minute component, rejecting instead of throwing.
 	 *
-	 * @param time Time string in format "HH:MM"
-	 * @return The minute component
-	 * @throws IllegalArgumentException if time format is invalid
+	 * @param part candidate hour/minute component
+	 * @param max  inclusive upper bound (23 for hours, 59 for minutes)
+	 * @return the component's value, or -1 when {@code part} is not a valid component
 	 */
-	public static int getMinute(final String time) {
-		if (isNull(time) || time.isEmpty()) {
-			throw new IllegalArgumentException("Time string cannot be null or empty");
+	private static int parseTimeComponent(final String part, final int max) {
+		if (part.isEmpty() || part.length() > 2) {
+			return -1;
 		}
-		final String[] pieces = time.split(":");
-		if (pieces.length < 2) {
-			throw new IllegalArgumentException("Invalid time format. Expected HH:MM");
+		int value = 0;
+		for (int i = 0; i < part.length(); i++) {
+			final int digit = Character.digit(part.charAt(i), 10);
+			if (digit < 0) {
+				return -1;
+			}
+			value = value * 10 + digit;
 		}
-		return Integer.parseInt(pieces[1]);
+		return value <= max ? value : -1;
+	}
+
+	/**
+	 * Format a time as the canonical persisted "HH:MM" form.
+	 * <p>
+	 * {@link Locale#ROOT} keeps the digits Western regardless of the app language: the default
+	 * locale under Arabic renders Eastern Arabic numerals, which silently corrupted the stored
+	 * value for the parser (issue #154). Writer and parser are round-trip tested together so the
+	 * two can't drift apart.
+	 *
+	 * @param hour   hour of day (0-23)
+	 * @param minute minute of hour (0-59)
+	 * @return the "HH:MM" string, zero-padded, Western digits
+	 */
+	public static String formatTime(final int hour, final int minute) {
+		return String.format(Locale.ROOT, "%02d:%02d", hour, minute);
 	}
 }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
@@ -6,6 +6,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -125,6 +127,37 @@ public class NotificationServiceTest {
 		@Test
 		public void matchesExpected() {
 			assertEquals(label, expected, NotificationService.versionedChannelId(baseId, version));
+		}
+	}
+
+	/**
+	 * {@link NotificationService#boundOrDefaultMinutes(String, String)} — a corrupt stored
+	 * quiet-hours bound falls back to that bound's default instead of crashing the alert path
+	 * (issue #154). Runs under Robolectric because the fallback is logged.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class BoundOrDefaultMinutes {
+
+		private static final String DEFAULT_START = "06:30";
+
+		@Test
+		public void validStoredBoundWins() {
+			assertEquals(22 * 60 + 15, NotificationService.boundOrDefaultMinutes("22:15", DEFAULT_START));
+		}
+
+		@Test
+		public void malformedStoredBoundFallsBackToDefault() {
+			assertEquals(6 * 60 + 30, NotificationService.boundOrDefaultMinutes("ab:cd", DEFAULT_START));
+			assertEquals(6 * 60 + 30, NotificationService.boundOrDefaultMinutes(null, DEFAULT_START));
+			assertEquals(6 * 60 + 30, NotificationService.boundOrDefaultMinutes("25:99", DEFAULT_START));
+		}
+
+		@Test
+		public void unparseableDefaultFloorsAtMidnightInsteadOfPropagating() {
+			// Can't happen with the real resource constants; the floor just keeps the impossible
+			// case inside the valid minutes-of-day range.
+			assertEquals(0, NotificationService.boundOrDefaultMinutes("bad", "also bad"));
 		}
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/util/GeneralHelperTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/util/GeneralHelperTest.java
@@ -1,0 +1,100 @@
+package com.almothafar.simplebatterynotifier.util;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for the pure time parsing/formatting in {@link GeneralHelper} (issue #154): a corrupt
+ * stored quiet-hours value must become -1, never an exception, because parsing runs on the
+ * broadcast path of every alert.
+ */
+@RunWith(Enclosed.class)
+public class GeneralHelperTest {
+
+	/**
+	 * {@link GeneralHelper#parseTimeToMinutes(String)} across valid, boundary and malformed inputs.
+	 * The malformed rows are the shapes issue #154 calls out; none may throw.
+	 */
+	@RunWith(Parameterized.class)
+	public static class ParseTimeToMinutes {
+
+		@Parameter(0) public String label;
+		@Parameter(1) public String time;
+		@Parameter(2) public int expected;
+
+		@Parameters(name = "{0}")
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{
+					{"default window start", "06:30", 6 * 60 + 30},
+					{"default window end", "23:30", 23 * 60 + 30},
+					{"midnight", "00:00", 0},
+					{"single-digit components", "0:0", 0},
+					{"last minute of day", "23:59", 23 * 60 + 59},
+					{"legacy Arabic-digit value kept working", "٠٦:٣٠", 6 * 60 + 30},
+					{"hour 24 rejected", "24:00", -1},
+					{"minute 60 rejected", "23:60", -1},
+					{"out-of-range both", "25:99", -1},
+					{"null rejected", null, -1},
+					{"empty rejected", "", -1},
+					{"no colon rejected", "12", -1},
+					{"letters rejected", "ab:cd", -1},
+					{"letter minute rejected", "12:ab", -1},
+					{"missing hour rejected", ":30", -1},
+					{"missing minute rejected", "12:", -1},
+					{"second colon rejected", "1:2:3", -1},
+					{"negative hour rejected", "-1:30", -1},
+					{"leading space rejected", " 6:30", -1},
+					{"three-digit hour rejected", "006:30", -1},
+			});
+		}
+
+		@Test
+		public void matchesExpected() {
+			assertEquals(label, expected, GeneralHelper.parseTimeToMinutes(time));
+		}
+	}
+
+	/**
+	 * {@link GeneralHelper#formatTime(int, int)} — the persisted-format writer. Round-tripped
+	 * through the parser so the two can't drift apart (issue #154 acceptance criterion), and pinned
+	 * to Western digits under the Arabic locale (the old default-locale formatting wrote Eastern
+	 * Arabic numerals there).
+	 */
+	public static class FormatTime {
+
+		@Test
+		public void writesZeroPaddedHhMm() {
+			assertEquals("06:30", GeneralHelper.formatTime(6, 30));
+			assertEquals("23:05", GeneralHelper.formatTime(23, 5));
+			assertEquals("00:00", GeneralHelper.formatTime(0, 0));
+		}
+
+		@Test
+		public void keepsWesternDigitsUnderArabicDefaultLocale() {
+			final Locale original = Locale.getDefault();
+			try {
+				Locale.setDefault(Locale.forLanguageTag("ar"));
+				assertEquals("06:30", GeneralHelper.formatTime(6, 30));
+			} finally {
+				Locale.setDefault(original);
+			}
+		}
+
+		@Test
+		public void roundTripsThroughTheParser() {
+			assertEquals(6 * 60 + 30, GeneralHelper.parseTimeToMinutes(GeneralHelper.formatTime(6, 30)));
+			assertEquals(0, GeneralHelper.parseTimeToMinutes(GeneralHelper.formatTime(0, 0)));
+			assertEquals(23 * 60 + 59, GeneralHelper.parseTimeToMinutes(GeneralHelper.formatTime(23, 59)));
+		}
+	}
+}


### PR DESCRIPTION
Closes #154.

## Problem

`GeneralHelper.getHour()/getMinute()` **threw** on malformed input (`IllegalArgumentException`, or an undocumented `NumberFormatException` for `"12:ab"`), and they ran inside `isWithinNotificationWindow()` — i.e. on **every** alert, in a `BroadcastReceiver` context. One corrupt stored quiet-hours value (backup/restore across versions, prefs file damage) turned all alerting into a crash loop.

## Fix

Follows the repo's validate-don't-throw pattern:

- **One pure parser**: `GeneralHelper.parseTimeToMinutes(String)` returns minutes-since-midnight or **-1** on anything malformed (`null`, `""`, `"12"`, `"ab:cd"`, `"12:ab"`, `"25:99"`, extra colons, …). It replaces `getHour`/`getMinute` entirely — also killing the old 4-splits-per-window-check double parsing and the javadoc/exception mismatch.
- **Per-bound fallback**: `isWithinTime()` resolves each bound via `boundOrDefaultMinutes(stored, default)` — a malformed bound falls back to that bound's default (06:30 / 23:30) with a logged warning (per the no-silent-handling standard). No stored value can throw out of `isWithinNotificationWindow()`.

## Bonus bug found on the writer side

`TimePickerPreference` formatted with the **default locale** — under the app's Arabic language `String.format("%02d:%02d", …)` writes Eastern Arabic numerals, which its own ASCII-only `\d` validation then rejected, silently **resetting stored quiet-hours times to 00:00**. Now:

- Writer and parser share `GeneralHelper.formatTime(hour, minute)` (`Locale.ROOT`, Western digits per the #96 convention).
- The parser accepts Eastern Arabic digits via `Character.digit`, so values already persisted by older versions under Arabic **keep working** and self-heal to the canonical form on next write.
- A round-trip test (`parseTimeToMinutes(formatTime(…))`) plus an Arabic-default-locale test pin writer and parser together, per the acceptance criteria.

## Testing

- New `GeneralHelperTest`: 20 parameterized parse cases (all the issue's malformed shapes + boundaries + a legacy Arabic-digit value) and 3 formatter tests.
- `NotificationServiceTest.BoundOrDefaultMinutes` (Robolectric, since the fallback logs): valid-wins, malformed-falls-back, and the defensive midnight floor.
- Full `testDebugUnitTest` + `lintDebug` green; debug build installed on the Mate 10 Pro.

No new user-facing strings (nothing for values-ar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)