### PR TITLE
Persist BatteryLevelReceiver alert episode state; pure decision cores (#164)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -17,17 +17,28 @@ import com.almothafar.simplebatterynotifier.service.SlowChargeDetector;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 
+import static java.util.Objects.isNull;
+
 /**
  * Broadcast receiver for monitoring battery level changes.
  * Sends notifications when battery reaches critical/warning levels or becomes full.
+ * <p>
+ * Alert episode state (level-alert de-dupe, full-once-per-charge, temperature hysteresis) is
+ * persisted in {@link SharedPreferences} so it survives process death (#164) — doze, OEM task
+ * killers and memory pressure routinely kill a background-monitoring app, and in-memory state
+ * previously reset mid-episode, firing duplicate alerts. The logic follows the same
+ * load → pure decide → save-on-change pattern as {@link FastDrainDetector} and
+ * {@link SlowChargeDetector}.
+ * <p>
+ * <b>Threading:</b> there is deliberately no lock. Both this receiver and the unplug reset
+ * ({@link PowerConnectionReceiver} → {@link #onChargerDisconnected}) are registered on and
+ * delivered to the main thread (see {@code PowerConnectionService}), so all state access is
+ * serialized by the main looper.
  */
 public class BatteryLevelReceiver extends BroadcastReceiver {
 
-	/**
-	 * Static lock object for thread-safe access to static fields.
-	 * Using synchronized(this) doesn't work for BroadcastReceivers since each broadcast creates a new instance.
-	 */
-	private static final Object LOCK = new Object();
+	/** "No alert sent" marker for {@code prevType}; the real types (1-3) live in NotificationService. */
+	static final int NO_ALERT = 0;
 
 	/**
 	 * How far (in °C) the battery must cool below the threshold before another high-temperature
@@ -35,28 +46,38 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 */
 	private static final int TEMPERATURE_HYSTERESIS_C = 3;
 
-	/**
-	 * Thread-safe static fields to track battery notification state
-	 */
-	private static volatile int prevLevel = 0;
-	private static volatile int prevType = 0;
-	private static volatile boolean fullNotificationCalled = false;
-	private static volatile boolean temperatureAlertSent = false;
+	// Persisted alert episode state (survives process restarts, #164).
+	private static final String PREF_PREV_LEVEL = "_level_alert_prev_level";
+	private static final String PREF_PREV_TYPE = "_level_alert_prev_type";
+	private static final String PREF_FULL_NOTIFIED = "_level_alert_full_notified";
+	private static final String PREF_TEMPERATURE_ALERTED = "_temperature_alert_sent";
 
 	/**
-	 * Reset notification state when charger is disconnected
+	 * Charger-disconnect reset: re-arms the alerts whose episode is bounded by a charge session —
+	 * the full-battery alert and the critical/warning de-dupe — so the new discharge session can
+	 * alert afresh. Deliberately <b>not</b> reset (#164):
+	 * <ul>
+	 *   <li>{@code prevLevel} — the next broadcast still compares against the real last-seen level,
+	 *       so an unchanged level keeps skipping the discharge branch;</li>
+	 *   <li>the temperature flag — a hot spell doesn't end at unplug; cooling below the threshold
+	 *       (the hysteresis in {@link #decideTemperature}) is its only re-arm.</li>
+	 * </ul>
+	 *
+	 * @param context The application context
 	 */
-	public static void resetVariables() {
-		synchronized (LOCK) {
-			fullNotificationCalled = false;
-			prevType = 0;
+	public static void onChargerDisconnected(final Context context) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		final LevelAlertState state = loadLevelState(prefs);
+		final LevelAlertState reset = new LevelAlertState(state.prevLevel(), NO_ALERT, false);
+		if (!reset.equals(state)) {
+			saveLevelState(prefs, reset);
 		}
 	}
 
 	@Override
 	public void onReceive(final Context context, final Intent intent) {
 		final Intent batteryStatus = context.getApplicationContext().registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
-		if (batteryStatus == null) {
+		if (isNull(batteryStatus)) {
 			return; // Cannot determine battery status, exit early
 		}
 
@@ -76,7 +97,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		// reusing the rate just computed instead of re-parsing the persisted sample window.
 		NotificationService.updateOngoingNotification(context, batteryDO, rate);
 
-		if (batteryDO == null) {
+		if (isNull(batteryDO)) {
 			// Without a real reading, don't assume a level. Previously this defaulted to 100%,
 			// which silently suppressed genuine low/critical alerts on a transient read failure.
 			return;
@@ -87,20 +108,23 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		BatteryHealthTracker.recordBatteryState(context, percentage, status);
 
 		final SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
-		final int warningLevel = sharedPref.getInt(context.getString(R.string._pref_key_warn_battery_level), 40);
-		final int criticalLevel = sharedPref.getInt(context.getString(R.string._pref_key_critical_battery_level), 20);
-		final boolean warningEnabled = sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_warning_level), true);
-		final boolean fullNotifyEnabled = sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_full_level), true);
-		final boolean alertEveryTick = sharedPref.getBoolean(context.getString(R.string._pref_key_notify_every_tick), false);
+		final LevelAlertConfig config = new LevelAlertConfig(
+				sharedPref.getInt(context.getString(R.string._pref_key_critical_battery_level), 20),
+				sharedPref.getInt(context.getString(R.string._pref_key_warn_battery_level), 40),
+				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_warning_level), true),
+				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_full_level), true),
+				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_every_tick), false));
 
