### PR TITLE
Atomic plugged-state dedupe in PowerConnectionReceiver (#156)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
@@ -13,6 +13,8 @@ import com.almothafar.simplebatterynotifier.model.ChargeSpeed;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Broadcast receiver for power connection/disconnection events.
  * <p>
@@ -37,11 +39,14 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 	static final long CHARGE_SAMPLE_DELAY_MS = 2000L;
 
 	/**
-	 * Previous plugged state to prevent duplicate notifications for the same state
+	 * Previous plugged state to prevent duplicate notifications for the same state.
 	 * <p>
-	 * This static field is thread-safe via synchronized access methods.
+	 * Atomic because BroadcastReceivers can run concurrently: the dedupe must read, compare and
+	 * update in one operation ({@link AtomicInteger#getAndSet}), or two quick broadcasts could both
+	 * see the stale state and both pass (issue #156). -1 means "unknown", so the first broadcast
+	 * after process start always processes.
 	 */
-	private static int currentState = -1;
+	private static final AtomicInteger currentState = new AtomicInteger(-1);
 
 	// Main-thread handler used to sample the charging speed a short delay after connection. Static so a
 	// stale pending sample can be cancelled if the charger is unplugged (or re-plugged) during the delay.
@@ -49,15 +54,14 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 	private static Runnable pendingSample;
 
 	/**
-	 * Update the current plugged state (synchronized for thread safety)
-	 * <p>
-	 * Thread safety is important because BroadcastReceivers can be called
-	 * concurrently from different threads.
+	 * Update the current plugged state without triggering a notification. Used by
+	 * {@code PowerConnectionService} to seed the state at service start, so the first broadcast
+	 * after startup doesn't announce a charger that was already plugged in.
 	 *
 	 * @param state The new plugged state
 	 */
-	public static synchronized void setCurrentState(final int state) {
-		currentState = state;
+	public static void setCurrentState(final int state) {
+		currentState.set(state);
 	}
 
 	/**
@@ -78,10 +82,11 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 		}
 
 		final int pluggedState = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
-		if (currentState == pluggedState) {
+		// Read-compare-update in one atomic step: a check-then-act here let two quick broadcasts
+		// both pass the dedupe (issue #156).
+		if (currentState.getAndSet(pluggedState) == pluggedState) {
 			return; // Same state as before, avoid duplicate notifications
 		}
-		setCurrentState(pluggedState);
 
 		final int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
 		final int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiverTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
@@ -97,6 +98,36 @@ public class PowerConnectionReceiverTest {
 			runPendingSample();
 			ns.verify(() -> NotificationService.notifyChargeConnected(any(Context.class),
 					any(ChargeSpeed.class), anyBoolean()), never());
+		}
+	}
+
+	@Test
+	public void repeatedBroadcastForSameState_notifiesOnlyOnce() {
+		// The dedupe updates the state atomically with the check (issue #156): the first receive
+		// claims the new state, so an immediate duplicate broadcast must be swallowed.
+		publishBattery(BatteryManager.BATTERY_PLUGGED_AC, 50, 100);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			receive();
+			runPendingSample();
+			ns.verify(() -> NotificationService.notifyChargeConnected(any(Context.class),
+					any(ChargeSpeed.class), anyBoolean()), times(1));
+		}
+	}
+
+	@Test
+	public void stateChangeAfterDedupe_stillProcesses() {
+		// Connect, then unplug: the second broadcast differs from the recorded state, so it must
+		// pass the dedupe and run the disconnect cleanup.
+		publishBattery(BatteryManager.BATTERY_PLUGGED_AC, 50, 100);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			publishBattery(0, 50, 100); // unplugged
+			receive();
+			runPendingSample();
+			ns.verify(() -> NotificationService.clearNotifications(any(Context.class)));
 		}
 	}
 


### PR DESCRIPTION
Closes #156.

## Problem

The plugged-state dedupe was check-then-act: an unsynchronized, non-volatile read of `currentState`, a compare, then a `synchronized` write. Two broadcasts in quick succession (plug/unplug bounce, `ACTION_BATTERY_CHANGED` bursts at plug-in) could both read the stale state and both pass — double-processing, or a disconnect racing a connect out of order. The class javadoc claimed thread safety the code didn't deliver.

## Fix

Exactly the issue's sketch: `currentState` is now an `AtomicInteger` and the dedupe is a single `getAndSet` — read, compare, and update in one atomic operation, no lock, no window. `setCurrentState()` remains as the notification-free seeding path used by `PowerConnectionService` at startup (acceptance criterion: no spurious notification on the first broadcast after service start — unchanged, it still just sets the state).

## Testing

- `PowerConnectionReceiverTest`: all 5 existing tests green, plus 2 new ones pinning the dedupe — a duplicate broadcast for the same state notifies **exactly once**, and a genuine state change (connect → disconnect) still passes the dedupe and runs cleanup.
- Full `testDebugUnitTest` + `lintDebug` green; debug build installed on the Mate 10 Pro.

No user-facing changes (no strings, no behavior change beyond closing the race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)