### PR TITLE
AlertType enum replaces the int notification-type constants; blank-notification fallback eliminated (#160)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -8,6 +8,7 @@ import android.os.BatteryManager;
 import androidx.preference.PreferenceManager;
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
+import com.almothafar.simplebatterynotifier.service.AlertType;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.BatteryRateTracker;
 import com.almothafar.simplebatterynotifier.service.FastDrainDetector;
@@ -17,6 +18,7 @@ import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 /**
  * Broadcast receiver for monitoring battery level changes.
@@ -35,9 +37,6 @@ import static java.util.Objects.isNull;
  * serialized by the main looper.
  */
 public class BatteryLevelReceiver extends BroadcastReceiver {
-
-	/** "No alert sent" marker for {@code prevType}; the real types (1-3) live in NotificationService. */
-	static final int NO_ALERT = 0;
 
 	/**
 	 * How far (in °C) the battery must cool below the threshold before another high-temperature
@@ -67,7 +66,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	public static void onChargerDisconnected(final Context context) {
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 		final LevelAlertState state = loadLevelState(prefs);
-		final LevelAlertState reset = new LevelAlertState(state.prevLevel(), NO_ALERT, false);
+		final LevelAlertState reset = new LevelAlertState(state.prevLevel(), null, false);
 		if (!reset.equals(state)) {
 			saveLevelState(prefs, reset);
 		}
@@ -119,7 +118,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		if (!decision.newState().equals(previous)) {
 			saveLevelState(sharedPref, decision.newState());
 		}
-		if (decision.notifyType() != NO_ALERT) {
+		if (nonNull(decision.notifyType())) {
 			NotificationService.sendNotification(context, decision.notifyType());
 		}
 
@@ -177,7 +176,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * @param full       whether the battery status is {@code BATTERY_STATUS_FULL}
 	 * @param config     the user's alert thresholds and toggles
 	 *
-	 * @return which alert to send now ({@link #NO_ALERT} for none) and the new state to persist
+	 * @return which alert to send now ({@code null} for none) and the new state to persist
 	 */
 	static LevelAlertDecision decideLevelAlert(final LevelAlertState state, final int percentage,
 	                                           final boolean charging, final boolean full,
@@ -196,19 +195,19 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	private static LevelAlertDecision decideDischarging(final LevelAlertState state, final int percentage,
 	                                                    final LevelAlertConfig config) {
 		// Force the critical alert through the de-dupe at the red-alert floor: about to die trumps "already told you".
-		int prevType = percentage <= NotificationService.RED_ALERT_LEVEL ? NO_ALERT : state.prevType();
-		int notifyType = NO_ALERT;
+		AlertType prevType = percentage <= NotificationService.RED_ALERT_LEVEL ? null : state.prevType();
+		AlertType notifyType = null;
 
 		if (percentage <= config.criticalLevel()) {
-			if (prevType != NotificationService.CRITICAL_TYPE || config.alertEveryTick()) {
-				notifyType = NotificationService.CRITICAL_TYPE;
+			if (prevType != AlertType.CRITICAL || config.alertEveryTick()) {
+				notifyType = AlertType.CRITICAL;
 			}
-			prevType = NotificationService.CRITICAL_TYPE;
+			prevType = AlertType.CRITICAL;
 		} else if (percentage <= config.warningLevel() && config.warningEnabled()) {
-			if (prevType != NotificationService.WARNING_TYPE) {
-				notifyType = NotificationService.WARNING_TYPE;
+			if (prevType != AlertType.WARNING) {
+				notifyType = AlertType.WARNING;
 			}
-			prevType = NotificationService.WARNING_TYPE;
+			prevType = AlertType.WARNING;
 		}
 		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, prevType, state.fullNotified()));
 	}
@@ -220,10 +219,10 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	private static LevelAlertDecision decideChargingOrFull(final LevelAlertState state, final int percentage,
 	                                                       final boolean full, final LevelAlertConfig config) {
 		boolean fullNotified = state.fullNotified();
-		int notifyType = NO_ALERT;
+		AlertType notifyType = null;
 
 		if (!fullNotified && full && config.fullNotifyEnabled()) {
-			notifyType = NotificationService.FULL_LEVEL_TYPE;
+			notifyType = AlertType.FULL;
 			fullNotified = true;
 		}
 		if (percentage <= NotificationService.FULL_PERCENTAGE && percentage > config.warningLevel()) {
@@ -265,26 +264,28 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	static LevelAlertState loadLevelState(final SharedPreferences prefs) {
 		return new LevelAlertState(
 				prefs.getInt(PREF_PREV_LEVEL, 0),
-				prefs.getInt(PREF_PREV_TYPE, NO_ALERT),
+				AlertType.fromPersistedId(prefs.getInt(PREF_PREV_TYPE, 0)),
 				prefs.getBoolean(PREF_FULL_NOTIFIED, false));
 	}
 
 	static void saveLevelState(final SharedPreferences prefs, final LevelAlertState state) {
 		prefs.edit()
 		     .putInt(PREF_PREV_LEVEL, state.prevLevel())
-		     .putInt(PREF_PREV_TYPE, state.prevType())
+		     .putInt(PREF_PREV_TYPE, AlertType.persistedId(state.prevType()))
 		     .putBoolean(PREF_FULL_NOTIFIED, state.fullNotified())
 		     .apply();
 	}
 
 	/**
-	 * Persisted level-alert episode state (#164).
+	 * Persisted level-alert episode state (#164). The type is stored via its stable persisted id
+	 * (see {@link AlertType#persistedId}), so state written by older int-typed versions reads back
+	 * unchanged.
 	 *
 	 * @param prevLevel    the percentage seen on the previous broadcast (gates the discharge branch)
-	 * @param prevType     the last level alert sent while discharging ({@link #NO_ALERT} when none)
+	 * @param prevType     the last level alert sent while discharging ({@code null} when none)
 	 * @param fullNotified whether the full-battery alert has fired this charge session
 	 */
-	record LevelAlertState(int prevLevel, int prevType, boolean fullNotified) {
+	record LevelAlertState(int prevLevel, AlertType prevType, boolean fullNotified) {
 	}
 
 	/**
@@ -304,10 +305,10 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	/**
 	 * Result of {@link #decideLevelAlert}: which alert to send now, and the state to persist.
 	 *
-	 * @param notifyType a {@code NotificationService} type, or {@link #NO_ALERT} for none
+	 * @param notifyType the alert to send, or {@code null} for none
 	 * @param newState   the state to persist
 	 */
-	record LevelAlertDecision(int notifyType, LevelAlertState newState) {
+	record LevelAlertDecision(AlertType notifyType, LevelAlertState newState) {
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/AlertType.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/AlertType.java
@@ -1,0 +1,65 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import static java.util.Objects.isNull;
+
+/**
+ * The battery-level alert types (critical, warning, full).
+ * <p>
+ * Replaces the old {@code int} constants (1/2/3): with an enum the notification-config switch is
+ * exhaustive at compile time, so an invalid type — which used to fall into a default branch that
+ * posted a completely blank notification — can no longer be constructed (issue #160).
+ * <p>
+ * "No alert" is represented as {@code null}, not an enum member, so a "none" value can never reach
+ * {@link NotificationService#sendNotification}.
+ */
+public enum AlertType {
+	CRITICAL(1),
+	WARNING(2),
+	FULL(3);
+
+	// Stable id used when the type is persisted in SharedPreferences (the level-alert de-dupe state,
+	// #164). Matches the old int constants so existing installs' persisted state stays valid.
+	private final int persistedId;
+
+	AlertType(final int persistedId) {
+		this.persistedId = persistedId;
+	}
+
+	/**
+	 * The stable id to persist for this type. {@code 0} is reserved for "no alert" ({@code null}).
+	 *
+	 * @param type the type to persist, or null for "no alert"
+	 *
+	 * @return the id to store in SharedPreferences
+	 */
+	public static int persistedId(final AlertType type) {
+		return isNull(type) ? 0 : type.persistedId;
+	}
+
+	/**
+	 * The type a persisted id maps back to. The inverse of {@link #persistedId(AlertType)}.
+	 *
+	 * @param id the id read from SharedPreferences
+	 *
+	 * @return the matching type, or null for 0 ("no alert") and any unknown value
+	 */
+	public static AlertType fromPersistedId(final int id) {
+		for (final AlertType type : values()) {
+			if (type.persistedId == id) {
+				return type;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Whether this alert should alert (sound/vibrate/heads-up) every time it is posted. Only the
+	 * critical alert does — the others set {@code setOnlyAlertOnce} so a re-posted notification
+	 * updates quietly.
+	 *
+	 * @return true when every post of this type should alert the user again
+	 */
+	public boolean alertsEveryTime() {
+		return this == CRITICAL;
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -55,10 +55,6 @@ import static java.util.Objects.nonNull;
  * by calling {@link #shutdown()}.
  */
 public final class NotificationService {
-	// Notification types
-	public static final int CRITICAL_TYPE = 1;
-	public static final int WARNING_TYPE = 2;
-	public static final int FULL_LEVEL_TYPE = 3;
 	// Battery thresholds
 	public static final int RED_ALERT_LEVEL = 4;
 	public static final int FULL_PERCENTAGE = 95;
@@ -138,9 +134,13 @@ public final class NotificationService {
 	 * Send a battery status notification
 	 *
 	 * @param context The application context
-	 * @param type    Notification type (CRITICAL_TYPE, WARNING_TYPE, or FULL_LEVEL_TYPE)
+	 * @param type    Which battery-level alert to send
 	 */
-	public static void sendNotification(final Context context, final int type) {
+	public static void sendNotification(final Context context, final AlertType type) {
+		if (isNull(type)) {
+			Log.w(TAG, "No alert type given, notification not sent");
+			return;
+		}
 		if (lacksNotificationPermission(context)) {
 			Log.w(TAG, "Missing POST_NOTIFICATIONS permission, notification not sent");
 			return;
@@ -779,7 +779,7 @@ public final class NotificationService {
 		final String channelId = channelFor(context, config.alertsAllowed, config.channelId);
 		final Notification.Builder builder = new Notification.Builder(context, channelId).setSmallIcon(config.iconRes);
 
-		if (config.type != CRITICAL_TYPE) {
+		if (!config.type.alertsEveryTime()) {
 			builder.setOnlyAlertOnce(true);
 		}
 
@@ -1226,7 +1226,7 @@ public final class NotificationService {
 	 * extracted from SharedPreferences and notification type.
 	 */
 	private static class NotificationConfig {
-		final int type;
+		final AlertType type;
 		final String channelId;
 		final int iconRes;
 		final String ticker;
@@ -1244,9 +1244,9 @@ public final class NotificationService {
 		 *
 		 * @param context The application context
 		 * @param prefs   SharedPreferences containing user settings
-		 * @param type    Notification type (CRITICAL_TYPE, WARNING_TYPE, or FULL_LEVEL_TYPE)
+		 * @param type    Which battery-level alert to configure (non-null)
 		 */
-		NotificationConfig(final Context context, final SharedPreferences prefs, final int type) {
+		NotificationConfig(final Context context, final SharedPreferences prefs, final AlertType type) {
 			this.type = type;
 
 			// Load common preferences
@@ -1256,52 +1256,64 @@ public final class NotificationService {
 			this.stickyNotification = prefs.getBoolean(context.getString(R.string._pref_key_notifications_sticky), false);
 			final boolean withinWindow = isWithinNotificationWindow(context, prefs);
 			final boolean criticalIgnoresQuietHours = prefs.getBoolean(context.getString(R.string._pref_key_critical_ignore_quiet_hours), true);
-			this.alertsAllowed = alertsAllowedNow(withinWindow, type == CRITICAL_TYPE, criticalIgnoresQuietHours);
+			this.alertsAllowed = alertsAllowedNow(withinWindow, type == AlertType.CRITICAL, criticalIgnoresQuietHours);
 			this.ignoreSilent = shouldIgnoreSilentMode(context, prefs);
 			this.vibrate = isVibrationEnabled(context, prefs);
 
 			final String defaultSound = context.getString(R.string._default_notification_sound_uri);
 
-			// Configure based on notification type
-			switch (type) {
-				case CRITICAL_TYPE -> {
-					this.channelId = CHANNEL_ID_CRITICAL;
-					this.iconRes = R.drawable.ic_stat_device_battery_charging_20;
-					this.alarmSound = prefs.getString(context.getString(R.string._pref_key_notifications_alert_sound_ringtone), defaultSound);
-					this.ticker = context.getString(R.string.notification_critical_ticker, criticalLevel);
-					this.title = context.getString(R.string.notification_critical_title);
-					this.content = context.getString(R.string.notification_critical_content, criticalLevel);
-					this.bigContent = context.getString(R.string.notification_critical_content_big, criticalLevel);
-				}
-				case WARNING_TYPE -> {
-					this.channelId = CHANNEL_ID_WARNING;
-					this.iconRes = R.drawable.ic_stat_device_battery_charging_50;
-					this.alarmSound = prefs.getString(context.getString(R.string._pref_key_notifications_warning_sound_ringtone), defaultSound);
-					this.ticker = context.getString(R.string.notification_warning_ticker, warningLevel);
-					this.title = context.getString(R.string.notification_warning_title);
-					this.content = context.getString(R.string.notification_warning_content, warningLevel);
-					this.bigContent = context.getString(R.string.notification_warning_content_big, warningLevel);
-				}
-				case FULL_LEVEL_TYPE -> {
-					this.channelId = CHANNEL_ID_FULL;
-					this.iconRes = R.drawable.ic_stat_device_battery_charging_full;
-					this.alarmSound = prefs.getString(context.getString(R.string._pref_key_notifications_full_sound_ringtone), defaultSound);
-					this.ticker = context.getString(R.string.notification_full_level_ticker);
-					this.title = context.getString(R.string.notification_full_level_title);
-					this.content = context.getString(R.string.notification_full_level_content);
-					this.bigContent = context.getString(R.string.notification_full_level_content_big);
-				}
-				default -> {
-					// Fallback to FULL_LEVEL_TYPE configuration
-					this.channelId = CHANNEL_ID_FULL;
-					this.iconRes = R.drawable.ic_stat_device_battery_charging_full;
-					this.alarmSound = defaultSound;
-					this.ticker = "";
-					this.title = "";
-					this.content = "";
-					this.bigContent = "";
-				}
-			}
+			// A switch EXPRESSION over the enum is exhaustive at compile time — the old int switch
+			// needed a default branch, which posted a completely blank notification on any invalid
+			// type value (issue #160). That branch can no longer exist.
+			final AlertStyle style = switch (type) {
+				case CRITICAL -> new AlertStyle(
+						CHANNEL_ID_CRITICAL,
+						R.drawable.ic_stat_device_battery_charging_20,
+						prefs.getString(context.getString(R.string._pref_key_notifications_alert_sound_ringtone), defaultSound),
+						context.getString(R.string.notification_critical_ticker, criticalLevel),
+						context.getString(R.string.notification_critical_title),
+						context.getString(R.string.notification_critical_content, criticalLevel),
+						context.getString(R.string.notification_critical_content_big, criticalLevel));
+				case WARNING -> new AlertStyle(
+						CHANNEL_ID_WARNING,
+						R.drawable.ic_stat_device_battery_charging_50,
+						prefs.getString(context.getString(R.string._pref_key_notifications_warning_sound_ringtone), defaultSound),
+						context.getString(R.string.notification_warning_ticker, warningLevel),
+						context.getString(R.string.notification_warning_title),
+						context.getString(R.string.notification_warning_content, warningLevel),
+						context.getString(R.string.notification_warning_content_big, warningLevel));
+				case FULL -> new AlertStyle(
+						CHANNEL_ID_FULL,
+						R.drawable.ic_stat_device_battery_charging_full,
+						prefs.getString(context.getString(R.string._pref_key_notifications_full_sound_ringtone), defaultSound),
+						context.getString(R.string.notification_full_level_ticker),
+						context.getString(R.string.notification_full_level_title),
+						context.getString(R.string.notification_full_level_content),
+						context.getString(R.string.notification_full_level_content_big));
+			};
+			this.channelId = style.channelId();
+			this.iconRes = style.iconRes();
+			this.alarmSound = style.alarmSound();
+			this.ticker = style.ticker();
+			this.title = style.title();
+			this.content = style.content();
+			this.bigContent = style.bigContent();
 		}
+	}
+
+	/**
+	 * The per-type presentation of a battery-level alert, produced by the exhaustive type switch in
+	 * {@link NotificationConfig} (#160).
+	 *
+	 * @param channelId  the audible base channel ID for this type
+	 * @param iconRes    the small-icon resource
+	 * @param alarmSound the user's chosen alarm sound for this type
+	 * @param ticker     the ticker text
+	 * @param title      the notification title
+	 * @param content    the collapsed content line
+	 * @param bigContent the expanded (BigTextStyle) content
+	 */
+	private record AlertStyle(String channelId, int iconRes, String alarmSound, String ticker,
+	                          String title, String content, String bigContent) {
 	}
 }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
@@ -4,13 +4,14 @@ import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelA
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertDecision;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertState;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.TemperatureDecision;
+import com.almothafar.simplebatterynotifier.service.AlertType;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
 
 import org.junit.Test;
 
-import static com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.NO_ALERT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -27,7 +28,7 @@ public class BatteryLevelReceiverDecisionTest {
 	private static final int THRESHOLD_C = 45;
 
 	private static final LevelAlertConfig DEFAULTS = new LevelAlertConfig(CRITICAL, WARNING, true, true, false);
-	private static final LevelAlertState FRESH = new LevelAlertState(0, NO_ALERT, false);
+	private static final LevelAlertState FRESH = new LevelAlertState(0, null, false);
 
 	private static final boolean DISCHARGING = false;
 	private static final boolean NOT_FULL = false;
@@ -37,36 +38,36 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void discharging_belowCritical_firesCriticalOnce() {
 		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(16, NO_ALERT, false), 15, DISCHARGING, NOT_FULL, DEFAULTS);
+				new LevelAlertState(16, null, false), 15, DISCHARGING, NOT_FULL, DEFAULTS);
 
-		assertEquals(NotificationService.CRITICAL_TYPE, first.notifyType());
-		assertEquals(new LevelAlertState(15, NotificationService.CRITICAL_TYPE, false), first.newState());
+		assertEquals(AlertType.CRITICAL, first.notifyType());
+		assertEquals(new LevelAlertState(15, AlertType.CRITICAL, false), first.newState());
 
 		// Next tick, still below critical: the persisted prevType suppresses the duplicate.
 		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
 				first.newState(), 14, DISCHARGING, NOT_FULL, DEFAULTS);
-		assertEquals(NO_ALERT, second.notifyType());
+		assertNull(second.notifyType());
 		assertEquals(14, second.newState().prevLevel());
 	}
 
 	@Test
 	public void discharging_inWarningBand_firesWarningOnce() {
 		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(41, NO_ALERT, false), 38, DISCHARGING, NOT_FULL, DEFAULTS);
+				new LevelAlertState(41, null, false), 38, DISCHARGING, NOT_FULL, DEFAULTS);
 
-		assertEquals(NotificationService.WARNING_TYPE, first.notifyType());
+		assertEquals(AlertType.WARNING, first.notifyType());
 
 		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
 				first.newState(), 35, DISCHARGING, NOT_FULL, DEFAULTS);
-		assertEquals(NO_ALERT, second.notifyType());
+		assertNull(second.notifyType());
 	}
 
 	@Test
 	public void discharging_aboveWarning_noAlert() {
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(81, NO_ALERT, false), 80, DISCHARGING, NOT_FULL, DEFAULTS);
+				new LevelAlertState(81, null, false), 80, DISCHARGING, NOT_FULL, DEFAULTS);
 
-		assertEquals(NO_ALERT, d.notifyType());
+		assertNull(d.notifyType());
 		assertEquals(80, d.newState().prevLevel());
 	}
 
@@ -74,38 +75,38 @@ public class BatteryLevelReceiverDecisionTest {
 	public void discharging_warningDisabled_staysSilentInWarningBand() {
 		final LevelAlertConfig noWarning = new LevelAlertConfig(CRITICAL, WARNING, false, true, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(41, NO_ALERT, false), 38, DISCHARGING, NOT_FULL, noWarning);
+				new LevelAlertState(41, null, false), 38, DISCHARGING, NOT_FULL, noWarning);
 
-		assertEquals(NO_ALERT, d.notifyType());
+		assertNull(d.notifyType());
 	}
 
 	@Test
 	public void discharging_warningThenCritical_escalates() {
-		final LevelAlertState afterWarning = new LevelAlertState(35, NotificationService.WARNING_TYPE, false);
+		final LevelAlertState afterWarning = new LevelAlertState(35, AlertType.WARNING, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
 				afterWarning, 20, DISCHARGING, NOT_FULL, DEFAULTS);
 
-		assertEquals(NotificationService.CRITICAL_TYPE, d.notifyType());
+		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
 
 	@Test
 	public void discharging_alertEveryTick_repeatsCritical() {
 		final LevelAlertConfig everyTick = new LevelAlertConfig(CRITICAL, WARNING, true, true, true);
-		final LevelAlertState alreadyCritical = new LevelAlertState(15, NotificationService.CRITICAL_TYPE, false);
+		final LevelAlertState alreadyCritical = new LevelAlertState(15, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
 				alreadyCritical, 14, DISCHARGING, NOT_FULL, everyTick);
 
-		assertEquals(NotificationService.CRITICAL_TYPE, d.notifyType());
+		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
 
 	@Test
 	public void discharging_atRedAlertFloor_overridesDeDupe() {
 		// Already alerted critical this episode, but at/below the red-alert level it must re-fire.
-		final LevelAlertState alreadyCritical = new LevelAlertState(5, NotificationService.CRITICAL_TYPE, false);
+		final LevelAlertState alreadyCritical = new LevelAlertState(5, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
 				alreadyCritical, NotificationService.RED_ALERT_LEVEL, DISCHARGING, NOT_FULL, DEFAULTS);
 
-		assertEquals(NotificationService.CRITICAL_TYPE, d.notifyType());
+		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
 
 	@Test
@@ -113,49 +114,49 @@ public class BatteryLevelReceiverDecisionTest {
 		// Same level as last tick routes to the charging-or-full branch (the receiver's historical
 		// split), so a repeated broadcast at the same percentage can't duplicate a level alert.
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(15, NotificationService.CRITICAL_TYPE, false), 15, DISCHARGING, NOT_FULL, DEFAULTS);
+				new LevelAlertState(15, AlertType.CRITICAL, false), 15, DISCHARGING, NOT_FULL, DEFAULTS);
 
-		assertEquals(NO_ALERT, d.notifyType());
+		assertNull(d.notifyType());
 	}
 
 	// --- charging / full: once per charge session ------------------------------------------------
 
 	@Test
 	public void charging_full_firesOnceThenHolds() {
-		final LevelAlertState atHundred = new LevelAlertState(100, NO_ALERT, false);
+		final LevelAlertState atHundred = new LevelAlertState(100, null, false);
 		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(atHundred, 100, false, true, DEFAULTS);
 
-		assertEquals(NotificationService.FULL_LEVEL_TYPE, first.notifyType());
+		assertEquals(AlertType.FULL, first.notifyType());
 		assertTrue(first.newState().fullNotified());
 
 		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(first.newState(), 100, false, true, DEFAULTS);
-		assertEquals(NO_ALERT, second.notifyType());
+		assertNull(second.notifyType());
 	}
 
 	@Test
 	public void charging_fullDisabled_staysSilent() {
 		final LevelAlertConfig noFull = new LevelAlertConfig(CRITICAL, WARNING, true, false, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(100, NO_ALERT, false), 100, false, true, noFull);
+				new LevelAlertState(100, null, false), 100, false, true, noFull);
 
-		assertEquals(NO_ALERT, d.notifyType());
+		assertNull(d.notifyType());
 		assertFalse(d.newState().fullNotified());
 	}
 
 	@Test
 	public void charging_levelLeavesFullBand_reArmsFullAlert() {
 		// Notified at full, then the level drops to 90 (≤ FULL_PERCENTAGE, above warning): re-armed.
-		final LevelAlertState notified = new LevelAlertState(100, NO_ALERT, true);
+		final LevelAlertState notified = new LevelAlertState(100, null, true);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(notified, 90, true, NOT_FULL, DEFAULTS);
 
-		assertEquals(NO_ALERT, d.notifyType());
+		assertNull(d.notifyType());
 		assertFalse(d.newState().fullNotified());
 	}
 
 	@Test
 	public void charging_belowWarningBand_doesNotReArmFullAlert() {
 		// The re-arm band is (warning, FULL_PERCENTAGE]: charging low keeps the flag as-is.
-		final LevelAlertState notified = new LevelAlertState(100, NO_ALERT, true);
+		final LevelAlertState notified = new LevelAlertState(100, null, true);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(notified, 30, true, NOT_FULL, DEFAULTS);
 
 		assertTrue(d.newState().fullNotified());
@@ -167,11 +168,11 @@ public class BatteryLevelReceiverDecisionTest {
 	public void restartMidEpisode_persistedStateSuppressesDuplicates() {
 		// Process death loses nothing: the decision on the persisted state after a "restart" is the
 		// same as it would have been in-process — no duplicate critical while still below threshold.
-		final LevelAlertState persisted = new LevelAlertState(15, NotificationService.CRITICAL_TYPE, false);
+		final LevelAlertState persisted = new LevelAlertState(15, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
 				persisted, 13, DISCHARGING, NOT_FULL, DEFAULTS);
 
-		assertEquals(NO_ALERT, d.notifyType());
+		assertNull(d.notifyType());
 	}
 
 	// --- temperature hysteresis -------------------------------------------------------------------

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
@@ -8,6 +8,7 @@ import androidx.preference.PreferenceManager;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertState;
+import com.almothafar.simplebatterynotifier.service.AlertType;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 
@@ -57,7 +58,7 @@ public class BatteryLevelReceiverTest {
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.CRITICAL_TYPE)));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL)));
 		}
 	}
 
@@ -67,7 +68,7 @@ public class BatteryLevelReceiverTest {
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.WARNING_TYPE)));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING)));
 		}
 	}
 
@@ -77,8 +78,8 @@ public class BatteryLevelReceiverTest {
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.WARNING_TYPE)), never());
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.CRITICAL_TYPE)), never());
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING)), never());
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL)), never());
 		}
 	}
 