-		synchronized (LOCK) {
-			final boolean isChanged = prevLevel != percentage;
-			if (isChanged && !isCharging) {
-				handleDischarging(context, percentage, criticalLevel, warningLevel, warningEnabled, alertEveryTick);
-			} else {
-				handleChargingOrFull(context, percentage, warningLevel, isFull, fullNotifyEnabled);
-			}
-			prevLevel = percentage;
+		final LevelAlertState previous = loadLevelState(sharedPref);
+		final LevelAlertDecision decision = decideLevelAlert(previous, percentage, isCharging, isFull, config);
+
+		// Persist only on change: most broadcasts (voltage/temperature deltas) re-decide an identical
+		// state, and rewriting it would churn SharedPreferences on every tick.
+		if (!decision.newState().equals(previous)) {
+			saveLevelState(sharedPref, decision.newState());
+		}
+		if (decision.notifyType() != NO_ALERT) {
+			NotificationService.sendNotification(context, decision.notifyType());
 		}
 
 		handleTemperature(context, batteryDO, sharedPref);
@@ -116,23 +140,16 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	/**
 	 * Send a high-temperature safety alert when the battery exceeds the configured threshold.
 	 * <p>
-	 * Uses hysteresis so a single hot spell triggers one alert; another alert can only fire once
-	 * the battery has cooled at least {@link #TEMPERATURE_HYSTERESIS_C}°C below the threshold.
+	 * The hysteresis flag is persisted (#164) so a process restart mid-hot-spell cannot fire a
+	 * duplicate alert; another alert can only fire once the battery has cooled at least
+	 * {@link #TEMPERATURE_HYSTERESIS_C}°C below the threshold.
 	 *
 	 * @param context    The application context
-	 * @param batteryDO  Current battery snapshot (may be null)
+	 * @param batteryDO  Current battery snapshot (non-null; the caller already checked)
 	 * @param sharedPref The shared preferences
 	 */
 	private void handleTemperature(final Context context, final BatteryDO batteryDO, final SharedPreferences sharedPref) {
-		if (batteryDO == null) {
-			return; // No reading available
-		}
-
 		final boolean enabled = sharedPref.getBoolean(context.getString(R.string._pref_key_notify_high_temperature), true);
-		if (!enabled) {
-			temperatureAlertSent = false; // Re-arm for when it's turned back on
-			return;
-		}
 
 		// The threshold is stored canonically in Celsius; the battery reading is also Celsius
 		// (tenths), so a chilly 45 °F (~7 °C) never trips a 45 °C threshold. See TemperatureUtils.
@@ -141,59 +158,168 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 				TemperatureUtils.DEFAULT_HIGH_TEMP_THRESHOLD_C);
 		final int rawTenthsC = batteryDO.getTemperature();
 
-		synchronized (LOCK) {
-			if (TemperatureUtils.isAtOrAboveThreshold(rawTenthsC, thresholdCelsius) && !temperatureAlertSent) {
-				NotificationService.sendTemperatureNotification(context, rawTenthsC);
-				temperatureAlertSent = true;
-			} else if (TemperatureUtils.isBelowResetThreshold(rawTenthsC, thresholdCelsius, TEMPERATURE_HYSTERESIS_C)) {
-				temperatureAlertSent = false;
-			}
+		final boolean previouslyAlerted = sharedPref.getBoolean(PREF_TEMPERATURE_ALERTED, false);
+		final TemperatureDecision decision = decideTemperature(previouslyAlerted, enabled, rawTenthsC, thresholdCelsius);
+
+		if (decision.alerted() != previouslyAlerted) {
+			sharedPref.edit().putBoolean(PREF_TEMPERATURE_ALERTED, decision.alerted()).apply();
+		}
+		if (decision.shouldNotify()) {
+			NotificationService.sendTemperatureNotification(context, rawTenthsC);
 		}
 	}
 
 	/**
-	 * Handle battery notifications while discharging
+	 * Pure decision core for the critical/warning/full level alerts, unit-testable with no Android
+	 * dependencies (#164). A changed level while discharging is judged against the thresholds; an
+	 * unchanged level or a charging/full state runs the full-battery logic instead — the same split
+	 * the receiver has always used, now explicit.
+	 *
+	 * @param state      current persisted episode state
+	 * @param percentage current battery percentage (whole, via the single rounding policy #158)
+	 * @param charging   whether the battery status is {@code BATTERY_STATUS_CHARGING}
+	 * @param full       whether the battery status is {@code BATTERY_STATUS_FULL}
+	 * @param config     the user's alert thresholds and toggles
+	 *
+	 * @return which alert to send now ({@link #NO_ALERT} for none) and the new state to persist
 	 */
-	private void handleDischarging(final Context context,
-	                               final int percentage,
-	                               final int criticalLevel,
-	                               final int warningLevel,
-	                               final boolean warningEnabled,
-	                               final boolean alertEveryTick) {
-		// Force critical notification for very low battery (red alert level)
-		if (percentage <= NotificationService.RED_ALERT_LEVEL) {
-			prevType = 0;
+	static LevelAlertDecision decideLevelAlert(final LevelAlertState state, final int percentage,
+	                                           final boolean charging, final boolean full,
+	                                           final LevelAlertConfig config) {
+		final boolean levelChanged = state.prevLevel() != percentage;
+		if (levelChanged && !charging) {
+			return decideDischarging(state, percentage, config);
 		}
+		return decideChargingOrFull(state, percentage, full, config);
+	}
 
-		// Handle critical level first, then warning
-		if (percentage <= criticalLevel) {
-			if (prevType != NotificationService.CRITICAL_TYPE || alertEveryTick) {
-				NotificationService.sendNotification(context, NotificationService.CRITICAL_TYPE);
-				prevType = NotificationService.CRITICAL_TYPE;
+	/**
+	 * The discharging side: critical first, then warning, de-duplicated via {@code prevType} —
+	 * except at/below the red-alert floor, where the critical alert always re-fires.
+	 */
+	private static LevelAlertDecision decideDischarging(final LevelAlertState state, final int percentage,
+	                                                    final LevelAlertConfig config) {
+		// Force the critical alert through the de-dupe at the red-alert floor: about to die trumps "already told you".
+		int prevType = percentage <= NotificationService.RED_ALERT_LEVEL ? NO_ALERT : state.prevType();
+		int notifyType = NO_ALERT;
+
+		if (percentage <= config.criticalLevel()) {
+			if (prevType != NotificationService.CRITICAL_TYPE || config.alertEveryTick()) {
+				notifyType = NotificationService.CRITICAL_TYPE;
 			}
-		} else if (percentage <= warningLevel && warningEnabled) {
+			prevType = NotificationService.CRITICAL_TYPE;
+		} else if (percentage <= config.warningLevel() && config.warningEnabled()) {
 			if (prevType != NotificationService.WARNING_TYPE) {
-				NotificationService.sendNotification(context, NotificationService.WARNING_TYPE);
-				prevType = NotificationService.WARNING_TYPE;
+				notifyType = NotificationService.WARNING_TYPE;
 			}
+			prevType = NotificationService.WARNING_TYPE;
 		}
+		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, prevType, state.fullNotified()));
 	}
 
 	/**
-	 * Handle battery notifications while charging or full
+	 * The charging-or-unchanged side: the full alert fires once per charge session, re-armed once
+	 * the level has genuinely dropped out of the full band while staying above the warning band.
 	 */
-	private void handleChargingOrFull(final Context context, final int percentage, final int warningLevel,
-	                                  final boolean isFull, final boolean fullNotifyEnabled) {
-		if (!fullNotificationCalled) {
-			if (isFull && fullNotifyEnabled) {
-				NotificationService.sendNotification(context, NotificationService.FULL_LEVEL_TYPE);
-				fullNotificationCalled = true;
-			}
-		}
+	private static LevelAlertDecision decideChargingOrFull(final LevelAlertState state, final int percentage,
+	                                                       final boolean full, final LevelAlertConfig config) {
+		boolean fullNotified = state.fullNotified();
+		int notifyType = NO_ALERT;
 
-		// Reset full notification flag when battery drops below full threshold
-		if (percentage <= NotificationService.FULL_PERCENTAGE && percentage > warningLevel) {
-			fullNotificationCalled = false;
+		if (!fullNotified && full && config.fullNotifyEnabled()) {
+			notifyType = NotificationService.FULL_LEVEL_TYPE;
+			fullNotified = true;
 		}
+		if (percentage <= NotificationService.FULL_PERCENTAGE && percentage > config.warningLevel()) {
+			fullNotified = false;
+		}
+		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, state.prevType(), fullNotified));
+	}
+
+	/**
+	 * Pure decision core for the high-temperature alert's hysteresis (#18, #164):
+	 * <ul>
+	 *   <li><b>Disabled</b> — never notify, and re-arm so re-enabling starts fresh;</li>
+	 *   <li><b>At/above the threshold</b> — notify only if not already alerted this hot spell;</li>
+	 *   <li><b>Cooled below threshold − hysteresis</b> — re-arm for the next spell;</li>
+	 *   <li><b>In the hysteresis band between them</b> — hold the current state.</li>
+	 * </ul>
+	 *
+	 * @param alreadyAlerted   whether this hot spell's alert has already fired
+	 * @param enabled          whether the high-temperature alert is enabled
+	 * @param rawTenthsC       battery temperature in tenths of a degree Celsius
+	 * @param thresholdCelsius alert threshold in whole degrees Celsius
+	 *
+	 * @return whether to notify now, and the new alerted flag to persist
+	 */
+	static TemperatureDecision decideTemperature(final boolean alreadyAlerted, final boolean enabled,
+	                                             final int rawTenthsC, final int thresholdCelsius) {
+		if (!enabled) {
+			return new TemperatureDecision(false, false);
+		}
+		if (TemperatureUtils.isAtOrAboveThreshold(rawTenthsC, thresholdCelsius)) {
+			return new TemperatureDecision(!alreadyAlerted, true);
+		}
+		if (TemperatureUtils.isBelowResetThreshold(rawTenthsC, thresholdCelsius, TEMPERATURE_HYSTERESIS_C)) {
+			return new TemperatureDecision(false, false);
+		}
+		return new TemperatureDecision(false, alreadyAlerted);
+	}
+
+	static LevelAlertState loadLevelState(final SharedPreferences prefs) {
+		return new LevelAlertState(
+				prefs.getInt(PREF_PREV_LEVEL, 0),
+				prefs.getInt(PREF_PREV_TYPE, NO_ALERT),
+				prefs.getBoolean(PREF_FULL_NOTIFIED, false));
+	}
+
+	static void saveLevelState(final SharedPreferences prefs, final LevelAlertState state) {
+		prefs.edit()
+		     .putInt(PREF_PREV_LEVEL, state.prevLevel())
+		     .putInt(PREF_PREV_TYPE, state.prevType())
+		     .putBoolean(PREF_FULL_NOTIFIED, state.fullNotified())
+		     .apply();
+	}
+
+	/**
+	 * Persisted level-alert episode state (#164).
+	 *
+	 * @param prevLevel    the percentage seen on the previous broadcast (gates the discharge branch)
+	 * @param prevType     the last level alert sent while discharging ({@link #NO_ALERT} when none)
+	 * @param fullNotified whether the full-battery alert has fired this charge session
+	 */
+	record LevelAlertState(int prevLevel, int prevType, boolean fullNotified) {
+	}
+
+	/**
+	 * The user's alert thresholds and toggles (reduces parameter count, like
+	 * {@code NotificationService.NotificationConfig}).
+	 *
+	 * @param criticalLevel     critical alert threshold in percent
+	 * @param warningLevel      warning alert threshold in percent
+	 * @param warningEnabled    whether the warning alert is enabled
+	 * @param fullNotifyEnabled whether the full-battery alert is enabled
+	 * @param alertEveryTick    whether the critical alert repeats on every level tick
+	 */
+	record LevelAlertConfig(int criticalLevel, int warningLevel, boolean warningEnabled,
+	                        boolean fullNotifyEnabled, boolean alertEveryTick) {
+	}
+
+	/**
+	 * Result of {@link #decideLevelAlert}: which alert to send now, and the state to persist.
+	 *
+	 * @param notifyType a {@code NotificationService} type, or {@link #NO_ALERT} for none
+	 * @param newState   the state to persist
+	 */
+	record LevelAlertDecision(int notifyType, LevelAlertState newState) {
+	}
+
+	/**
+	 * Result of {@link #decideTemperature}: whether to notify now, and the flag to persist.
+	 *
+	 * @param shouldNotify whether to send the temperature alert now
+	 * @param alerted      whether the current hot spell counts as alerted
+	 */
+	record TemperatureDecision(boolean shouldNotify, boolean alerted) {
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
@@ -128,13 +128,14 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 	/**
 	 * Handle charger disconnected event
 	 * <p>
-	 * Cancels any pending speed sample, resets battery monitoring state and clears active notifications.
+	 * Cancels any pending speed sample, re-arms the charge-session alerts (full-battery + level
+	 * de-dupe — see {@link BatteryLevelReceiver#onChargerDisconnected}) and clears active notifications.
 	 *
 	 * @param context The application context
 	 */
 	private void handleChargerDisconnected(final Context context) {
 		cancelPendingSample();
-		BatteryLevelReceiver.resetVariables();
+		BatteryLevelReceiver.onChargerDisconnected(context);
 		NotificationService.clearNotifications(context);
 
 		Log.i(TAG, "Charger disconnected");

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
@@ -1,0 +1,216 @@
+package com.almothafar.simplebatterynotifier.receiver;
+
+import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertConfig;
+import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertDecision;
+import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertState;
+import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.TemperatureDecision;
+import com.almothafar.simplebatterynotifier.service.NotificationService;
+
+import org.junit.Test;
+
+import static com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.NO_ALERT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link BatteryLevelReceiver}'s pure decision cores (#164), in the
+ * {@code FastDrainDetectorTest} style: the critical/warning de-dupe, the red-alert override, the
+ * full-once-per-charge episode with its re-arm band, and the temperature hysteresis. Because the
+ * state is now a value passed in and returned, every test doubles as a process-restart test: the
+ * decision depends only on what was persisted, not on in-memory history.
+ */
+public class BatteryLevelReceiverDecisionTest {
+
+	private static final int CRITICAL = 20;
+	private static final int WARNING = 40;
+	private static final int THRESHOLD_C = 45;
+
+	private static final LevelAlertConfig DEFAULTS = new LevelAlertConfig(CRITICAL, WARNING, true, true, false);
+	private static final LevelAlertState FRESH = new LevelAlertState(0, NO_ALERT, false);
+
+	private static final boolean DISCHARGING = false;
+	private static final boolean NOT_FULL = false;
+
+	// --- discharging: critical/warning thresholds and de-dupe -----------------------------------
+
+	@Test
+	public void discharging_belowCritical_firesCriticalOnce() {
+		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
+				new LevelAlertState(16, NO_ALERT, false), 15, DISCHARGING, NOT_FULL, DEFAULTS);
+
+		assertEquals(NotificationService.CRITICAL_TYPE, first.notifyType());
+		assertEquals(new LevelAlertState(15, NotificationService.CRITICAL_TYPE, false), first.newState());
+
+		// Next tick, still below critical: the persisted prevType suppresses the duplicate.
+		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
+				first.newState(), 14, DISCHARGING, NOT_FULL, DEFAULTS);
+		assertEquals(NO_ALERT, second.notifyType());
+		assertEquals(14, second.newState().prevLevel());
+	}
+
+	@Test
+	public void discharging_inWarningBand_firesWarningOnce() {
+		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
+				new LevelAlertState(41, NO_ALERT, false), 38, DISCHARGING, NOT_FULL, DEFAULTS);
+
+		assertEquals(NotificationService.WARNING_TYPE, first.notifyType());
+
+		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
+				first.newState(), 35, DISCHARGING, NOT_FULL, DEFAULTS);
+		assertEquals(NO_ALERT, second.notifyType());
+	}
+
+	@Test
+	public void discharging_aboveWarning_noAlert() {
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				new LevelAlertState(81, NO_ALERT, false), 80, DISCHARGING, NOT_FULL, DEFAULTS);
+
+		assertEquals(NO_ALERT, d.notifyType());
+		assertEquals(80, d.newState().prevLevel());
+	}
+
+	@Test
+	public void discharging_warningDisabled_staysSilentInWarningBand() {
+		final LevelAlertConfig noWarning = new LevelAlertConfig(CRITICAL, WARNING, false, true, false);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				new LevelAlertState(41, NO_ALERT, false), 38, DISCHARGING, NOT_FULL, noWarning);
+
+		assertEquals(NO_ALERT, d.notifyType());
+	}
+
+	@Test
+	public void discharging_warningThenCritical_escalates() {
+		final LevelAlertState afterWarning = new LevelAlertState(35, NotificationService.WARNING_TYPE, false);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				afterWarning, 20, DISCHARGING, NOT_FULL, DEFAULTS);
+
+		assertEquals(NotificationService.CRITICAL_TYPE, d.notifyType());
+	}
+
+	@Test
+	public void discharging_alertEveryTick_repeatsCritical() {
+		final LevelAlertConfig everyTick = new LevelAlertConfig(CRITICAL, WARNING, true, true, true);
+		final LevelAlertState alreadyCritical = new LevelAlertState(15, NotificationService.CRITICAL_TYPE, false);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				alreadyCritical, 14, DISCHARGING, NOT_FULL, everyTick);
+
+		assertEquals(NotificationService.CRITICAL_TYPE, d.notifyType());
+	}
+
+	@Test
+	public void discharging_atRedAlertFloor_overridesDeDupe() {
+		// Already alerted critical this episode, but at/below the red-alert level it must re-fire.
+		final LevelAlertState alreadyCritical = new LevelAlertState(5, NotificationService.CRITICAL_TYPE, false);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				alreadyCritical, NotificationService.RED_ALERT_LEVEL, DISCHARGING, NOT_FULL, DEFAULTS);
+
+		assertEquals(NotificationService.CRITICAL_TYPE, d.notifyType());
+	}
+
+	@Test
+	public void discharging_unchangedLevel_doesNotAlert() {
+		// Same level as last tick routes to the charging-or-full branch (the receiver's historical
+		// split), so a repeated broadcast at the same percentage can't duplicate a level alert.
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				new LevelAlertState(15, NotificationService.CRITICAL_TYPE, false), 15, DISCHARGING, NOT_FULL, DEFAULTS);
+
+		assertEquals(NO_ALERT, d.notifyType());
+	}
+
+	// --- charging / full: once per charge session ------------------------------------------------
+
+	@Test
+	public void charging_full_firesOnceThenHolds() {
+		final LevelAlertState atHundred = new LevelAlertState(100, NO_ALERT, false);
+		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(atHundred, 100, false, true, DEFAULTS);
+
+		assertEquals(NotificationService.FULL_LEVEL_TYPE, first.notifyType());
+		assertTrue(first.newState().fullNotified());
+
+		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(first.newState(), 100, false, true, DEFAULTS);
+		assertEquals(NO_ALERT, second.notifyType());
+	}
+
+	@Test
+	public void charging_fullDisabled_staysSilent() {
+		final LevelAlertConfig noFull = new LevelAlertConfig(CRITICAL, WARNING, true, false, false);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				new LevelAlertState(100, NO_ALERT, false), 100, false, true, noFull);
+
+		assertEquals(NO_ALERT, d.notifyType());
+		assertFalse(d.newState().fullNotified());
+	}
+
+	@Test
+	public void charging_levelLeavesFullBand_reArmsFullAlert() {
+		// Notified at full, then the level drops to 90 (≤ FULL_PERCENTAGE, above warning): re-armed.
+		final LevelAlertState notified = new LevelAlertState(100, NO_ALERT, true);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(notified, 90, true, NOT_FULL, DEFAULTS);
+
+		assertEquals(NO_ALERT, d.notifyType());
+		assertFalse(d.newState().fullNotified());
+	}
+
+	@Test
+	public void charging_belowWarningBand_doesNotReArmFullAlert() {
+		// The re-arm band is (warning, FULL_PERCENTAGE]: charging low keeps the flag as-is.
+		final LevelAlertState notified = new LevelAlertState(100, NO_ALERT, true);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(notified, 30, true, NOT_FULL, DEFAULTS);
+
+		assertTrue(d.newState().fullNotified());
+	}
+
+	// --- charger-disconnect reset semantics (via the pure state) ---------------------------------
+
+	@Test
+	public void restartMidEpisode_persistedStateSuppressesDuplicates() {
+		// Process death loses nothing: the decision on the persisted state after a "restart" is the
+		// same as it would have been in-process — no duplicate critical while still below threshold.
+		final LevelAlertState persisted = new LevelAlertState(15, NotificationService.CRITICAL_TYPE, false);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				persisted, 13, DISCHARGING, NOT_FULL, DEFAULTS);
+
+		assertEquals(NO_ALERT, d.notifyType());
+	}
+
+	// --- temperature hysteresis -------------------------------------------------------------------
+
+	@Test
+	public void temperature_aboveThreshold_firesOnce() {
+		final TemperatureDecision first = BatteryLevelReceiver.decideTemperature(false, true, 460, THRESHOLD_C);
+		assertTrue(first.shouldNotify());
+		assertTrue(first.alerted());
+
+		final TemperatureDecision second = BatteryLevelReceiver.decideTemperature(first.alerted(), true, 470, THRESHOLD_C);
+		assertFalse(second.shouldNotify());
+		assertTrue(second.alerted());
+	}
+
+	@Test
+	public void temperature_inHysteresisBand_holdsState() {
+		// 43.0 °C: below the 45° threshold but not yet 3° cooler — the alerted flag must hold, so a
+		// process restart in this band can't re-fire when the temperature ticks back up.
+		final TemperatureDecision d = BatteryLevelReceiver.decideTemperature(true, true, 430, THRESHOLD_C);
+		assertFalse(d.shouldNotify());
+		assertTrue(d.alerted());
+	}
+
+	@Test
+	public void temperature_cooledBelowHysteresis_reArms() {
+		final TemperatureDecision cooled = BatteryLevelReceiver.decideTemperature(true, true, 420, THRESHOLD_C);
+		assertFalse(cooled.shouldNotify());
+		assertFalse(cooled.alerted());
+
+		// The next spell alerts again.
+		final TemperatureDecision reAlert = BatteryLevelReceiver.decideTemperature(cooled.alerted(), true, 455, THRESHOLD_C);
+		assertTrue(reAlert.shouldNotify());
+	}
+
+	@Test
+	public void temperature_disabled_neverNotifiesAndReArms() {
+		final TemperatureDecision d = BatteryLevelReceiver.decideTemperature(true, false, 470, THRESHOLD_C);
+		assertFalse(d.shouldNotify());
+		assertFalse(d.alerted());
+	}
+}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.BatteryManager;
 
