### PR TITLE
i18n: localize legacy channel names/descriptions + ringtone "None" (#165)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -654,49 +654,52 @@ public final class NotificationService {
 		final boolean vibrate = prefs.getBoolean(context.getString(R.string._pref_key_notifications_vibrate), true);
 		final int version = alertChannelVersion(prefs);
 
-		createChannelIfNotExists(manager, versionedChannelId(CHANNEL_ID_CRITICAL, version),
-				"Battery Critical Alerts", "Critical battery level alerts", Color.RED, vibrate);
-		createChannelIfNotExists(manager, versionedChannelId(CHANNEL_ID_WARNING, version),
-				"Battery Warnings", "Battery warning notifications", Color.rgb(0xff, 0x66, 0x00), vibrate);
-		createChannelIfNotExists(manager, versionedChannelId(CHANNEL_ID_FULL, version),
-				"Battery Full", "Battery fully charged notifications", Color.GREEN, vibrate);
-		createChannelIfNotExists(manager, versionedChannelId(CHANNEL_ID_TEMPERATURE, version),
+		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_CRITICAL, version),
+				context.getString(R.string.notification_critical_channel_name),
+				context.getString(R.string.notification_critical_channel_description), Color.RED, vibrate);
+		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_WARNING, version),
+				context.getString(R.string.notification_warning_channel_name),
+				context.getString(R.string.notification_warning_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
+		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_FULL, version),
+				context.getString(R.string.notification_full_channel_name),
+				context.getString(R.string.notification_full_channel_description), Color.GREEN, vibrate);
+		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_TEMPERATURE, version),
 				context.getString(R.string.notification_temperature_channel_name),
 				context.getString(R.string.notification_temperature_channel_description), Color.RED, vibrate);
