### PR TITLE
Extract SustainedConditionTracker: FastDrain / SlowCharge share one sustained-condition engine (#163)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
@@ -7,6 +7,9 @@ import androidx.preference.PreferenceManager;
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.service.BatteryRateTracker.BatteryRate;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Outcome;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Streak;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.StreakStore;
 
 import static java.util.Objects.isNull;
 
@@ -28,11 +31,15 @@ import static java.util.Objects.isNull;
  */
 public final class FastDrainDetector {
 
-	// Persisted streak/hysteresis state (survives process restarts).
+	// Persisted streak/hysteresis state (survives process restarts). Keys unchanged from before the
+	// shared-core extraction (#163) so no in-progress episode is lost on upgrade.
 	private static final String PREF_STREAK_START = "_fast_drain_streak_start";
 	private static final String PREF_ALERTED = "_fast_drain_alerted";
 	private static final String PREF_LAST_REMINDER = "_fast_drain_last_reminder";
 	private static final String PREF_LAST_SEEN_ABOVE = "_fast_drain_last_seen_above";
+
+	private static final StreakStore STORE =
+			new StreakStore(PREF_STREAK_START, PREF_ALERTED, PREF_LAST_SEEN_ABOVE, PREF_LAST_REMINDER);
 
 	// Defaults and accepted ranges (user-tunable), matching the settings XML min/max — enforced when the
 	// preferences are read, so a corrupt/out-of-range value can't turn this into a spike alarm.
@@ -43,15 +50,7 @@ public final class FastDrainDetector {
 	static final int MIN_REMINDER_MINUTES = 5;
 	static final int MAX_REMINDER_MINUTES = 60;
 
-	// How long the streak survives without a fresh above-limit observation. The rate itself is smoothed
-	// over BatteryRateTracker.WINDOW_MS, so continuity beyond that window is unknowable — after a longer
-	// gap (process death, doze, unusable rate) the "sustained" claim has lapsed and the episode restarts,
-	// rather than instantly alerting with a wildly inflated "for the last N minutes".
-	static final long MAX_OBSERVATION_GAP_MS = BatteryRateTracker.WINDOW_MS;
-
 	private static final long MS_PER_MINUTE = 60_000L;
-
-	private static final FastDrainState CLEARED = new FastDrainState(0, false, 0, 0);
 
 	private FastDrainDetector() {
 		// Utility class - prevent instantiation
@@ -77,7 +76,7 @@ public final class FastDrainDetector {
 		// Only while discharging, and only when enabled. Either way the episode is re-armed (charging, or
 		// the feature being off, ends any streak) so a later fast discharge starts fresh.
 		if (!enabled || !discharging) {
-			clearState(prefs);
+			STORE.clear(prefs);
 			return;
 		}
 
@@ -89,15 +88,11 @@ public final class FastDrainDetector {
 		final boolean activelyUsed = SystemService.isActivelyUsed(context);
 		final long now = System.currentTimeMillis();
 
-		final FastDrainState previous = loadState(prefs);
-		final FastDrainDecision decision = decide(previous, rate.hasRate(), rate.percentPerHour(),
+		final Streak previous = STORE.load(prefs);
+		final Outcome decision = decide(previous, rate.hasRate(), rate.percentPerHour(),
 				limit, sustainedMs, reminderGapMs, activelyUsed, now);
 
-		// Persist only on change: the common case (discharging below the limit) re-decides CLEARED on
-		// every broadcast, and rewriting identical state would churn SharedPreferences for nothing.
-		if (!decision.newState().equals(previous)) {
-			saveState(prefs, decision.newState());
-		}
+		STORE.saveIfChanged(prefs, decision.newState());
 		if (decision.shouldNotify()) {
 			final int elapsedMinutes = Math.max(1, Math.round(decision.elapsedMs() / (float) MS_PER_MINUTE));
 			NotificationService.sendFastDrainNotification(context, rate.percentPerHour(), limit, elapsedMinutes);
@@ -105,22 +100,14 @@ public final class FastDrainDetector {
 	}
 
 	/**
-	 * Pure decision core, unit-testable with no Android dependencies.
-	 * <ul>
-	 *   <li><b>Rate unavailable</b> (#108 can't produce a %/h yet — warm-up, or an unsupported device):
-	 *       the alert <em>sleeps</em>. No notification, and the streak is left intact so a brief data gap
-	 *       doesn't reset it. Fail-quiet = no false alarms. Continuity is bounded, though: if the rate
-	 *       hasn't been observed at/above the limit for {@link #MAX_OBSERVATION_GAP_MS}, the streak has
-	 *       lapsed and the next above-limit reading starts a fresh episode instead of instantly alerting
-	 *       with a duration built on unobserved time.</li>
-	 *   <li><b>Rate below the limit</b>: the drain has calmed → re-arm the episode (clear the streak and
-	 *       the alerted flag), so a later flare-up warns again (hysteresis).</li>
-	 *   <li><b>Rate at/above the limit</b>: start the streak if new; once it has been sustained for the
-	 *       window, fire the first alert (regardless of screen state — warn at least once). After that,
-	 *       stay silent while actively used, but remind every {@code reminderGap} while off/locked.</li>
-	 * </ul>
+	 * The fast-drain decision as a pure function of the drain rate, delegating the streak/lapse/hysteresis
+	 * mechanics to {@link SustainedConditionTracker} (#163). The condition is "rate at/above the limit";
+	 * the repeat policy is {@link SustainedConditionTracker#withReminders} — the first alert fires
+	 * regardless of screen state, then reminders repeat only while the screen is off/locked (background
+	 * drain the user can't see). Kept as a rate-oriented method so the behaviour contract stays unit-tested
+	 * against the domain inputs.
 	 *
-	 * @param state         current persisted state
+	 * @param state         current persisted streak
 	 * @param rateAvailable whether #108 produced a trustworthy %/h this tick
 	 * @param ratePph       the drain rate magnitude in %/h (valid when {@code rateAvailable})
 	 * @param limitPph      the user's high-drain limit in %/h
@@ -129,41 +116,13 @@ public final class FastDrainDetector {
 	 * @param activelyUsed  whether the screen is on and unlocked right now
 	 * @param nowMillis     current time in millis
 	 *
-	 * @return the notify flag, the new state to persist, and the streak's elapsed time (for the message)
+	 * @return the notify flag, the new streak to persist, and the streak's elapsed time (for the message)
 	 */
-	static FastDrainDecision decide(final FastDrainState state, final boolean rateAvailable, final int ratePph,
-	                                final int limitPph, final long sustainedMs, final long reminderGapMs,
-	                                final boolean activelyUsed, final long nowMillis) {
-		if (!rateAvailable) {
-			return new FastDrainDecision(false, state, 0); // sleep — keep the streak, don't fire
-		}
-		if (ratePph < limitPph) {
-			return new FastDrainDecision(false, CLEARED, 0); // calmed — re-arm the episode
-		}
-
-		// Continuity: the sleep above keeps the streak through a brief data gap, but after a long one
-		// (process death, doze) the "sustained" claim has lapsed — start a fresh episode instead of
-		// alerting immediately with an inflated duration built on unobserved time.
-		final boolean lapsed = state.streakStart() != 0
-				&& nowMillis - state.lastSeenAbove() > MAX_OBSERVATION_GAP_MS;
-
-		final long start = (state.streakStart() == 0 || lapsed) ? nowMillis : state.streakStart();
-		final long elapsed = nowMillis - start;
-		boolean alerted = !lapsed && state.alerted();
-		long lastReminder = lapsed ? 0 : state.lastReminder();
-		boolean notify = false;
-
-		if (elapsed >= sustainedMs) {
-			if (!alerted) {
-				notify = true;          // first alert this episode, regardless of screen state
-				alerted = true;
-				lastReminder = nowMillis;
-			} else if (!activelyUsed && nowMillis - lastReminder >= reminderGapMs) {
-				notify = true;          // background drain the user can't see — remind on the gap
-				lastReminder = nowMillis;
-			}
-		}
-		return new FastDrainDecision(notify, new FastDrainState(start, alerted, lastReminder, nowMillis), elapsed);
+	static Outcome decide(final Streak state, final boolean rateAvailable, final int ratePph,
+	                      final int limitPph, final long sustainedMs, final long reminderGapMs,
+	                      final boolean activelyUsed, final long nowMillis) {
+		return SustainedConditionTracker.decide(state, rateAvailable, ratePph >= limitPph,
+				sustainedMs, nowMillis, SustainedConditionTracker.withReminders(activelyUsed, reminderGapMs));
 	}
 
 	private static long minutesPref(final SharedPreferences prefs, final Context context, final int keyRes,
@@ -185,57 +144,5 @@ public final class FastDrainDetector {
 	 */
 	static long clampMinutesToMs(final int storedMinutes, final int minMinutes, final int maxMinutes) {
 		return Math.max(minMinutes, Math.min(maxMinutes, storedMinutes)) * MS_PER_MINUTE;
-	}
-
-	private static FastDrainState loadState(final SharedPreferences prefs) {
-		return new FastDrainState(
-				prefs.getLong(PREF_STREAK_START, 0),
-				prefs.getBoolean(PREF_ALERTED, false),
-				prefs.getLong(PREF_LAST_REMINDER, 0),
-				prefs.getLong(PREF_LAST_SEEN_ABOVE, 0));
-	}
-
-	private static void saveState(final SharedPreferences prefs, final FastDrainState state) {
-		prefs.edit()
-		     .putLong(PREF_STREAK_START, state.streakStart())
-		     .putBoolean(PREF_ALERTED, state.alerted())
-		     .putLong(PREF_LAST_REMINDER, state.lastReminder())
-		     .putLong(PREF_LAST_SEEN_ABOVE, state.lastSeenAbove())
-		     .apply();
-	}
-
-	/**
-	 * Clears the streak only when it isn't already clear, so charging/disabled broadcasts don't churn
-	 * SharedPreferences on every tick.
-	 *
-	 * @param prefs the shared preferences
-	 */
-	private static void clearState(final SharedPreferences prefs) {
-		if (!loadState(prefs).equals(CLEARED)) {
-			saveState(prefs, CLEARED);
-		}
-	}
-
-	/**
-	 * Persisted streak/hysteresis state.
-	 *
-	 * @param streakStart   when the rate first reached the limit this episode (0 = no active streak)
-	 * @param alerted       whether the first alert has fired this episode
-	 * @param lastReminder  when the last (re)notification was sent
-	 * @param lastSeenAbove when the rate was last observed at/above the limit; a gap longer than
-	 *                      {@link #MAX_OBSERVATION_GAP_MS} lapses the streak (continuity unknowable)
-	 */
-	record FastDrainState(long streakStart, boolean alerted, long lastReminder, long lastSeenAbove) {
-	}
-
-	/**
-	 * Result of {@link #decide}: whether to (re)notify, the new state to persist, and the streak's
-	 * elapsed time (for the "for the last N minutes" message).
-	 *
-	 * @param shouldNotify whether to send a notification now
-	 * @param newState     the state to persist
-	 * @param elapsedMs    the streak's elapsed time in millis
-	 */
-	record FastDrainDecision(boolean shouldNotify, FastDrainState newState, long elapsedMs) {
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
@@ -65,7 +65,7 @@ public final class FastDrainDetector {
 	 * @param batteryDO Current battery snapshot (may be null)
 	 * @param rate      The rate just computed by {@link BatteryRateTracker#record}
 	 */
-	public static void evaluate(final Context context, final BatteryDO batteryDO, final BatteryRate rate) {
+	public static void evaluate(Context context, BatteryDO batteryDO, BatteryRate rate) {
 		if (isNull(context) || isNull(batteryDO)) {
 			return;
 		}
@@ -118,15 +118,26 @@ public final class FastDrainDetector {
 	 *
 	 * @return the notify flag, the new streak to persist, and the streak's elapsed time (for the message)
 	 */
-	static Outcome decide(final Streak state, final boolean rateAvailable, final int ratePph,
-	                      final int limitPph, final long sustainedMs, final long reminderGapMs,
-	                      final boolean activelyUsed, final long nowMillis) {
-		return SustainedConditionTracker.decide(state, rateAvailable, ratePph >= limitPph,
-				sustainedMs, nowMillis, SustainedConditionTracker.withReminders(activelyUsed, reminderGapMs));
+	static Outcome decide(Streak state,
+	                      boolean rateAvailable,
+	                      int ratePph,
+	                      int limitPph,
+	                      long sustainedMs,
+	                      long reminderGapMs,
+	                      boolean activelyUsed,
+	                      long nowMillis) {
+		final boolean conditionActive = ratePph >= limitPph;
+		final SustainedConditionTracker.RepeatPolicy policy =
+				SustainedConditionTracker.withReminders(activelyUsed, reminderGapMs);
+		return SustainedConditionTracker.decide(state, rateAvailable, conditionActive, sustainedMs, nowMillis, policy);
 	}
 
-	private static long minutesPref(final SharedPreferences prefs, final Context context, final int keyRes,
-	                                final int defaultMinutes, final int minMinutes, final int maxMinutes) {
+	private static long minutesPref(SharedPreferences prefs,
+	                                Context context,
+	                                int keyRes,
+	                                int defaultMinutes,
+	                                int minMinutes,
+	                                int maxMinutes) {
 		return clampMinutesToMs(prefs.getInt(context.getString(keyRes), defaultMinutes), minMinutes, maxMinutes);
 	}
 
@@ -142,7 +153,7 @@ public final class FastDrainDetector {
 	 *
 	 * @return the clamped duration in milliseconds
 	 */
-	static long clampMinutesToMs(final int storedMinutes, final int minMinutes, final int maxMinutes) {
+	static long clampMinutesToMs(int storedMinutes, int minMinutes, int maxMinutes) {
 		return Math.max(minMinutes, Math.min(maxMinutes, storedMinutes)) * MS_PER_MINUTE;
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
@@ -75,7 +75,7 @@ public final class SlowChargeDetector {
 	 * @param context   Application context
 	 * @param batteryDO Current battery snapshot (may be null)
 	 */
-	public static void evaluate(final Context context, final BatteryDO batteryDO) {
+	public static void evaluate(Context context, BatteryDO batteryDO) {
 		if (isNull(context) || isNull(batteryDO)) {
 			return;
 		}
@@ -129,9 +129,14 @@ public final class SlowChargeDetector {
 	 *
 	 * @return whether to warn now, the new streak to persist, and the streak's elapsed time
 	 */
-	static Outcome decide(final Streak state, final boolean powerKnown, final int milliwatts,
-	                      final int floorMw, final long sustainedMs, final long nowMillis) {
-		return SustainedConditionTracker.decide(state, powerKnown, milliwatts < floorMw,
-				sustainedMs, nowMillis, SustainedConditionTracker.fireOnce());
+	static Outcome decide(Streak state,
+	                      boolean powerKnown,
+	                      int milliwatts,
+	                      int floorMw,
+	                      long sustainedMs,
+	                      long nowMillis) {
+		final boolean conditionActive = milliwatts < floorMw;
+		return SustainedConditionTracker.decide(state, powerKnown, conditionActive, sustainedMs, nowMillis,
+				SustainedConditionTracker.fireOnce());
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
@@ -8,6 +8,9 @@ import androidx.preference.PreferenceManager;
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.model.ChargeSpeed;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Outcome;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Streak;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.StreakStore;
 
 import static java.util.Objects.isNull;
 
@@ -39,10 +42,15 @@ import static java.util.Objects.isNull;
  */
 public final class SlowChargeDetector {
 
-	// Persisted streak/hysteresis state (survives process restarts).
+	// Persisted streak/hysteresis state (survives process restarts). Keys unchanged from before the
+	// shared-core extraction (#163) so no in-progress episode is lost on upgrade.
 	private static final String PREF_STREAK_START = "_slow_charge_streak_start";
 	private static final String PREF_ALERTED = "_slow_charge_alerted";
 	private static final String PREF_LAST_SEEN_BELOW = "_slow_charge_last_seen_below";
+
+	// No reminder concept: slow charge warns once per session (three-arg store, no reminder key).
+	private static final StreakStore STORE =
+			new StreakStore(PREF_STREAK_START, PREF_ALERTED, PREF_LAST_SEEN_BELOW);
 
 	// Trickle floor: sustained wired power below this while charging low is the damaged-cable signal. It
 	// sits below the weakest legitimate charger (a 5 W cube at 5 W is fine), so genuine chargers never trip
@@ -53,13 +61,6 @@ public final class SlowChargeDetector {
 	// How long the power must stay below the floor before warning. A constant in v1 (not user-tunable, per
 	// the issue): long enough that a brief post-plug dip or a single noisy reading can't trip it.
 	static final long SUSTAINED_MS = 3L * 60 * 1000;
-
-	// The streak survives a brief data gap but not a long one (process death, doze, an unusable reading):
-	// past this the "sustained" claim is unverifiable, so a fresh episode starts rather than an inflated
-	// duration. Same bound as the rate window, mirroring FastDrainDetector.
-	static final long MAX_OBSERVATION_GAP_MS = BatteryRateTracker.WINDOW_MS;
-
-	private static final SlowChargeState CLEARED = new SlowChargeState(0, false, 0);
 
 	private SlowChargeDetector() {
 		// Utility class - prevent instantiation
@@ -86,7 +87,7 @@ public final class SlowChargeDetector {
 		// unknown or unplugged ends the session and re-arms for next time.
 		if (!enabled || (status != BatteryManager.BATTERY_STATUS_CHARGING
 				&& status != BatteryManager.BATTERY_STATUS_NOT_CHARGING)) {
-			clearState(prefs);
+			STORE.clear(prefs);
 			return;
 		}
 
@@ -103,116 +104,34 @@ public final class SlowChargeDetector {
 		// notification segment, this detector) must see the same reading (#157).
 		final ChargeSpeed speed = ChargeSpeed.fromMeasurements(batteryDO.getCurrentMicroAmps(), batteryDO.getVoltage());
 		final long now = System.currentTimeMillis();
-		final SlowChargeState previous = loadState(prefs);
-		final SlowChargeDecision decision = decide(previous, speed.isKnown(), speed.getMilliwatts(),
-				FLOOR_MILLIWATTS, SUSTAINED_MS, now);
+		final Streak previous = STORE.load(prefs);
+		final Outcome decision = decide(previous, speed.isKnown(), speed.getMilliwatts(), FLOOR_MILLIWATTS, SUSTAINED_MS, now);
 
-		// Persist only on change: an eligible-but-healthy charge re-decides CLEARED on every broadcast, and
-		// rewriting identical state would churn SharedPreferences for nothing.
-		if (!decision.newState().equals(previous)) {
-			saveState(prefs, decision.newState());
-		}
+		STORE.saveIfChanged(prefs, decision.newState());
 		if (decision.shouldNotify()) {
 			NotificationService.sendSlowChargeWarning(context, speed.getWatts());
 		}
 	}
 
 	/**
-	 * Pure decision core, unit-testable with no Android dependencies. The caller has already confirmed
-	 * eligibility (charging, wired, below the taper level); this decides purely on the power vs the floor
-	 * and the sustained streak.
-	 * <ul>
-	 *   <li><b>Power unknown</b> (a device without {@code CURRENT_NOW}, or a blank reading): <em>sleep</em> —
-	 *       no warning, streak untouched, so a brief gap doesn't reset it. The observation-gap lapse still
-	 *       bounds continuity so a long gap can't later fire an inflated duration.</li>
-	 *   <li><b>Power at/above the floor</b>: the charge is healthy → re-arm (clear the streak + alerted), so
-	 *       a later collapse warns again (hysteresis).</li>
-	 *   <li><b>Power below the floor</b>: start the streak if new; once it has held for the window, fire the
-	 *       single warning for this charge session.</li>
-	 * </ul>
+	 * The slow-charge decision as a pure function of the estimated charge power, delegating the
+	 * streak/lapse/hysteresis mechanics to {@link SustainedConditionTracker} (#163). The condition is
+	 * "power below the floor"; the repeat policy is {@link SustainedConditionTracker#fireOnce} — a single
+	 * warning per charge session, re-armed only when the power recovers. The caller has already confirmed
+	 * eligibility (charging, wired, below the taper level).
 	 *
-	 * @param state       current persisted state
+	 * @param state       current persisted streak
 	 * @param powerKnown  whether the charge power could be estimated this tick
 	 * @param milliwatts  the estimated charge power in mW (valid when {@code powerKnown})
 	 * @param floorMw     the trickle floor in mW
 	 * @param sustainedMs how long the power must stay below the floor before warning
 	 * @param nowMillis   current time in millis
 	 *
-	 * @return whether to warn now, and the new state to persist
+	 * @return whether to warn now, the new streak to persist, and the streak's elapsed time
 	 */
-	static SlowChargeDecision decide(final SlowChargeState state,
-	                                 final boolean powerKnown,
-	                                 final int milliwatts,
-	                                 final int floorMw,
-	                                 final long sustainedMs,
-	                                 final long nowMillis) {
-		if (!powerKnown) {
-			return new SlowChargeDecision(false, state); // sleep — keep the streak, don't warn
-		}
-		if (milliwatts >= floorMw) {
-			return new SlowChargeDecision(false, CLEARED); // healthy power — re-arm the session
-		}
-
-		// Continuity: after a long observation gap the "sustained" claim has lapsed — start a fresh episode
-		// rather than warn immediately with a duration built on unobserved time.
-		final boolean lapsed = state.streakStart() != 0
-				&& nowMillis - state.lastSeenBelow() > MAX_OBSERVATION_GAP_MS;
-		final long start = (state.streakStart() == 0 || lapsed) ? nowMillis : state.streakStart();
-		final long elapsed = nowMillis - start;
-		boolean alerted = !lapsed && state.alerted();
-		boolean notify = false;
-
-		if (elapsed >= sustainedMs && !alerted) {
-			notify = true;      // the single warning for this charge session
-			alerted = true;
-		}
-		return new SlowChargeDecision(notify, new SlowChargeState(start, alerted, nowMillis));
-	}
-
-	private static SlowChargeState loadState(final SharedPreferences prefs) {
-		return new SlowChargeState(
-				prefs.getLong(PREF_STREAK_START, 0),
-				prefs.getBoolean(PREF_ALERTED, false),
-				prefs.getLong(PREF_LAST_SEEN_BELOW, 0));
-	}
-
-	private static void saveState(final SharedPreferences prefs, final SlowChargeState state) {
-		prefs.edit()
-		     .putLong(PREF_STREAK_START, state.streakStart())
-		     .putBoolean(PREF_ALERTED, state.alerted())
-		     .putLong(PREF_LAST_SEEN_BELOW, state.lastSeenBelow())
-		     .apply();
-	}
-
-	/**
-	 * Clears the streak only when it isn't already clear, so the common non-eligible broadcasts don't churn
-	 * SharedPreferences on every tick.
-	 *
-	 * @param prefs the shared preferences
-	 */
-	private static void clearState(final SharedPreferences prefs) {
-		if (!loadState(prefs).equals(CLEARED)) {
-			saveState(prefs, CLEARED);
-		}
-	}
-
-	/**
-	 * Persisted streak/hysteresis state.
-	 *
-	 * @param streakStart   when the power first dropped below the floor this episode (0 = no active streak)
-	 * @param alerted       whether the one warning has fired this charge session
-	 * @param lastSeenBelow when the power was last observed below the floor; a gap longer than
-	 *                      {@link #MAX_OBSERVATION_GAP_MS} lapses the streak (continuity unverifiable)
-	 */
-	record SlowChargeState(long streakStart, boolean alerted, long lastSeenBelow) {
-	}
-
-	/**
-	 * Result of {@link #decide}: whether to warn now, and the new state to persist.
-	 *
-	 * @param shouldNotify whether to send the warning now
-	 * @param newState     the state to persist
-	 */
-	record SlowChargeDecision(boolean shouldNotify, SlowChargeState newState) {
+	static Outcome decide(final Streak state, final boolean powerKnown, final int milliwatts,
+	                      final int floorMw, final long sustainedMs, final long nowMillis) {
+		return SustainedConditionTracker.decide(state, powerKnown, milliwatts < floorMw,
+				sustainedMs, nowMillis, SustainedConditionTracker.fireOnce());
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTracker.java
@@ -1,0 +1,237 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.SharedPreferences;
+
+/**
+ * The shared "a condition has held for a sustained window" engine behind {@link FastDrainDetector}
+ * (#109) and {@link SlowChargeDetector} (#123) — and the base #132's session-relative slow-charge
+ * detection builds on.
+ * <p>
+ * Both detectors were structural twins: a persisted streak (start / alerted / last-seen), the
+ * observation-gap <b>lapse</b> rule, <b>sleep</b> on an unmeasurable reading, <b>re-arm</b> when the
+ * condition clears (hysteresis), the fire-once-then-maybe-repeat logic, and the persist-only-on-change
+ * churn guard. That was ~150 lines that had to be kept in lock-step by hand — a fix to the lapse rule in
+ * one had to be mirrored in the other. This owns that machinery once (issue #163). The two things that
+ * genuinely differ are pluggable:
+ * <ul>
+ *   <li>the <b>condition</b> — whether the streak is currently active (drain at/above the limit vs charge
+ *       power below the floor) — which the caller passes in as a boolean;</li>
+ *   <li>the <b>repeat policy</b> — {@link #fireOnce()} (slow charge) vs {@link #withReminders} (fast drain
+ *       reminds while the screen is off/locked).</li>
+ * </ul>
+ * The {@link #decide} core is pure and Android-free; persistence is a thin {@link StreakStore} keyed by
+ * each detector's own preference keys, so no stored state is lost on upgrade.
+ */
+final class SustainedConditionTracker {
+
+    /**
+     * How long a streak survives without a fresh in-condition observation before it is treated as
+     * lapsed. The underlying rate/power is smoothed over {@link BatteryRateTracker#WINDOW_MS}, so
+     * continuity beyond that window is unknowable — after a longer gap (process death, doze, an
+     * unusable reading) the "sustained" claim has lapsed and the episode restarts, rather than firing
+     * immediately with a duration built on unobserved time.
+     */
+    static final long MAX_OBSERVATION_GAP_MS = BatteryRateTracker.WINDOW_MS;
+
+    /** A cleared streak: no active episode. */
+    static final Streak CLEARED = new Streak(0, false, 0, 0);
+
+    private SustainedConditionTracker() {
+        // Utility class - prevent instantiation
+    }
+
+    /**
+     * Pure decision core, unit-testable with no Android dependencies.
+     * <ul>
+     *   <li><b>Unmeasurable</b> (no trustworthy rate/power this tick — warm-up, or an unsupported
+     *       device): <em>sleep</em>. No notification, and the streak is left intact so a brief data gap
+     *       doesn't reset it. Continuity is still bounded by {@link #MAX_OBSERVATION_GAP_MS}.</li>
+     *   <li><b>Condition inactive</b> (drain calmed / charge power recovered): re-arm the episode (clear
+     *       the streak and the alerted flag) so a later recurrence fires again — hysteresis.</li>
+     *   <li><b>Condition active</b>: start the streak if new; once it has held for {@code sustainedMs},
+     *       hand off to the {@code policy} to decide whether to (re)notify.</li>
+     * </ul>
+     *
+     * @param state           current persisted streak
+     * @param measurable      whether the underlying reading (rate/power) was available this tick
+     * @param conditionActive whether the watched condition holds right now (caller-computed: above the
+     *                        limit / below the floor); ignored when {@code !measurable}
+     * @param sustainedMs     how long the condition must hold before the first alert
+     * @param nowMillis       current time in millis
+     * @param policy          how to (re)notify once the window is met — {@link #fireOnce} or
+     *                        {@link #withReminders}
+     *
+     * @return whether to notify now, the new streak to persist, and the streak's elapsed time
+     */
+    static Outcome decide(final Streak state, final boolean measurable, final boolean conditionActive,
+                          final long sustainedMs, final long nowMillis, final RepeatPolicy policy) {
+        if (!measurable) {
+            return new Outcome(false, state, 0); // sleep — keep the streak, don't fire
+        }
+        if (!conditionActive) {
+            return new Outcome(false, CLEARED, 0); // condition cleared — re-arm (hysteresis)
+        }
+
+        final boolean lapsed = state.start() != 0 && nowMillis - state.lastSeen() > MAX_OBSERVATION_GAP_MS;
+        final long start = (state.start() == 0 || lapsed) ? nowMillis : state.start();
+        final long elapsed = nowMillis - start;
+        final boolean alerted = !lapsed && state.alerted();
+        final long lastReminder = lapsed ? 0 : state.lastReminder();
+
+        final Repeat repeat = elapsed >= sustainedMs
+                ? policy.decide(alerted, lastReminder, nowMillis)
+                : new Repeat(false, alerted, lastReminder);
+
+        return new Outcome(repeat.fire(),
+                new Streak(start, repeat.alerted(), nowMillis, repeat.lastReminder()), elapsed);
+    }
+
+    /**
+     * Fire a single alert per episode and then stay silent until the condition clears (re-arm). Used by
+     * {@link SlowChargeDetector}; #132 layers on the same policy.
+     *
+     * @return a once-per-episode repeat policy
+     */
+    static RepeatPolicy fireOnce() {
+        return (alerted, lastReminder, nowMillis) -> alerted
+                ? new Repeat(false, true, lastReminder) // already warned this episode
+                : new Repeat(true, true, lastReminder); // the one warning
+    }
+
+    /**
+     * Fire the first alert regardless of screen state, then remind every {@code reminderGapMs} while the
+     * screen is off/locked (background drain the user can't see), staying silent while actively used.
+     * Used by {@link FastDrainDetector}.
+     *
+     * @param activelyUsed  whether the screen is on and unlocked right now
+     * @param reminderGapMs minimum gap between reminders while off/locked
+     *
+     * @return a repeat-with-reminders policy
+     */
+    static RepeatPolicy withReminders(final boolean activelyUsed, final long reminderGapMs) {
+        return (alerted, lastReminder, nowMillis) -> {
+            if (!alerted) {
+                return new Repeat(true, true, nowMillis); // first alert this episode, any screen state
+            }
+            if (!activelyUsed && nowMillis - lastReminder >= reminderGapMs) {
+                return new Repeat(true, true, nowMillis); // background drain — remind on the gap
+            }
+            return new Repeat(false, true, lastReminder);
+        };
+    }
+
+    /**
+     * Persists a {@link Streak} under a detector's own preference keys (so no stored state is lost on
+     * upgrade), with the shared persist-only-on-change churn guard. Detectors without a reminder concept
+     * pass {@code null} for {@code keyLastReminder}; that field then stays 0 and is never written.
+     */
+    static final class StreakStore {
+
+        private final String keyStart;
+        private final String keyAlerted;
+        private final String keyLastSeen;
+        private final String keyLastReminder;
+
+        StreakStore(final String keyStart, final String keyAlerted, final String keyLastSeen, final String keyLastReminder) {
+            this.keyStart = keyStart;
+            this.keyAlerted = keyAlerted;
+            this.keyLastSeen = keyLastSeen;
+            this.keyLastReminder = keyLastReminder;
+        }
+
+        StreakStore(final String keyStart, final String keyAlerted, final String keyLastSeen) {
+            this(keyStart, keyAlerted, keyLastSeen, null);
+        }
+
+        Streak load(final SharedPreferences prefs) {
+            return new Streak(
+                    prefs.getLong(keyStart, 0),
+                    prefs.getBoolean(keyAlerted, false),
+                    prefs.getLong(keyLastSeen, 0),
+                    keyLastReminder == null ? 0 : prefs.getLong(keyLastReminder, 0));
+        }
+
+        void save(final SharedPreferences prefs, final Streak state) {
+            final SharedPreferences.Editor editor = prefs.edit()
+                    .putLong(keyStart, state.start())
+                    .putBoolean(keyAlerted, state.alerted())
+                    .putLong(keyLastSeen, state.lastSeen());
+            if (keyLastReminder != null) {
+                editor.putLong(keyLastReminder, state.lastReminder());
+            }
+            editor.apply();
+        }
+
+        /**
+         * Persists the new state only when it differs from what's stored — the common healthy-tick case
+         * re-decides the same state on every broadcast, and rewriting it would churn SharedPreferences.
+         *
+         * @param prefs the shared preferences
+         * @param state the state to persist
+         */
+        void saveIfChanged(final SharedPreferences prefs, final Streak state) {
+            if (!load(prefs).equals(state)) {
+                save(prefs, state);
+            }
+        }
+
+        /**
+         * Clears the streak, only when it isn't already clear (so ineligible broadcasts don't churn
+         * SharedPreferences every tick).
+         *
+         * @param prefs the shared preferences
+         */
+        void clear(final SharedPreferences prefs) {
+            saveIfChanged(prefs, CLEARED);
+        }
+    }
+
+    /**
+     * A persisted streak / hysteresis state.
+     *
+     * @param start        when the condition first held this episode (0 = no active streak)
+     * @param alerted      whether the first alert has fired this episode
+     * @param lastSeen     when the condition was last observed to hold; a gap longer than
+     *                     {@link #MAX_OBSERVATION_GAP_MS} lapses the streak (continuity unknowable)
+     * @param lastReminder when the last (re)notification was sent; 0 for detectors that don't remind
+     */
+    record Streak(long start, boolean alerted, long lastSeen, long lastReminder) {
+
+        /** A streak for a detector with no reminder concept (slow charge). */
+        Streak(final long start, final boolean alerted, final long lastSeen) {
+            this(start, alerted, lastSeen, 0);
+        }
+    }
+
+    /**
+     * Result of {@link #decide}: whether to (re)notify, the new streak to persist, and the streak's
+     * elapsed time (used for the "for the last N minutes" message).
+     *
+     * @param shouldNotify whether to send a notification now
+     * @param newState     the streak to persist
+     * @param elapsedMs    the streak's elapsed time in millis
+     */
+    record Outcome(boolean shouldNotify, Streak newState, long elapsedMs) {
+    }
+
+    /**
+     * The pluggable repeat decision, applied only once the sustained window has been met: given the
+     * current alerted flag and last-reminder time, decide whether to (re)notify and the updated flags.
+     */
+    @FunctionalInterface
+    interface RepeatPolicy {
+
+        Repeat decide(boolean alerted, long lastReminder, long nowMillis);
+    }
+
+    /**
+     * A {@link RepeatPolicy} result. ({@code fire}, not {@code notify}, because a record component named
+     * {@code notify} would clash with {@link Object#notify()}.)
+     *
+     * @param fire         whether to (re)notify now
+     * @param alerted      the alerted flag to carry forward
+     * @param lastReminder the last-reminder time to carry forward
+     */
+    record Repeat(boolean fire, boolean alerted, long lastReminder) {
+    }
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTracker.java
@@ -63,8 +63,12 @@ final class SustainedConditionTracker {
      *
      * @return whether to notify now, the new streak to persist, and the streak's elapsed time
      */
-    static Outcome decide(final Streak state, final boolean measurable, final boolean conditionActive,
-                          final long sustainedMs, final long nowMillis, final RepeatPolicy policy) {
+    static Outcome decide(Streak state,
+                          boolean measurable,
+                          boolean conditionActive,
+                          long sustainedMs,
+                          long nowMillis,
+                          RepeatPolicy policy) {
         if (!measurable) {
             return new Outcome(false, state, 0); // sleep — keep the streak, don't fire
         }
@@ -108,7 +112,7 @@ final class SustainedConditionTracker {
      *
      * @return a repeat-with-reminders policy
      */
-    static RepeatPolicy withReminders(final boolean activelyUsed, final long reminderGapMs) {
+    static RepeatPolicy withReminders(boolean activelyUsed, long reminderGapMs) {
         return (alerted, lastReminder, nowMillis) -> {
             if (!alerted) {
                 return new Repeat(true, true, nowMillis); // first alert this episode, any screen state
@@ -132,18 +136,21 @@ final class SustainedConditionTracker {
         private final String keyLastSeen;
         private final String keyLastReminder;
 
-        StreakStore(final String keyStart, final String keyAlerted, final String keyLastSeen, final String keyLastReminder) {
+        StreakStore(String keyStart,
+                    String keyAlerted,
+                    String keyLastSeen,
+                    String keyLastReminder) {
             this.keyStart = keyStart;
             this.keyAlerted = keyAlerted;
             this.keyLastSeen = keyLastSeen;
             this.keyLastReminder = keyLastReminder;
         }
 
-        StreakStore(final String keyStart, final String keyAlerted, final String keyLastSeen) {
+        StreakStore(String keyStart, String keyAlerted, String keyLastSeen) {
             this(keyStart, keyAlerted, keyLastSeen, null);
         }
 
-        Streak load(final SharedPreferences prefs) {
+        Streak load(SharedPreferences prefs) {
             return new Streak(
                     prefs.getLong(keyStart, 0),
                     prefs.getBoolean(keyAlerted, false),
@@ -151,7 +158,7 @@ final class SustainedConditionTracker {
                     keyLastReminder == null ? 0 : prefs.getLong(keyLastReminder, 0));
         }
 
-        void save(final SharedPreferences prefs, final Streak state) {
+        void save(SharedPreferences prefs, Streak state) {
             final SharedPreferences.Editor editor = prefs.edit()
                     .putLong(keyStart, state.start())
                     .putBoolean(keyAlerted, state.alerted())
@@ -169,7 +176,7 @@ final class SustainedConditionTracker {
          * @param prefs the shared preferences
          * @param state the state to persist
          */
-        void saveIfChanged(final SharedPreferences prefs, final Streak state) {
+        void saveIfChanged(SharedPreferences prefs, Streak state) {
             if (!load(prefs).equals(state)) {
                 save(prefs, state);
             }
@@ -181,7 +188,7 @@ final class SustainedConditionTracker {
          *
          * @param prefs the shared preferences
          */
-        void clear(final SharedPreferences prefs) {
+        void clear(SharedPreferences prefs) {
             saveIfChanged(prefs, CLEARED);
         }
     }
@@ -198,7 +205,7 @@ final class SustainedConditionTracker {
     record Streak(long start, boolean alerted, long lastSeen, long lastReminder) {
 
         /** A streak for a detector with no reminder concept (slow charge). */
-        Streak(final long start, final boolean alerted, final long lastSeen) {
+        Streak(long start, boolean alerted, long lastSeen) {
             this(start, alerted, lastSeen, 0);
         }
     }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/FastDrainDetectorTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/FastDrainDetectorTest.java
@@ -1,7 +1,7 @@
 package com.almothafar.simplebatterynotifier.service;
 
-import com.almothafar.simplebatterynotifier.service.FastDrainDetector.FastDrainDecision;
-import com.almothafar.simplebatterynotifier.service.FastDrainDetector.FastDrainState;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Outcome;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Streak;
 
 import org.junit.Test;
 
@@ -10,10 +10,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Unit tests for the pure fast-drain decision core {@link FastDrainDetector#decide} (issue #109):
- * the sustained-streak trigger, the once-vs-reminder split by screen state, the re-arm hysteresis,
- * the observation-gap lapse rule, and the timing-preference clamp.
- * Times in millis; limit in %/h. States carry a lastSeenAbove close to "now" where the scenario
+ * Unit tests for the pure fast-drain decision core {@link FastDrainDetector#decide} (issue #109),
+ * unchanged as the behaviour contract after the shared engine was extracted (#163): the
+ * sustained-streak trigger, the once-vs-reminder split by screen state, the re-arm hysteresis, the
+ * observation-gap lapse rule, and the timing-preference clamp.
+ * Times in millis; limit in %/h. The streak's {@code lastSeen} sits close to "now" where the scenario
  * implies continuous observation — in production every above-limit tick refreshes it.
  */
 public class FastDrainDetectorTest {
@@ -25,12 +26,13 @@ public class FastDrainDetectorTest {
 	private static final boolean USED = true;
 	private static final boolean LOCKED = false; // "not actively used" == screen off/locked
 
-	private static final FastDrainState CLEARED = new FastDrainState(0, false, 0, 0);
+	// Streak(start, alerted, lastSeen, lastReminder).
+	private static final Streak CLEARED = new Streak(0, false, 0, 0);
 
 	@Test
 	public void rateUnavailable_sleepsAndKeepsStreak() {
-		final FastDrainState state = new FastDrainState(1000, true, 2000, 2000);
-		final FastDrainDecision d = FastDrainDetector.decide(state, false, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 999_999);
+		final Streak state = new Streak(1000, true, 2000, 2000);
+		final Outcome d = FastDrainDetector.decide(state, false, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 999_999);
 
 		assertFalse(d.shouldNotify());
 		assertEquals(state, d.newState()); // untouched
@@ -38,8 +40,8 @@ public class FastDrainDetectorTest {
 
 	@Test
 	public void rateBelowLimit_reArmsEpisode() {
-		final FastDrainState state = new FastDrainState(1000, true, 2000, 2000);
-		final FastDrainDecision d = FastDrainDetector.decide(state, true, 10, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000);
+		final Streak state = new Streak(1000, true, 2000, 2000);
+		final Outcome d = FastDrainDetector.decide(state, true, 10, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000);
 
 		assertFalse(d.shouldNotify());
 		assertEquals(CLEARED, d.newState());
@@ -47,31 +49,31 @@ public class FastDrainDetectorTest {
 
 	@Test
 	public void rateAtLimit_startsStreakButDoesNotFireYet() {
-		final FastDrainDecision d = FastDrainDetector.decide(CLEARED, true, 20, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 1000);
+		final Outcome d = FastDrainDetector.decide(CLEARED, true, 20, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 1000);
 
 		assertFalse(d.shouldNotify());
-		assertEquals(1000, d.newState().streakStart());
-		assertEquals(1000, d.newState().lastSeenAbove());
+		assertEquals(1000, d.newState().start());
+		assertEquals(1000, d.newState().lastSeen());
 		assertFalse(d.newState().alerted());
 	}
 
 	@Test
 	public void streakNotYetSustained_doesNotFire() {
-		final FastDrainState state = new FastDrainState(1000, false, 0, 1000);
+		final Streak state = new Streak(1000, false, 1000, 0);
 		final long now = 1000 + 2 * MINUTE_MS; // only 2 min in
-		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+		final Outcome d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
 
 		assertFalse(d.shouldNotify());
-		assertEquals(1000, d.newState().streakStart()); // start preserved
-		assertEquals(now, d.newState().lastSeenAbove()); // observation refreshed
+		assertEquals(1000, d.newState().start());     // start preserved
+		assertEquals(now, d.newState().lastSeen());   // observation refreshed
 		assertFalse(d.newState().alerted());
 	}
 
 	@Test
 	public void sustained_firesFirstAlertEvenWhileActivelyUsed() {
-		final FastDrainState state = new FastDrainState(1000, false, 0, 1000);
+		final Streak state = new Streak(1000, false, 1000, 0);
 		final long now = 1000 + SUSTAINED_MS;
-		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, USED, now);
+		final Outcome d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, USED, now);
 
 		assertTrue(d.shouldNotify());              // warn at least once per episode
 		assertTrue(d.newState().alerted());
@@ -83,10 +85,10 @@ public class FastDrainDetectorTest {
 	public void afterAlert_activelyUsed_staysSilent() {
 		final long start = 1000;
 		final long now = start + REMINDER_MS + MINUTE_MS; // well past a reminder gap
-		final FastDrainState state = new FastDrainState(start, true, start, now - MINUTE_MS);
-		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, USED, now);
+		final Streak state = new Streak(start, true, now - MINUTE_MS, start);
+		final Outcome d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, USED, now);
 
-		assertFalse(d.shouldNotify());                       // once per episode while the user can see it
+		assertFalse(d.shouldNotify());                    // once per episode while the user can see it
 		assertEquals(start, d.newState().lastReminder()); // reminder time untouched
 	}
 
@@ -94,8 +96,8 @@ public class FastDrainDetectorTest {
 	public void afterAlert_lockedAndGapElapsed_reminds() {
 		final long start = 1000;
 		final long now = start + REMINDER_MS;
-		final FastDrainState state = new FastDrainState(start, true, start, now - MINUTE_MS);
-		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+		final Streak state = new Streak(start, true, now - MINUTE_MS, start);
+		final Outcome d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
 
 		assertTrue(d.shouldNotify());
 		assertEquals(now, d.newState().lastReminder());
@@ -106,8 +108,8 @@ public class FastDrainDetectorTest {
 	public void afterAlert_lockedButGapNotElapsed_staysSilent() {
 		final long start = 1000;
 		final long now = start + REMINDER_MS - MINUTE_MS; // one minute short of the gap
-		final FastDrainState state = new FastDrainState(start, true, start, now - MINUTE_MS);
-		final FastDrainDecision d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+		final Streak state = new Streak(start, true, now - MINUTE_MS, start);
+		final Outcome d = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
 
 		assertFalse(d.shouldNotify());
 		assertEquals(start, d.newState().lastReminder());
@@ -116,16 +118,16 @@ public class FastDrainDetectorTest {
 	@Test
 	public void reArmedEpisode_canAlertAgainLater() {
 		// A calmed episode clears, then a fresh flare re-starts the streak and alerts once sustained.
-		final FastDrainDecision calmed = FastDrainDetector.decide(
-				new FastDrainState(1000, true, 1000, 1000), true, 5, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 400_000);
+		final Outcome calmed = FastDrainDetector.decide(
+				new Streak(1000, true, 1000, 1000), true, 5, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 400_000);
 		assertEquals(CLEARED, calmed.newState());
 
-		final FastDrainDecision restart = FastDrainDetector.decide(
+		final Outcome restart = FastDrainDetector.decide(
 				calmed.newState(), true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000);
 		assertFalse(restart.shouldNotify());
-		assertEquals(500_000, restart.newState().streakStart());
+		assertEquals(500_000, restart.newState().start());
 
-		final FastDrainDecision reAlert = FastDrainDetector.decide(
+		final Outcome reAlert = FastDrainDetector.decide(
 				restart.newState(), true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, 500_000 + SUSTAINED_MS);
 		assertTrue(reAlert.shouldNotify());
 	}
@@ -137,27 +139,27 @@ public class FastDrainDetectorTest {
 		// Streak observed for 4 min, then no usable rate for ~86 min (process death / doze). The next
 		// above-limit reading must start a fresh episode, not alert "for the last 90 minutes".
 		final long lastSeen = 1000 + 4 * MINUTE_MS;
-		final FastDrainState state = new FastDrainState(1000, false, 0, lastSeen);
+		final Streak state = new Streak(1000, false, lastSeen, 0);
 		final long now = 1000 + 90 * MINUTE_MS;
-		final FastDrainDecision d = FastDrainDetector.decide(state, true, 22, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+		final Outcome d = FastDrainDetector.decide(state, true, 22, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
 
 		assertFalse(d.shouldNotify());
-		assertEquals(now, d.newState().streakStart());   // fresh episode
-		assertEquals(now, d.newState().lastSeenAbove());
+		assertEquals(now, d.newState().start());   // fresh episode
+		assertEquals(now, d.newState().lastSeen());
 	}
 
 	@Test
 	public void lapsedGapAfterAlert_startsFreshEpisodeThatCanAlertAgain() {
 		final long alertedAt = 1000 + SUSTAINED_MS;
-		final FastDrainState state = new FastDrainState(1000, true, alertedAt, alertedAt);
+		final Streak state = new Streak(1000, true, alertedAt, alertedAt);
 		final long now = 1000 + 120 * MINUTE_MS; // hours later
-		final FastDrainDecision lapsed = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
+		final Outcome lapsed = FastDrainDetector.decide(state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now);
 
 		assertFalse(lapsed.shouldNotify());
-		assertEquals(now, lapsed.newState().streakStart());
+		assertEquals(now, lapsed.newState().start());
 		assertFalse(lapsed.newState().alerted()); // new episode: the first-alert is re-armed
 
-		final FastDrainDecision reAlert = FastDrainDetector.decide(
+		final Outcome reAlert = FastDrainDetector.decide(
 				lapsed.newState(), true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, now + SUSTAINED_MS);
 		assertTrue(reAlert.shouldNotify());
 	}
@@ -166,16 +168,16 @@ public class FastDrainDetectorTest {
 	public void gapAtBoundary_continuesStreak() {
 		// A gap of exactly MAX_OBSERVATION_GAP_MS is still continuous; one millisecond more lapses it.
 		final long lastSeen = 1000;
-		final long atBoundary = lastSeen + FastDrainDetector.MAX_OBSERVATION_GAP_MS;
-		final FastDrainState state = new FastDrainState(1000, false, 0, lastSeen);
+		final long atBoundary = lastSeen + SustainedConditionTracker.MAX_OBSERVATION_GAP_MS;
+		final Streak state = new Streak(1000, false, lastSeen, 0);
 
-		final FastDrainDecision continued = FastDrainDetector.decide(
+		final Outcome continued = FastDrainDetector.decide(
 				state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, atBoundary);
-		assertEquals(1000, continued.newState().streakStart()); // preserved
+		assertEquals(1000, continued.newState().start()); // preserved
 
-		final FastDrainDecision lapsed = FastDrainDetector.decide(
+		final Outcome lapsed = FastDrainDetector.decide(
 				state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, atBoundary + 1);
-		assertEquals(atBoundary + 1, lapsed.newState().streakStart()); // restarted
+		assertEquals(atBoundary + 1, lapsed.newState().start()); // restarted
 	}
 
 	// --- timing-preference clamp ----------------------------------------------------------------

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetectorTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetectorTest.java
@@ -1,7 +1,7 @@
 package com.almothafar.simplebatterynotifier.service;
 
-import com.almothafar.simplebatterynotifier.service.SlowChargeDetector.SlowChargeDecision;
-import com.almothafar.simplebatterynotifier.service.SlowChargeDetector.SlowChargeState;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Outcome;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Streak;
 
 import org.junit.Test;
 
@@ -10,11 +10,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Unit tests for the pure slow-charge decision core {@link SlowChargeDetector#decide} (issue #123): the
+ * Unit tests for the pure slow-charge decision core {@link SlowChargeDetector#decide} (issue #123),
+ * unchanged as the behaviour contract after the shared engine was extracted (#163): the
  * sustained-below-floor trigger, the once-per-session guarantee, the re-arm-on-recovery hysteresis, and
- * the observation-gap lapse rule. Power in mW; times in millis. States carry a lastSeenBelow close to
- * "now" where the scenario implies continuous observation — in production every below-floor tick refreshes
- * it.
+ * the observation-gap lapse rule. Power in mW; times in millis. The streak's {@code lastSeen} sits close
+ * to "now" where the scenario implies continuous observation — in production every below-floor tick
+ * refreshes it.
  */
 public class SlowChargeDetectorTest {
 
@@ -24,12 +25,13 @@ public class SlowChargeDetectorTest {
 	private static final long SUSTAINED_MS = SlowChargeDetector.SUSTAINED_MS; // 3 min
 	private static final long MINUTE_MS = 60_000L;
 
-	private static final SlowChargeState CLEARED = new SlowChargeState(0, false, 0);
+	// Streak(start, alerted, lastSeen) — no reminder concept for slow charge.
+	private static final Streak CLEARED = new Streak(0, false, 0);
 
 	@Test
 	public void powerUnknown_sleepsAndKeepsStreak() {
-		final SlowChargeState state = new SlowChargeState(1000, true, 2000);
-		final SlowChargeDecision d = SlowChargeDetector.decide(state, false, 0, FLOOR_MW, SUSTAINED_MS, 999_999);
+		final Streak state = new Streak(1000, true, 2000);
+		final Outcome d = SlowChargeDetector.decide(state, false, 0, FLOOR_MW, SUSTAINED_MS, 999_999);
 
 		assertFalse(d.shouldNotify());
 		assertEquals(state, d.newState()); // untouched
@@ -37,8 +39,8 @@ public class SlowChargeDetectorTest {
 
 	@Test
 	public void powerAtOrAboveFloor_reArmsSession() {
-		final SlowChargeState state = new SlowChargeState(1000, true, 2000);
-		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, HEALTHY_MW, FLOOR_MW, SUSTAINED_MS, 500_000);
+		final Streak state = new Streak(1000, true, 2000);
+		final Outcome d = SlowChargeDetector.decide(state, true, HEALTHY_MW, FLOOR_MW, SUSTAINED_MS, 500_000);
 
 		assertFalse(d.shouldNotify());
 		assertEquals(CLEARED, d.newState());
@@ -48,48 +50,48 @@ public class SlowChargeDetectorTest {
 	public void floorIsInclusiveHealthy_exactlyAtFloorReArms() {
 		// At the floor counts as healthy (re-arm); one milliwatt below starts a slow streak.
 		assertEquals(CLEARED, SlowChargeDetector.decide(CLEARED, true, FLOOR_MW, FLOOR_MW, SUSTAINED_MS, 1000).newState());
-		assertEquals(1000, SlowChargeDetector.decide(CLEARED, true, FLOOR_MW - 1, FLOOR_MW, SUSTAINED_MS, 1000).newState().streakStart());
+		assertEquals(1000, SlowChargeDetector.decide(CLEARED, true, FLOOR_MW - 1, FLOOR_MW, SUSTAINED_MS, 1000).newState().start());
 	}
 
 	@Test
 	public void belowFloor_startsStreakButDoesNotFireYet() {
-		final SlowChargeDecision d = SlowChargeDetector.decide(CLEARED, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, 1000);
+		final Outcome d = SlowChargeDetector.decide(CLEARED, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, 1000);
 
 		assertFalse(d.shouldNotify());
-		assertEquals(1000, d.newState().streakStart());
-		assertEquals(1000, d.newState().lastSeenBelow());
+		assertEquals(1000, d.newState().start());
+		assertEquals(1000, d.newState().lastSeen());
 		assertFalse(d.newState().alerted());
 	}
 
 	@Test
 	public void streakNotYetSustained_doesNotFire() {
-		final SlowChargeState state = new SlowChargeState(1000, false, 1000);
+		final Streak state = new Streak(1000, false, 1000);
 		final long now = 1000 + 2 * MINUTE_MS; // 2 min in, sustained window is 3
-		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+		final Outcome d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
 
 		assertFalse(d.shouldNotify());
-		assertEquals(1000, d.newState().streakStart());   // start preserved
-		assertEquals(now, d.newState().lastSeenBelow());  // observation refreshed
+		assertEquals(1000, d.newState().start());     // start preserved
+		assertEquals(now, d.newState().lastSeen());   // observation refreshed
 		assertFalse(d.newState().alerted());
 	}
 
 	@Test
 	public void sustained_firesTheOneWarning() {
-		final SlowChargeState state = new SlowChargeState(1000, false, 1000);
+		final Streak state = new Streak(1000, false, 1000);
 		final long now = 1000 + SUSTAINED_MS;
-		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+		final Outcome d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
 
 		assertTrue(d.shouldNotify());
 		assertTrue(d.newState().alerted());
-		assertEquals(1000, d.newState().streakStart());
+		assertEquals(1000, d.newState().start());
 	}
 
 	@Test
 	public void afterWarning_staysSilentForTheRestOfTheSession() {
 		final long start = 1000;
 		final long now = start + SUSTAINED_MS + 20 * MINUTE_MS; // long after the warning
-		final SlowChargeState state = new SlowChargeState(start, true, now - MINUTE_MS);
-		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+		final Streak state = new Streak(start, true, now - MINUTE_MS);
+		final Outcome d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
 
 		assertFalse(d.shouldNotify()); // once per charge session — no reminders
 		assertTrue(d.newState().alerted());
@@ -98,16 +100,16 @@ public class SlowChargeDetectorTest {
 	@Test
 	public void reArmedSession_canWarnAgainLater() {
 		// Power recovers (charge fixed), then collapses again in a later session and warns once more.
-		final SlowChargeDecision recovered = SlowChargeDetector.decide(
-				new SlowChargeState(1000, true, 1000), true, HEALTHY_MW, FLOOR_MW, SUSTAINED_MS, 400_000);
+		final Outcome recovered = SlowChargeDetector.decide(
+				new Streak(1000, true, 1000), true, HEALTHY_MW, FLOOR_MW, SUSTAINED_MS, 400_000);
 		assertEquals(CLEARED, recovered.newState());
 
-		final SlowChargeDecision restart = SlowChargeDetector.decide(
+		final Outcome restart = SlowChargeDetector.decide(
 				recovered.newState(), true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, 500_000);
 		assertFalse(restart.shouldNotify());
-		assertEquals(500_000, restart.newState().streakStart());
+		assertEquals(500_000, restart.newState().start());
 
-		final SlowChargeDecision reAlert = SlowChargeDetector.decide(
+		final Outcome reAlert = SlowChargeDetector.decide(
 				restart.newState(), true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, 500_000 + SUSTAINED_MS);
 		assertTrue(reAlert.shouldNotify());
 	}
@@ -119,27 +121,27 @@ public class SlowChargeDetectorTest {
 		// Below-floor for a bit, then no usable reading for longer than the window (process death / doze).
 		// The next below-floor reading must start a fresh episode, not warn on unobserved time.
 		final long lastSeen = 1000 + MINUTE_MS;
-		final SlowChargeState state = new SlowChargeState(1000, false, lastSeen);
-		final long now = lastSeen + SlowChargeDetector.MAX_OBSERVATION_GAP_MS + 1;
-		final SlowChargeDecision d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+		final Streak state = new Streak(1000, false, lastSeen);
+		final long now = lastSeen + SustainedConditionTracker.MAX_OBSERVATION_GAP_MS + 1;
+		final Outcome d = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
 
 		assertFalse(d.shouldNotify());
-		assertEquals(now, d.newState().streakStart());   // fresh episode
-		assertEquals(now, d.newState().lastSeenBelow());
+		assertEquals(now, d.newState().start());   // fresh episode
+		assertEquals(now, d.newState().lastSeen());
 	}
 
 	@Test
 	public void lapsedGapAfterWarning_startsFreshEpisodeThatCanWarnAgain() {
 		final long alertedAt = 1000 + SUSTAINED_MS;
-		final SlowChargeState state = new SlowChargeState(1000, true, alertedAt);
-		final long now = alertedAt + SlowChargeDetector.MAX_OBSERVATION_GAP_MS + 1;
-		final SlowChargeDecision lapsed = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
+		final Streak state = new Streak(1000, true, alertedAt);
+		final long now = alertedAt + SustainedConditionTracker.MAX_OBSERVATION_GAP_MS + 1;
+		final Outcome lapsed = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now);
 
 		assertFalse(lapsed.shouldNotify());
-		assertEquals(now, lapsed.newState().streakStart());
+		assertEquals(now, lapsed.newState().start());
 		assertFalse(lapsed.newState().alerted()); // new episode: the warning is re-armed
 
-		final SlowChargeDecision reAlert = SlowChargeDetector.decide(
+		final Outcome reAlert = SlowChargeDetector.decide(
 				lapsed.newState(), true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, now + SUSTAINED_MS);
 		assertTrue(reAlert.shouldNotify());
 	}
@@ -148,13 +150,13 @@ public class SlowChargeDetectorTest {
 	public void gapAtBoundary_continuesStreak() {
 		// A gap of exactly MAX_OBSERVATION_GAP_MS is still continuous; one millisecond more lapses it.
 		final long lastSeen = 1000;
-		final long atBoundary = lastSeen + SlowChargeDetector.MAX_OBSERVATION_GAP_MS;
-		final SlowChargeState state = new SlowChargeState(1000, false, lastSeen);
+		final long atBoundary = lastSeen + SustainedConditionTracker.MAX_OBSERVATION_GAP_MS;
+		final Streak state = new Streak(1000, false, lastSeen);
 
-		final SlowChargeDecision continued = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, atBoundary);
-		assertEquals(1000, continued.newState().streakStart()); // preserved
+		final Outcome continued = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, atBoundary);
+		assertEquals(1000, continued.newState().start()); // preserved
 
-		final SlowChargeDecision lapsed = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, atBoundary + 1);
-		assertEquals(atBoundary + 1, lapsed.newState().streakStart()); // restarted
+		final Outcome lapsed = SlowChargeDetector.decide(state, true, SLOW_MW, FLOOR_MW, SUSTAINED_MS, atBoundary + 1);
+		assertEquals(atBoundary + 1, lapsed.newState().start()); // restarted
 	}
 }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTrackerTest.java
@@ -1,0 +1,165 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Outcome;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.Streak;
+import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.StreakStore;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the shared sustained-condition engine {@link SustainedConditionTracker} (issue #163):
+ * the generic decide core (sleep / re-arm / lapse / sustained window) and its two repeat policies, plus
+ * the {@link StreakStore} persistence — including that it reads back state written under the detectors'
+ * existing preference keys, so no in-progress episode is lost on upgrade.
+ */
+@RunWith(Enclosed.class)
+public class SustainedConditionTrackerTest {
+
+	private static final long SUSTAINED_MS = 3 * 60_000L;
+	private static final long REMINDER_MS = 15 * 60_000L;
+	private static final Streak CLEARED = new Streak(0, false, 0, 0);
+
+	/** The generic {@link SustainedConditionTracker#decide} mechanics, independent of any detector. */
+	public static class DecideCore {
+
+		@Test
+		public void unmeasurable_sleepsAndKeepsStreakUntouched() {
+			final Streak state = new Streak(1000, true, 2000, 2000);
+			final Outcome d = SustainedConditionTracker.decide(state, false, true, SUSTAINED_MS, 999_999,
+					SustainedConditionTracker.fireOnce());
+
+			assertFalse(d.shouldNotify());
+			assertEquals(state, d.newState());
+		}
+
+		@Test
+		public void conditionInactive_reArmsToCleared() {
+			final Streak state = new Streak(1000, true, 2000, 0);
+			final Outcome d = SustainedConditionTracker.decide(state, true, false, SUSTAINED_MS, 500_000,
+					SustainedConditionTracker.fireOnce());
+
+			assertFalse(d.shouldNotify());
+			assertEquals(CLEARED, d.newState());
+		}
+
+		@Test
+		public void fireOnce_firesWhenSustainedThenStaysSilent() {
+			final Streak building = new Streak(1000, false, 1000, 0);
+			final Outcome first = SustainedConditionTracker.decide(building, true, true, SUSTAINED_MS,
+					1000 + SUSTAINED_MS, SustainedConditionTracker.fireOnce());
+			assertTrue(first.shouldNotify());
+			assertTrue(first.newState().alerted());
+
+			final Outcome later = SustainedConditionTracker.decide(first.newState(), true, true, SUSTAINED_MS,
+					1000 + SUSTAINED_MS + REMINDER_MS, SustainedConditionTracker.fireOnce());
+			assertFalse(later.shouldNotify()); // once only — no reminders
+		}
+
+		@Test
+		public void withReminders_remindsWhileLockedButNotWhileUsed() {
+			final long start = 1000;
+			final long now = start + SUSTAINED_MS + REMINDER_MS;
+			final Streak alerted = new Streak(start, true, now - 60_000L, start);
+
+			final Outcome used = SustainedConditionTracker.decide(alerted, true, true, SUSTAINED_MS, now,
+					SustainedConditionTracker.withReminders(true, REMINDER_MS));
+			assertFalse(used.shouldNotify()); // visible to the user — stay silent
+
+			final Outcome locked = SustainedConditionTracker.decide(alerted, true, true, SUSTAINED_MS, now,
+					SustainedConditionTracker.withReminders(false, REMINDER_MS));
+			assertTrue(locked.shouldNotify()); // background — remind on the gap
+			assertEquals(now, locked.newState().lastReminder());
+		}
+
+		@Test
+		public void longObservationGap_lapsesAndRestartsTheStreak() {
+			final long lastSeen = 1000;
+			final long now = lastSeen + SustainedConditionTracker.MAX_OBSERVATION_GAP_MS + 1;
+			final Streak state = new Streak(1000, true, lastSeen, 0);
+
+			final Outcome d = SustainedConditionTracker.decide(state, true, true, SUSTAINED_MS, now,
+					SustainedConditionTracker.fireOnce());
+			assertEquals(now, d.newState().start());   // fresh episode
+			assertFalse(d.newState().alerted());        // re-armed
+		}
+	}
+
+	/** {@link StreakStore}: round-trip, the reminder-less variant, the churn-guarded clear, and upgrade safety. */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class Persistence {
+
+		// The real fast-drain keys — this test doubles as the "keys unchanged on upgrade" guard (#163).
+		private static final String KEY_START = "_fast_drain_streak_start";
+		private static final String KEY_ALERTED = "_fast_drain_alerted";
+		private static final String KEY_LAST_SEEN = "_fast_drain_last_seen_above";
+		private static final String KEY_LAST_REMINDER = "_fast_drain_last_reminder";
+
+		private SharedPreferences prefs;
+
+		@Before
+		public void setUp() {
+			final Context context = ApplicationProvider.getApplicationContext();
+			prefs = PreferenceManager.getDefaultSharedPreferences(context);
+			prefs.edit().clear().apply();
+		}
+
+		@Test
+		public void roundTripsAllFourFields() {
+			final StreakStore store = new StreakStore(KEY_START, KEY_ALERTED, KEY_LAST_SEEN, KEY_LAST_REMINDER);
+			final Streak state = new Streak(111, true, 222, 333);
+			store.save(prefs, state);
+
+			assertEquals(state, store.load(prefs));
+		}
+
+		@Test
+		public void reminderlessStore_ignoresAndNeverWritesTheReminderField() {
+			final StreakStore store = new StreakStore(KEY_START, KEY_ALERTED, KEY_LAST_SEEN);
+			store.save(prefs, new Streak(111, true, 222, 999)); // 999 must not be persisted
+
+			assertEquals(new Streak(111, true, 222, 0), store.load(prefs));
+			assertFalse(prefs.contains(KEY_LAST_REMINDER));
+		}
+
+		@Test
+		public void clear_resetsToCleared() {
+			final StreakStore store = new StreakStore(KEY_START, KEY_ALERTED, KEY_LAST_SEEN, KEY_LAST_REMINDER);
+			store.save(prefs, new Streak(111, true, 222, 333));
+
+			store.clear(prefs);
+
+			assertEquals(CLEARED, store.load(prefs));
+		}
+
+		@Test
+		public void loadsStateWrittenUnderTheLegacyKeys() {
+			// Simulate an install upgraded mid-episode: raw values sitting under the pre-#163 keys.
+			prefs.edit()
+			     .putLong(KEY_START, 4242)
+			     .putBoolean(KEY_ALERTED, true)
+			     .putLong(KEY_LAST_SEEN, 5353)
+			     .putLong(KEY_LAST_REMINDER, 6464)
+			     .apply();
+
+			final Streak loaded = new StreakStore(KEY_START, KEY_ALERTED, KEY_LAST_SEEN, KEY_LAST_REMINDER).load(prefs);
+
+			assertEquals(new Streak(4242, true, 5353, 6464), loaded);
+		}
+	}
+}


### PR DESCRIPTION
## What

`FastDrainDetector` (#109) and `SlowChargeDetector` (#123) were structural twins — the persisted streak, the observation-gap **lapse** rule, **sleep** on an unmeasurable reading, **re-arm** hysteresis, the persist-only-on-change churn guard, and the `load`/`save`/`clear` boilerplate were duplicated near line-for-line (~150 lines that had to be kept in lock-step by hand).

New **`SustainedConditionTracker`** owns that machinery once:

- generic `Streak` / `Outcome` records + a pure `decide()` core (streak-start, lapse, sustained-window)
- the **condition** is pluggable — the caller passes a boolean "active" (`ratePph >= limit` vs `milliwatts < floor`)
- the **repeat policy** is pluggable — `fireOnce()` (slow charge: one warning per session) vs `withReminders(activelyUsed, gap)` (fast drain: first alert always, then remind while the screen is off/locked)
- `StreakStore` for persistence, constructed with **each detector's own preference keys**

Each detector keeps a thin, rate/power-oriented `decide()` wrapper — its behaviour contract — that just picks the condition + policy and delegates. `evaluate()` uses the shared `StreakStore`.

## Safety / acceptance

- **Prefs keys unchanged** → no in-progress episode lost on upgrade. There's a direct test that loads state written under the legacy `_fast_drain_*` keys.
- **Byte-for-byte behaviour-identical**: the existing `FastDrainDetectorTest` (14) and `SlowChargeDetectorTest` (11) port over with only type/accessor renames (`FastDrainState`/`SlowChargeState` → shared `Streak`; `.streakStart()`→`.start()`, `.lastSeenAbove()`/`.lastSeenBelow()`→`.lastSeen()`) — every scenario and assertion is unchanged.
- New `SustainedConditionTrackerTest` (9) covers the generic engine (sleep / re-arm / lapse / both policies) and `StreakStore` (round-trip, reminder-less variant, churn-guarded clear, legacy-key load).
- **#132 unblocked**: it can add its session-relative trigger as a second condition on the shared core instead of a third copy.

Pure refactor, no user-facing change (no new strings). `testDebugUnitTest` (429) + `lintDebug` green; debug build installed on the Mate 10 Pro.

Closes #163
Related: #109, #123, #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)