+import androidx.preference.PreferenceManager;
 import androidx.test.core.app.ApplicationProvider;
 
+import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertState;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 
@@ -16,9 +18,8 @@ import org.mockito.MockedStatic;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.lang.reflect.Field;
-
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -31,6 +32,10 @@ import static org.mockito.Mockito.times;
  * notification to {@link NotificationService}, whose static methods are mocked so we can assert
  * <em>which</em> alert (if any) it decides to send without doing real Android notification work.
  * {@link SystemService} is left real so it builds a {@code BatteryDO} from the sticky intent we set.
+ * <p>
+ * Episode state lives in SharedPreferences (#164), and each {@code receive()} uses a fresh receiver
+ * instance — so every multi-broadcast test also exercises the state surviving "process death"
+ * (nothing is carried in memory between broadcasts).
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
@@ -40,12 +45,9 @@ public class BatteryLevelReceiverTest {
 
 	@Before
 	public void setUp() {
+		// Robolectric gives each test a fresh application (and thus fresh SharedPreferences), so the
+		// persisted episode state (#164) always starts cleared; no manual reset needed.
 		context = ApplicationProvider.getApplicationContext();
-		// Clear the static de-dup state between tests so ordering can't leak through
-		setStatic("prevLevel", 0);
-		setStatic("prevType", 0);
-		setStatic("fullNotificationCalled", false);
-		setStatic("temperatureAlertSent", false);
 	}
 
 	@Test
@@ -109,7 +111,7 @@ public class BatteryLevelReceiverTest {
 	@Test
 	public void full_whileCharging_sendsFullAlertOnce() {
 		// Simulate the battery already sitting at 100% (unchanged) so the charging/full branch runs
-		setStatic("prevLevel", 100);
+		saveLevelState(new LevelAlertState(100, BatteryLevelReceiver.NO_ALERT, false));
 		publishBattery(BatteryManager.BATTERY_STATUS_FULL, 100, 100, BatteryManager.BATTERY_PLUGGED_AC);
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
@@ -119,38 +121,81 @@ public class BatteryLevelReceiverTest {
 		}
 	}
 
+	@Test
+	public void unplug_reArmsFullAlert_forNextChargeSession() {
+		saveLevelState(new LevelAlertState(100, BatteryLevelReceiver.NO_ALERT, false));
+		publishBattery(BatteryManager.BATTERY_STATUS_FULL, 100, 100, BatteryManager.BATTERY_PLUGGED_AC);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			// Unplugged: the charge-session reset re-arms the full alert; plugging back in at full fires again.
+			BatteryLevelReceiver.onChargerDisconnected(context);
+			receive();
+
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.FULL_LEVEL_TYPE)), times(2));
+		}
+	}
+
+	@Test
+	public void temperature_hotSpell_alertsOnceAcrossBroadcasts() {
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			// 46.0 °C — above the default 45 °C threshold. Each receive() is a fresh receiver instance,
+			// so the second broadcast staying hot is exactly the killed-and-restarted-mid-spell case.
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 80, 100, 0, 460);
+			receive();
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 79, 100, 0, 465);
+			receive();
+
+			ns.verify(() -> NotificationService.sendTemperatureNotification(any(Context.class), anyInt()), times(1));
+		}
+	}
+
+	@Test
+	public void temperature_cooledBelowHysteresis_alertsAgainOnNextSpell() {
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 80, 100, 0, 460);
+			receive();
+			// Cooled to 41.0 °C (≤ 45 − 3 hysteresis) — re-arms; the next spell alerts again.
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 79, 100, 0, 410);
+			receive();
+			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 78, 100, 0, 460);
+			receive();
+
+			ns.verify(() -> NotificationService.sendTemperatureNotification(any(Context.class), anyInt()), times(2));
+		}
+	}
+
 	// --- helpers -------------------------------------------------------------
 
 	private void receive() {
 		new BatteryLevelReceiver().onReceive(context, new Intent(Intent.ACTION_BATTERY_CHANGED));
 	}
 