-		createChannelIfNotExists(manager, versionedChannelId(CHANNEL_ID_FAST_DRAIN, version),
+		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_FAST_DRAIN, version),
 				context.getString(R.string.notification_fast_drain_channel_name),
 				context.getString(R.string.notification_fast_drain_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
-		createChannelIfNotExists(manager, versionedChannelId(CHANNEL_ID_SLOW_CHARGE, version),
+		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_SLOW_CHARGE, version),
 				context.getString(R.string.notification_slow_charge_channel_name),
 				context.getString(R.string.notification_slow_charge_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
-		createSilentChannelIfNotExists(manager, CHANNEL_ID_STATUS,
+		createOrUpdateSilentChannel(manager, CHANNEL_ID_STATUS,
 				context.getString(R.string.notification_status_channel_name),
 				context.getString(R.string.notification_status_channel_description));
-		createSilentChannelIfNotExists(manager, CHANNEL_ID_ALERTS_SILENT,
+		createOrUpdateSilentChannel(manager, CHANNEL_ID_ALERTS_SILENT,
 				context.getString(R.string.notification_quiet_channel_name),
 				context.getString(R.string.notification_quiet_channel_description));
 	}
 
 	/**
-	 * Create a low-importance, fully silent channel (no sound, vibration, lights or badge).
+	 * Create a low-importance, fully silent channel (no sound, vibration, lights or badge), or update
+	 * its name/description if it already exists.
 	 * <p>
 	 * Used both by the persistent status notification and, during the user's quiet hours, to deliver
 	 * an alert quietly so it stays visible without disturbing the user (issue #111).
+	 * <p>
+	 * As with the alert channels, re-calling for an existing ID updates only name/description, so
+	 * translated names reach upgraded installs (#165) without disturbing the silent behaviour.
 	 *
 	 * @param manager     The NotificationManager
 	 * @param channelId   The channel ID to create
 	 * @param name        The channel name
 	 * @param description The channel description
 	 */
-	private static void createSilentChannelIfNotExists(
+	private static void createOrUpdateSilentChannel(
 			final NotificationManager manager,
 			final String channelId,
 			final String name,
 			final String description) {
-		if (nonNull(manager.getNotificationChannel(channelId))) {
-			return;
-		}
-
 		final NotificationChannel channel = new NotificationChannel(channelId, name, NotificationManager.IMPORTANCE_LOW);
 		channel.setDescription(description);
 		channel.enableLights(false);
@@ -707,7 +710,13 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Create a notification channel if it doesn't already exist
+	 * Create an alert channel, or update its name/description if it already exists.
+	 * <p>
+	 * Re-calling {@code createNotificationChannel} with an existing ID updates only the name,
+	 * description and group — Android ignores importance, vibration, lights and sound so the user's
+	 * (and the versioned #153) settings are preserved. This is how translated channel names reach
+	 * <em>upgraded</em> installs, not just fresh ones (#165): the channel already exists, so we still
+	 * re-apply the current locale's name and description.
 	 *
 	 * @param manager   The NotificationManager
 	 * @param channelId The channel ID
@@ -716,17 +725,13 @@ public final class NotificationService {
 	 * @param ledColor  The LED color for notifications
 	 * @param vibrate   Whether the channel should vibrate (from the user's Vibrate preference)
 	 */
-	private static void createChannelIfNotExists(
+	private static void createOrUpdateAlertChannel(
 			final NotificationManager manager,
 			final String channelId,
 			final String name,
 			final String description,
 			final int ledColor,
 			final boolean vibrate) {
-		if (nonNull(manager.getNotificationChannel(channelId))) {
-			return;
-		}
-
 		final NotificationChannel channel = new NotificationChannel(channelId, name, NotificationManager.IMPORTANCE_HIGH);
 		channel.setDescription(description);
 		channel.enableLights(true);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -213,6 +213,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 			return;
 		}
 
+		// Debug-only strings: this block runs only in debuggable builds, so its literals are
+		// deliberately left untranslated (no values-ar). Skip them in i18n sweeps (#165).
 		final String[] options = {
 				"Show Debug Info",
 				"Add 50 Test Cycles",
@@ -388,6 +390,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 * Resets all health tracking data, including the first-use date and real charge cycles.
 	 */
 	private void resetHealthData() {
+		// Reached only from the debuggable-only debug menu, so these literals are deliberately
+		// left untranslated (no values-ar). Skip them in i18n sweeps (#165).
 		new MaterialAlertDialogBuilder(this)
 				.setTitle("Reset ALL health data?")
 				.setMessage("This deletes ALL tracked battery health data, including the first-use date "

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/RingtonePreference.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/RingtonePreference.java
@@ -10,6 +10,8 @@ import android.util.AttributeSet;
 import android.util.Log;
 import androidx.preference.Preference;
 
+import com.almothafar.simplebatterynotifier.R;
+
 import static java.util.Objects.nonNull;
 
 /**
@@ -203,7 +205,7 @@ public class RingtonePreference extends Preference {
 				Log.e(TAG, "Error loading ringtone for " + currentRingtoneUri, e);
 			}
 		}
-		// Empty or null URI means no ringtone selected (silent/none)
-		setSummary("None");
+		// Empty or null URI means no ringtone selected — matches the picker's own "Silent" option (#165)
+		setSummary(getContext().getString(R.string.pref_ringtone_silent));
 	}
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -152,6 +152,14 @@
 
     <!-- ==== Added for localization pass #42 (drafted by Claude — pending maintainer review) ==== -->
 
+    <!-- Notification channel names/descriptions shown in system Settings → Notifications (#165) -->
+    <string name="notification_critical_channel_name">تنبيهات البطارية الحرجة</string>
+    <string name="notification_critical_channel_description">تنبيهات مستوى البطارية الحرج</string>
+    <string name="notification_warning_channel_name">تحذيرات البطارية</string>
+    <string name="notification_warning_channel_description">إشعارات تحذير البطارية</string>
+    <string name="notification_full_channel_name">اكتمال شحن البطارية</string>
+    <string name="notification_full_channel_description">إشعارات اكتمال شحن البطارية</string>
+
     <!-- Persistent foreground-service status notification -->
     <string name="notification_status_channel_name">حالة البطارية</string>
     <string name="notification_status_channel_description">حالة البطارية المستمرة أثناء تفعيل المراقبة</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,6 +129,15 @@
     <string name="notification_full_level_content">You can unplug your charger now</string>
     <string name="notification_full_level_content_big" formatted="false">Charge complete — you can unplug now. Batteries age fastest when kept at 100%, so unplugging soon (and staying roughly between 20% and 80% day to day) helps the battery last longer.</string>
 
+    <!-- Notification channel names/descriptions shown in system Settings → Notifications (#165).
+         The critical/warning/full channels predate the resourced newer channels below. -->
+    <string name="notification_critical_channel_name">Battery Critical Alerts</string>
+    <string name="notification_critical_channel_description">Critical battery level alerts</string>
+    <string name="notification_warning_channel_name">Battery Warnings</string>
+    <string name="notification_warning_channel_description">Battery warning notifications</string>
+    <string name="notification_full_channel_name">Battery Full</string>
+    <string name="notification_full_channel_description">Battery fully charged notifications</string>
+
     <string name="notification_charge_started_title">Charging started</string>
 
     <!-- Charge-connected message (issue #122): reports charging speed + wired/wireless instead of


### PR DESCRIPTION
Closes #165.

## Problem
The three oldest notification channels (critical / warning / full) had their names and descriptions hard-coded in English in `NotificationService`, where lint can't see them. Arabic users saw English rows in **system Settings → Notifications**. The `RingtonePreference` fallback summary was likewise a hard-coded `"None"`.

## Changes
- **Six channel strings → resources** with `values-ar` translations (critical/warning/full × name+description), and the three legacy channels now read them via `context.getString(...)`.
- **Translated names on _upgraded_ installs, not just fresh ones.** The channel helpers no longer early-return when the channel already exists. Re-calling `createNotificationChannel` with the same ID updates **only** name/description/group — Android ignores importance, vibration, lights and sound — so the #153 versioning and any user customization are preserved. Renamed to `createOrUpdateAlertChannel` / `createOrUpdateSilentChannel` to reflect the honest semantics. This benefits every channel (e.g. a locale switch now refreshes all names on next service start), not only the three legacy ones.
- **Ringtone fallback** reuses the existing (previously orphaned, already-translated) `pref_ringtone_silent` string instead of a literal `"None"`. Visible text changes **"None" → "Silent"**, which also matches the label on the system picker's own silent option.
- **Debug-only literals** in `BatteryInsightsActivity` (options array, "Reset ALL health data?" dialog + toasts) are commented as deliberately untranslated so future i18n sweeps skip them knowingly.

## Acceptance criteria
- [x] All three legacy channel names/descriptions come from resources, Arabic included
- [x] "None" summary localized (now "Silent" / "صامت")
- [ ] **Translated channel names visible on an upgraded install (not only fresh)** — code handles it (early-return removed); needs on-device verification
- [x] Deliberately-untranslated debug strings commented as such

## Verification
`./gradlew :app:lintDebug` → `BUILD SUCCESSFUL`, no `MissingTranslation` errors (the repo treats that as an error, so a clean pass confirms every new string is translated). Compiles clean.

**Still needs on-device testing:** install a build _without_ this change, then install this build over it in an Arabic locale, and confirm the three channels flip to Arabic in Settings → Notifications on the _upgraded_ install.

## Notes for review
- Arabic strings drafted by Claude — pending maintainer review.
- The "None" → "Silent" wording change is a deliberate call (reuses an orphaned string, matches the picker); flag if you'd prefer the literal "None" preserved.

Related: #153 (channel recreation), #96/#98 (locale work), #42 (Arabic localization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)