@@ -91,7 +92,7 @@ public class BatteryLevelReceiverTest {
 			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 35, 100, 0);
 			receive();
 
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.WARNING_TYPE)), times(1));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING)), times(1));
 		}
 	}
 
@@ -105,26 +106,26 @@ public class BatteryLevelReceiverTest {
 			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 14, 100, 0);
 			receive();
 
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.CRITICAL_TYPE)), times(2));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL)), times(2));
 		}
 	}
 
 	@Test
 	public void full_whileCharging_sendsFullAlertOnce() {
 		// Simulate the battery already sitting at 100% (unchanged) so the charging/full branch runs
-		saveLevelState(new LevelAlertState(100, BatteryLevelReceiver.NO_ALERT, false));
+		saveLevelState(new LevelAlertState(100, null, false));
 		publishBattery(BatteryManager.BATTERY_STATUS_FULL, 100, 100, BatteryManager.BATTERY_PLUGGED_AC);
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
 			receive(); // second identical tick must not re-send
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.FULL_LEVEL_TYPE)), times(1));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL)), times(1));
 		}
 	}
 
 	@Test
 	public void unplug_reArmsFullAlert_forNextChargeSession() {
-		saveLevelState(new LevelAlertState(100, BatteryLevelReceiver.NO_ALERT, false));
+		saveLevelState(new LevelAlertState(100, null, false));
 		publishBattery(BatteryManager.BATTERY_STATUS_FULL, 100, 100, BatteryManager.BATTERY_PLUGGED_AC);
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
@@ -133,7 +134,7 @@ public class BatteryLevelReceiverTest {
 			BatteryLevelReceiver.onChargerDisconnected(context);
 			receive();
 
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(NotificationService.FULL_LEVEL_TYPE)), times(2));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL)), times(2));
 		}
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/AlertTypeTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/AlertTypeTest.java
@@ -1,0 +1,46 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link AlertType} (issue #160). The persisted ids are a compatibility contract:
+ * the level-alert de-dupe state (#164) was written by older app versions as the int constants
+ * 1/2/3 (0 = none), so the mapping must stay exactly that — otherwise an upgrade would misread an
+ * in-progress alert episode.
+ */
+public class AlertTypeTest {
+
+	@Test
+	public void persistedIds_keepTheLegacyIntValues() {
+		assertEquals(1, AlertType.persistedId(AlertType.CRITICAL));
+		assertEquals(2, AlertType.persistedId(AlertType.WARNING));
+		assertEquals(3, AlertType.persistedId(AlertType.FULL));
+		assertEquals(0, AlertType.persistedId(null));
+	}
+
+	@Test
+	public void fromPersistedId_roundTripsEveryType() {
+		for (final AlertType type : AlertType.values()) {
+			assertEquals(type, AlertType.fromPersistedId(AlertType.persistedId(type)));
+		}
+	}
+
+	@Test
+	public void fromPersistedId_zeroAndUnknownReadAsNone() {
+		assertNull(AlertType.fromPersistedId(0));
+		assertNull(AlertType.fromPersistedId(-1));
+		assertNull(AlertType.fromPersistedId(99));
+	}
+
+	@Test
+	public void onlyCriticalAlertsEveryTime() {
+		assertTrue(AlertType.CRITICAL.alertsEveryTime());
+		assertFalse(AlertType.WARNING.alertsEveryTime());
+		assertFalse(AlertType.FULL.alertsEveryTime());
+	}
+}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
@@ -201,7 +201,7 @@ public class NotificationServiceTest {
 
 		@Test
 		public void chargeNotification_doesNotReplaceLevelAlert() {
-			NotificationService.sendNotification(context, NotificationService.CRITICAL_TYPE);
+			NotificationService.sendNotification(context, AlertType.CRITICAL);
 			NotificationService.notifyChargeConnected(context, ChargeSpeed.unknown(), false);
 
 			// Distinct IDs: both must be showing, not "Charging started" swallowing the critical alert.
@@ -210,7 +210,7 @@ public class NotificationServiceTest {
 
 		@Test
 		public void clearNotifications_onDisconnect_removesLevelAlertAndChargeNotification() {
-			NotificationService.sendNotification(context, NotificationService.CRITICAL_TYPE);
+			NotificationService.sendNotification(context, AlertType.CRITICAL);
 			NotificationService.notifyChargeConnected(context, ChargeSpeed.unknown(), false);
 
 			NotificationService.clearNotifications(context);
@@ -221,13 +221,22 @@ public class NotificationServiceTest {
 
 		@Test
 		public void clearLevelAlert_dismissesOnlyTheLevelAlert() {
-			NotificationService.sendNotification(context, NotificationService.CRITICAL_TYPE);
+			NotificationService.sendNotification(context, AlertType.CRITICAL);
 			NotificationService.notifyChargeConnected(context, ChargeSpeed.unknown(), false);
 
 			NotificationService.clearLevelAlert(context);
 
 			// The plug-in dismissal targets the level alert; "Charging started" keeps showing.
 			assertEquals(1, shadowOf(manager).size());
+		}
+
+		@Test
+		public void nullAlertType_postsNothing() {
+			// The old int API's default branch posted a completely BLANK notification for an invalid
+			// type (#160). With the enum, the only invalid value left is null — and it must be a no-op.
+			NotificationService.sendNotification(context, null);
+
+			assertEquals(0, shadowOf(manager).size());
 		}
 	}
 


### PR DESCRIPTION
## What

`sendNotification` took an `int` type, and the `NotificationConfig` switch''s `default` branch — despite its "Fallback to FULL_LEVEL_TYPE configuration" comment — set empty ticker/title/content, so any invalid type posted a **blank notification** on the full-battery channel.

- New `AlertType` enum (`CRITICAL`, `WARNING`, `FULL`); "no alert" is `null`, deliberately not an enum member, so a "none" value can never reach the sender.
- The per-type config is now built by an exhaustive **switch expression** (producing a small `AlertStyle` record) — the impossible `default` branch is gone at compile time. A `null` type passed to `sendNotification` is a logged no-op.
- The `type != CRITICAL_TYPE` special case in the builder reads as `!type.alertsEveryTime()`; the quiet-hours critical override reads as `type == AlertType.CRITICAL`.
- `BatteryLevelReceiver`''s dedupe state (`prevType`, the `LevelAlertDecision`) holds the enum; `NO_ALERT = 0` magic removed. **Persisted-state compatibility (#164):** the type is stored via stable ids matching the old int constants (1/2/3, 0 = none), so an in-progress alert episode written by an older version reads back unchanged.
- `RED_ALERT_LEVEL` / `FULL_PERCENTAGE` untouched.

## Tests

- New `AlertTypeTest`: persisted ids pinned to the legacy 1/2/3 values, round-trip through `fromPersistedId`, unknown/0 → none, `alertsEveryTime` only for critical.
- New `nullAlertType_postsNothing` (Robolectric): the last representable invalid input posts nothing.
- Existing dedupe/decision tests (`BatteryLevelReceiverDecisionTest`, `BatteryLevelReceiverTest`) converted to the enum — behavior assertions unchanged, all green.
- `testDebugUnitTest` + `lintDebug` green; debug build installed on the Mate 10 Pro.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)