-	@SuppressWarnings("deprecation")
 	private void publishBattery(final int status, final int level, final int scale, final int plugged) {
+		publishBattery(status, level, scale, plugged, 250); // 25.0 °C, well below the alert threshold
+	}
+
+	@SuppressWarnings("deprecation")
+	private void publishBattery(final int status, final int level, final int scale, final int plugged,
+	                            final int temperatureTenthsC) {
 		final Intent battery = new Intent(Intent.ACTION_BATTERY_CHANGED);
 		battery.putExtra(BatteryManager.EXTRA_STATUS, status);
 		battery.putExtra(BatteryManager.EXTRA_LEVEL, level);
 		battery.putExtra(BatteryManager.EXTRA_SCALE, scale);
 		battery.putExtra(BatteryManager.EXTRA_PLUGGED, plugged);
 		battery.putExtra(BatteryManager.EXTRA_PRESENT, true);
-		battery.putExtra(BatteryManager.EXTRA_TEMPERATURE, 250); // 25.0 °C, well below the alert threshold
+		battery.putExtra(BatteryManager.EXTRA_TEMPERATURE, temperatureTenthsC);
 		context.sendStickyBroadcast(battery);
 	}
 
 	private void enableAlertEveryTick() {
-		androidx.preference.PreferenceManager.getDefaultSharedPreferences(context)
+		PreferenceManager.getDefaultSharedPreferences(context)
 				.edit()
 				.putBoolean(context.getString(com.almothafar.simplebatterynotifier.R.string._pref_key_notify_every_tick), true)
 				.commit();
 	}
 
