### PR TITLE
Receivers: use the delivered ACTION_BATTERY_CHANGED intent instead of re-querying the sticky broadcast (#159)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -3,7 +3,6 @@ package com.almothafar.simplebatterynotifier.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.os.BatteryManager;
 import androidx.preference.PreferenceManager;
@@ -76,17 +75,19 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 
 	@Override
 	public void onReceive(final Context context, final Intent intent) {
-		final Intent batteryStatus = context.getApplicationContext().registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
-		if (isNull(batteryStatus)) {
-			return; // Cannot determine battery status, exit early
+		// The receiver is registered for ACTION_BATTERY_CHANGED (see PowerConnectionService), so the
+		// delivered intent already carries the battery state — no need to re-query the sticky
+		// broadcast (#159). The action check guards against unexpected/spoofed intents.
+		if (isNull(intent) || !Intent.ACTION_BATTERY_CHANGED.equals(intent.getAction())) {
+			return;
 		}
 
-		final int status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+		final int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
 		final boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING;
 		final boolean isFull = status == BatteryManager.BATTERY_STATUS_FULL;
 
-		// Reuse the sticky intent we already read above instead of triggering a second read.
-		final BatteryDO batteryDO = SystemService.getBatteryInfo(context, batteryStatus);
+		// Build the reading from the delivered intent; with a non-null intent this never returns null.
+		final BatteryDO batteryDO = SystemService.getBatteryInfo(context, intent);
 
 		// Feed the charge/drain rate window from this broadcast (no polling timer of our own) so both the
 		// ongoing notification below and the details table reflect the latest reading (issue #108). The
@@ -97,11 +98,6 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		// reusing the rate just computed instead of re-parsing the persisted sample window.
 		NotificationService.updateOngoingNotification(context, batteryDO, rate);
 
-		if (isNull(batteryDO)) {
-			// Without a real reading, don't assume a level. Previously this defaulted to 100%,
-			// which silently suppressed genuine low/critical alerts on a transient read failure.
-			return;
-		}
 		final int percentage = batteryDO.getBatteryPercentageInt();
 
 		// Track battery health and charge cycles

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
@@ -65,31 +65,33 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 	}
 
 	/**
-	 * Called when a power connection broadcast is received
+	 * Called when a battery-changed broadcast is received
 	 * <p>
 	 * This method determines the current battery state, detects whether charging is wired or
 	 * wireless, and schedules the charge-connected notification for the user.
 	 *
 	 * @param context The context in which the receiver is running
-	 * @param intent  The intent being received
+	 * @param intent  The delivered {@code ACTION_BATTERY_CHANGED} intent
 	 */
 	@Override
 	public void onReceive(final Context context, final Intent intent) {
-		final Intent batteryStatus = context.getApplicationContext().registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
-		if (batteryStatus == null) {
-			Log.w(TAG, "Unable to retrieve battery status");
-			return; // Cannot determine battery status, exit early
+		// The receiver is registered for ACTION_BATTERY_CHANGED (see PowerConnectionService), so the
+		// delivered intent already carries the battery state — no need to re-query the sticky
+		// broadcast (#159). The action check guards against unexpected/spoofed intents.
+		if (intent == null || !Intent.ACTION_BATTERY_CHANGED.equals(intent.getAction())) {
+			Log.w(TAG, "Ignoring unexpected broadcast: " + (intent == null ? "null intent" : intent.getAction()));
+			return;
 		}
 
-		final int pluggedState = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
+		final int pluggedState = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
 		// Read-compare-update in one atomic step: a check-then-act here let two quick broadcasts
 		// both pass the dedupe (issue #156).
 		if (currentState.getAndSet(pluggedState) == pluggedState) {
 			return; // Same state as before, avoid duplicate notifications
 		}
 
-		final int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
-		final int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+		final int level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
+		final int scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
 		// Through the single rounding policy (#158) — also guards the scale=-1 default the raw division didn't.
 		final int percentage = new BatteryDO().setLevel(level).setScale(scale).getBatteryPercentageInt();
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
@@ -28,10 +28,10 @@ import static org.mockito.Mockito.times;
 /**
  * Robolectric + Mockito tests for {@link BatteryLevelReceiver}'s threshold and de-duplication logic.
  * <p>
- * The receiver reads the sticky {@code ACTION_BATTERY_CHANGED} intent and delegates the actual
- * notification to {@link NotificationService}, whose static methods are mocked so we can assert
- * <em>which</em> alert (if any) it decides to send without doing real Android notification work.
- * {@link SystemService} is left real so it builds a {@code BatteryDO} from the sticky intent we set.
+ * The receiver reads the delivered {@code ACTION_BATTERY_CHANGED} intent (#159) and delegates the
+ * actual notification to {@link NotificationService}, whose static methods are mocked so we can
+ * assert <em>which</em> alert (if any) it decides to send without doing real Android notification
+ * work. {@link SystemService} is left real so it builds a {@code BatteryDO} from the intent we deliver.
  * <p>
  * Episode state lives in SharedPreferences (#164), and each {@code receive()} uses a fresh receiver
  * instance — so every multi-broadcast test also exercises the state surviving "process death"
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.times;
 public class BatteryLevelReceiverTest {
 
 	private Context context;
+	private Intent latestBattery;
 
 	@Before
 	public void setUp() {
@@ -165,17 +166,30 @@ public class BatteryLevelReceiverTest {
 		}
 	}
 
+	@Test
+	public void unexpectedAction_isIgnored() {
+		// The receiver reads the delivered intent (#159); a wrong-action intent (whose missing extras
+		// would otherwise read as a 0% battery) must be dropped by the guard, not alerted on.
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			new BatteryLevelReceiver().onReceive(context, new Intent(Intent.ACTION_POWER_CONNECTED));
+			ns.verifyNoInteractions();
+		}
+	}
+
 	// --- helpers -------------------------------------------------------------
 
 	private void receive() {
-		new BatteryLevelReceiver().onReceive(context, new Intent(Intent.ACTION_BATTERY_CHANGED));
+		new BatteryLevelReceiver().onReceive(context, latestBattery);
 	}
 
 	private void publishBattery(final int status, final int level, final int scale, final int plugged) {
 		publishBattery(status, level, scale, plugged, 250); // 25.0 °C, well below the alert threshold
 	}
 
-	@SuppressWarnings("deprecation")
+	/**
+	 * Build the battery-changed intent {@link #receive()} will deliver. The receiver reads the
+	 * delivered intent directly (#159), so no sticky broadcast is involved anymore.
+	 */
 	private void publishBattery(final int status, final int level, final int scale, final int plugged,
 	                            final int temperatureTenthsC) {
 		final Intent battery = new Intent(Intent.ACTION_BATTERY_CHANGED);
@@ -185,7 +199,7 @@ public class BatteryLevelReceiverTest {
 		battery.putExtra(BatteryManager.EXTRA_PLUGGED, plugged);
 		battery.putExtra(BatteryManager.EXTRA_PRESENT, true);
 		battery.putExtra(BatteryManager.EXTRA_TEMPERATURE, temperatureTenthsC);
-		context.sendStickyBroadcast(battery);
+		latestBattery = battery;
 	}
 
 	private void enableAlertEveryTick() {

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiverTest.java
@@ -31,7 +31,7 @@ import static org.robolectric.Shadows.shadowOf;
  * Robolectric + Mockito tests for {@link PowerConnectionReceiver}: wired/wireless detection,
  * plugged-state de-duplication, and the disconnect cleanup path. The
  * {@link NotificationService} static methods are mocked so we can assert what the receiver decides
- * to do from the sticky {@code ACTION_BATTERY_CHANGED} intent.
+ * to do from the delivered {@code ACTION_BATTERY_CHANGED} intent (#159).
  * <p>
  * The charge-connected notification is dispatched a short delay after connection (the charging
  * current is noisy right at plug-in), so tests advance the main looper by
@@ -42,6 +42,7 @@ import static org.robolectric.Shadows.shadowOf;
 public class PowerConnectionReceiverTest {
 
 	private Context context;
+	private Intent latestBattery;
 
 	@Before
 	public void setUp() {
@@ -144,6 +145,19 @@ public class PowerConnectionReceiverTest {
 	}
 
 	@Test
+	public void unexpectedAction_isIgnored() {
+		// The receiver reads the delivered intent (#159), so an intent with the wrong action must be
+		// dropped by the guard instead of being misread as a battery snapshot.
+		publishBattery(BatteryManager.BATTERY_PLUGGED_AC, 50, 100);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			new PowerConnectionReceiver().onReceive(context, new Intent(Intent.ACTION_POWER_CONNECTED));
+			runPendingSample();
+			ns.verifyNoInteractions();
+		}
+	}
+
+	@Test
 	public void disconnected_clearsNotifications() {
 		PowerConnectionReceiver.setCurrentState(BatteryManager.BATTERY_PLUGGED_AC);
 		publishBattery(0, 50, 100); // unplugged
@@ -160,7 +174,7 @@ public class PowerConnectionReceiverTest {
 	// --- helpers -------------------------------------------------------------
 
 	private void receive() {
-		new PowerConnectionReceiver().onReceive(context, new Intent(Intent.ACTION_POWER_CONNECTED));
+		new PowerConnectionReceiver().onReceive(context, latestBattery);
 	}
 
 	/**
@@ -170,6 +184,11 @@ public class PowerConnectionReceiverTest {
 		shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(PowerConnectionReceiver.CHARGE_SAMPLE_DELAY_MS));
 	}
 
+	/**
+	 * Build the battery-changed intent {@link #receive()} will deliver (the receiver reads the
+	 * delivered intent directly since #159), and publish it as the sticky broadcast too — the
+	 * delayed sample's still-plugged re-check reads the sticky state.
+	 */
 	@SuppressWarnings("deprecation")
 	private void publishBattery(final int plugged, final int level, final int scale) {
 		final Intent battery = new Intent(Intent.ACTION_BATTERY_CHANGED);
@@ -178,5 +197,6 @@ public class PowerConnectionReceiverTest {
 		battery.putExtra(BatteryManager.EXTRA_SCALE, scale);
 		battery.putExtra(BatteryManager.EXTRA_PRESENT, true);
 		context.sendStickyBroadcast(battery);
+		latestBattery = battery;
 	}
 }


### PR DESCRIPTION
## What

Both `BatteryLevelReceiver` and `PowerConnectionReceiver` are registered for `ACTION_BATTERY_CHANGED` (see `PowerConnectionService`), so the intent delivered to `onReceive` **is** the battery-status intent — yet both re-fetched it with `registerReceiver(null, new IntentFilter(ACTION_BATTERY_CHANGED))`. They now read the delivered intent directly, guarded by an action check (`ACTION_BATTERY_CHANGED.equals(intent.getAction())`, same belt-and-braces style as `BootCompletedIntentReceiver`).

- Removes a binder round-trip on every battery broadcast and the artificial "sticky query returned null" failure branches (including the now-impossible null-`BatteryDO` branch in `BatteryLevelReceiver`).
- Deliberately **unchanged**: the init-time read in `PowerConnectionService.registerPowerConnectionReceiver` (no delivered intent there) and `isStillPlugged` after the 2s sample delay (a fresh query is the whole point there).
- Part 2 of the issue (unguarded `level/scale` math) was already fixed when #158 routed the percentage through `BatteryDO.getBatteryPercentageInt()` — no ad-hoc math is left in the receivers.

## Tests

- Both receiver test helpers now deliver the battery intent to `onReceive` (matching real delivery) instead of relying on the receiver re-reading the sticky broadcast; `PowerConnectionReceiverTest` still publishes the sticky state for the delayed still-plugged re-check.
- New `unexpectedAction_isIgnored` test in each class: a wrong-action intent is dropped by the guard — no notification decisions, no state change.
- `testDebugUnitTest` (366 tests) and `lintDebug` green; debug build installed on the Mate 10 Pro.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)