-	private static void setStatic(final String fieldName, final Object value) {
-		try {
-			final Field field = BatteryLevelReceiver.class.getDeclaredField(fieldName);
-			field.setAccessible(true);
-			field.set(null, value);
-		} catch (ReflectiveOperationException e) {
-			throw new IllegalStateException("Unable to reset " + fieldName, e);
-		}
+	private void saveLevelState(final LevelAlertState state) {
+		BatteryLevelReceiver.saveLevelState(PreferenceManager.getDefaultSharedPreferences(context), state);
 	}
 }


### PR DESCRIPTION
Closes #164.

## Problem

`BatteryLevelReceiver` kept its alert episode state (`prevLevel`, `prevType`, `fullNotificationCalled`, `temperatureAlertSent`) in in-memory volatile statics. Process death — doze, OEM task killers, app updates, memory pressure — silently reset all four, so:

- the temperature hysteresis was defeated mid-hot-spell (duplicate high-temperature alert, precisely when the device is hot and the system is killing processes),
- a duplicate critical/warning alert fired after restart while still below the threshold,
- a duplicate full-battery alert fired while still on the charger.

## Fix

The receiver now follows the same **load → pure decide → save-on-change** pattern as `FastDrainDetector` (#109) and `SlowChargeDetector` (#123):

- **Persisted state** — `LevelAlertState(prevLevel, prevType, fullNotified)` and the temperature flag live in SharedPreferences; both are written **only on change**, so voltage/temperature-delta broadcasts that re-decide identical state don't churn the prefs file.
- **Pure decision cores** — `decideLevelAlert()` (critical/warning de-dupe, red-alert override, every-tick repeat, full-once-per-charge with its re-arm band) and `decideTemperature()` (hysteresis with an explicit *hold* band between the threshold and threshold − 3 °C) are Android-free and fully unit-testable.
- **`resetVariables()` → `onChargerDisconnected(context)`** — the partial reset is now an explicit, documented decision: unplug re-arms the charge-session alerts (full-battery + level de-dupe) and deliberately keeps `prevLevel` (the next broadcast still compares against the real last-seen level) and the temperature flag (a hot spell doesn't end at unplug — cooling below the hysteresis point is its only re-arm).
- **The static `LOCK` and volatiles are removed** — both receivers and the unplug reset are registered on and delivered to the main thread by `PowerConnectionService`, so access is serialized by the main looper; the class doc states that assumption.

## Tests

26 receiver tests, all green (349 total):

- **17 new pure decision tests** (`BatteryLevelReceiverDecisionTest`, in the `FastDrainDetectorTest` style): threshold bands, de-dupe, warning→critical escalation, red-alert override of the de-dupe, every-tick repeats, disabled toggles, full-once with the `(warning, 95]` re-arm band, restart-mid-episode suppression, and the temperature hysteresis including the hold band.
- **Robolectric receiver tests** dropped their reflection-based static resets for persisted state, and added unplug-re-arm and hot-spell-dedupe coverage. Since every broadcast uses a fresh receiver instance with nothing carried in memory, each multi-broadcast test doubles as a kill-the-app-mid-episode verification (acceptance criterion 1).

Related: #109, #123, #163, #35 (QA rows 3-7, 11), #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)