### PR TITLE
Ongoing notification: stable metrics in the title, volatile details in the body

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -557,8 +557,8 @@ public final class NotificationService {
 
 		return new Notification.Builder(context, CHANNEL_ID_STATUS)
 				.setSmallIcon(ongoingIconRes(batteryDO))
-				.setContentTitle(context.getString(R.string.app_name))
-				.setContentText(statusText(context, batteryDO, rate))
+				.setContentTitle(statusTitle(context, batteryDO, rate))
+				.setContentText(statusDetail(context, batteryDO, rate))
 				.setContentIntent(createMainActivityIntent(context))
 				.setOnlyAlertOnce(true)
 				.setOngoing(true)
@@ -1116,26 +1116,94 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Build the content line of the ongoing status notification, e.g. "85.12% · Discharging 9%/h · 32.0 °C".
+	 * Build the title line of the ongoing status notification, e.g. "85.12% · Discharging 9%/h".
 	 * <p>
-	 * The percentage is the same live value the home gauge shows — two decimals when the device
+	 * The title carries the headline data, not the app name — Android already prints the app name in
+	 * the notification header, so repeating it in the title wasted the most glanceable line. The
+	 * percentage is the same live value the home gauge shows — two decimals when the device
 	 * genuinely resolves below one percent, whole otherwise (#158); only the level <em>alerts</em>
-	 * (critical/warning) stay integer. The middle segment appends the charge/drain rate to the status
-	 * label when available, falling back to the raw mA, then to the plain label — always showing the
-	 * best number on hand (issue #108). The appended rate is gated by a user setting (default on); the
+	 * (critical/warning) stay integer. The status segment appends the charge/drain rate when
+	 * available, falling back to the raw mA, then to the plain label — always showing the best
+	 * number on hand (issue #108). The appended rate is gated by a user setting (default on); the
 	 * plain label always shows.
 	 *
 	 * @param context   The application context
 	 * @param batteryDO Current battery snapshot, or null if unavailable
 	 * @param rate      The precomputed charge/drain rate
-	 * @return Formatted status text
+	 * @return Formatted title text
 	 */
-	private static String statusText(final Context context, final BatteryDO batteryDO,
-	                                 final BatteryRateTracker.BatteryRate rate) {
+	static String statusTitle(final Context context, final BatteryDO batteryDO,
+	                          final BatteryRateTracker.BatteryRate rate) {
 		final String percentage = BatteryPercentFormatter.formatLive(batteryDO);
 		final String statusLabel = SystemService.getStatusLabel(context, isNull(batteryDO) ? -1 : batteryDO.getStatus());
+		return context.getString(R.string.notification_status_title, percentage, statusWithRate(context, batteryDO, statusLabel, rate));
+	}
+
+	/**
+	 * Build the content line of the ongoing status notification — the secondary detail under the
+	 * headline: the estimated time to empty/full plus the temperature, e.g. "~9h 26m left · 34.6 °C"
+	 * or "~45m to full · 34.6 °C", degrading to just the temperature when no trustworthy rate is
+	 * available (or the user turned the rate display off — the estimate is derived from the same
+	 * tracker, so the toggle governs both). The projection is the same capacity-free linear one the
+	 * details table shows (#124/#188); precision is a non-goal — the OS owns the accurate figure.
+	 *
+	 * @param context   The application context
+	 * @param batteryDO Current battery snapshot, or null if unavailable
+	 * @param rate      The precomputed charge/drain rate
+	 * @return Formatted detail text (empty when nothing is known)
+	 */
+	static String statusDetail(final Context context, final BatteryDO batteryDO,
+	                           final BatteryRateTracker.BatteryRate rate) {
 		final String temperature = isNull(batteryDO) ? "" : TemperatureUtils.format(context, batteryDO.getTemperature());
-		return context.getString(R.string.notification_status_content, percentage, statusWithRate(context, batteryDO, statusLabel, rate), temperature);
+		final String time = timeEstimateSegment(context, batteryDO, rate);
+		if (isNull(time)) {
+			return temperature;
+		}
+		if (temperature.isEmpty()) {
+			return time;
+		}
+		return context.getString(R.string.notification_status_detail, time, temperature);
+	}
+
+	/**
+	 * The estimated-time segment of the detail line: "~9h 26m left" while discharging, "~45m to full"
+	 * while charging — mirroring the details table's time row (#124/#188), including its gating: a
+	 * trustworthy %/h and a non-degenerate estimate (not already full/empty). Returns null when no
+	 * figure should be shown, so the caller falls back to the temperature alone.
+	 *
+	 * @param context   The application context
+	 * @param batteryDO Current battery snapshot, or null if unavailable
+	 * @param rate      The precomputed charge/drain rate
+	 * @return the formatted time segment, or null when no estimate is available
+	 */
+	private static String timeEstimateSegment(final Context context, final BatteryDO batteryDO,
+	                                          final BatteryRateTracker.BatteryRate rate) {
+		if (isNull(batteryDO) || isNull(rate) || !rate.hasRate() || !showRateEnabled(context)) {
+			return null;
+		}
+		final int level = batteryDO.getBatteryPercentageInt();
+		final int minutes = rate.charging()
+				? BatteryRateTracker.estimateMinutesToFull(level, rate.percentPerHour())
+				: BatteryRateTracker.estimateMinutesToEmpty(level, rate.percentPerHour());
+		if (minutes <= 0) {
+			return null;
+		}
+		final String duration = BatteryRateTracker.formatDuration(context, minutes);
+		return context.getString(rate.charging()
+				? R.string.notification_status_time_to_full
+				: R.string.notification_status_time_left, duration);
+	}
+
+	/**
+	 * Whether the "show rate in status notification" setting is on (default on). Governs both the
+	 * rate appended to the status segment and the derived time estimate in the detail line.
+	 *
+	 * @param context The application context
+	 * @return true when the rate (and its derived estimate) should be shown
+	 */
+	private static boolean showRateEnabled(final Context context) {
+		return PreferenceManager.getDefaultSharedPreferences(context)
+		                        .getBoolean(context.getString(R.string._pref_key_show_rate_in_notification), true);
 	}
 
 	/**
@@ -1150,12 +1218,7 @@ public final class NotificationService {
 	 */
 	private static String statusWithRate(final Context context, final BatteryDO batteryDO,
 	                                     final String statusLabel, final BatteryRateTracker.BatteryRate rate) {
-		if (isNull(batteryDO) || isNull(rate)) {
-			return statusLabel;
-		}
-		final boolean showRate = PreferenceManager.getDefaultSharedPreferences(context)
-		                                           .getBoolean(context.getString(R.string._pref_key_show_rate_in_notification), true);
-		if (!showRate) {
+		if (isNull(batteryDO) || isNull(rate) || !showRateEnabled(context)) {
 			return statusLabel;
 		}
 		// While charging, humans think in charger speed, not %/h — show the estimated tier + wattage when we

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -34,6 +34,8 @@ import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 
 import java.lang.ref.WeakReference;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -93,6 +95,9 @@ public final class NotificationService {
 	// Separate ID so "Charging started" doesn't replace a level alert (#155). The level alert is
 	// still dismissed at plug-in, but explicitly (see clearLevelAlert), not by ID collision.
 	private static final int CHARGE_CONNECTED_NOTIFICATION_ID = 1641992;
+
+	// Joins the ongoing notification's detail segments (rate/power · time · temperature).
+	private static final String DETAIL_SEPARATOR = " · ";
 
 	// Do Not Disturb mode constants
 	private static final String ZEN_MODE = "zen_mode";
@@ -557,7 +562,7 @@ public final class NotificationService {
 
 		return new Notification.Builder(context, CHANNEL_ID_STATUS)
 				.setSmallIcon(ongoingIconRes(batteryDO))
-				.setContentTitle(statusTitle(context, batteryDO, rate))
+				.setContentTitle(statusTitle(context, batteryDO))
 				.setContentText(statusDetail(context, batteryDO, rate))
 				.setContentIntent(createMainActivityIntent(context))
 				.setOnlyAlertOnce(true)
@@ -1116,69 +1121,122 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Build the title line of the ongoing status notification, e.g. "85.12% · Discharging 9%/h".
+	 * Build the title line of the ongoing status notification: the stable headline "85% · Discharging".
 	 * <p>
-	 * The title carries the headline data, not the app name — Android already prints the app name in
-	 * the notification header, so repeating it in the title wasted the most glanceable line. The
-	 * percentage is the same live value the home gauge shows — two decimals when the device
-	 * genuinely resolves below one percent, whole otherwise (#158); only the level <em>alerts</em>
-	 * (critical/warning) stay integer. The status segment appends the charge/drain rate when
-	 * available, falling back to the raw mA, then to the plain label — always showing the best
-	 * number on hand (issue #108). The appended rate is gated by a user setting (default on); the
-	 * plain label always shows.
+	 * The title carries the two most stable, always-available metrics — the live percentage and the
+	 * plain charge state — not the app name (Android already prints that in the header) and not the
+	 * volatile rate/time (those live in the detail line, so the title and body never repeat each other).
+	 * The percentage is the same live value the home gauge shows: two decimals when the device genuinely
+	 * resolves below one percent, whole otherwise (#158).
 	 *
 	 * @param context   The application context
 	 * @param batteryDO Current battery snapshot, or null if unavailable
-	 * @param rate      The precomputed charge/drain rate
 	 * @return Formatted title text
 	 */
-	static String statusTitle(final Context context, final BatteryDO batteryDO,
-	                          final BatteryRateTracker.BatteryRate rate) {
+	static String statusTitle(Context context, BatteryDO batteryDO) {
 		final String percentage = BatteryPercentFormatter.formatLive(batteryDO);
 		final String statusLabel = SystemService.getStatusLabel(context, isNull(batteryDO) ? -1 : batteryDO.getStatus());
-		return context.getString(R.string.notification_status_title, percentage, statusWithRate(context, batteryDO, statusLabel, rate));
+		return context.getString(R.string.notification_status_title, percentage, statusLabel);
 	}
 
 	/**
-	 * Build the content line of the ongoing status notification — the secondary detail under the
-	 * headline: the estimated time to empty/full plus the temperature, e.g. "~9h 26m left · 34.6 °C"
-	 * or "~45m to full · 34.6 °C", degrading to just the temperature when no trustworthy rate is
-	 * available (or the user turned the rate display off — the estimate is derived from the same
-	 * tracker, so the toggle governs both). The projection is the same capacity-free linear one the
-	 * details table shows (#124/#188); precision is a non-goal — the OS owns the accurate figure.
+	 * Build the content line of the ongoing status notification — the volatile details under the stable
+	 * headline: the live rate/power, the estimated time to empty/full, and the temperature, joined by
+	 * "{@value #DETAIL_SEPARATOR}" and each shown only when it's available, e.g. "9%/h · ~9h 27m left ·
+	 * 34.6 °C" or "~18 W · ~45m to full · 34.6 °C". The rate/power and the time estimate are gated by the
+	 * show-rate setting (default on); the temperature always shows when a snapshot exists. Degrades to
+	 * whatever remains — down to just the temperature, or empty when there's no snapshot at all.
 	 *
 	 * @param context   The application context
 	 * @param batteryDO Current battery snapshot, or null if unavailable
 	 * @param rate      The precomputed charge/drain rate
 	 * @return Formatted detail text (empty when nothing is known)
 	 */
-	static String statusDetail(final Context context, final BatteryDO batteryDO,
-	                           final BatteryRateTracker.BatteryRate rate) {
-		final String temperature = isNull(batteryDO) ? "" : TemperatureUtils.format(context, batteryDO.getTemperature());
-		final String time = timeEstimateSegment(context, batteryDO, rate);
-		if (isNull(time)) {
-			return temperature;
+	static String statusDetail(Context context, BatteryDO batteryDO, BatteryRateTracker.BatteryRate rate) {
+		final boolean showRate = showRateEnabled(context);
+		final List<String> parts = new ArrayList<>(3);
+
+		final String speed = speedDetailSegment(context, batteryDO, rate, showRate);
+		if (nonNull(speed)) {
+			parts.add(speed);
 		}
-		if (temperature.isEmpty()) {
-			return time;
+		final String time = timeEstimateSegment(context, batteryDO, rate, showRate);
+		if (nonNull(time)) {
+			parts.add(time);
 		}
-		return context.getString(R.string.notification_status_detail, time, temperature);
+		if (nonNull(batteryDO)) {
+			parts.add(TemperatureUtils.format(context, batteryDO.getTemperature()));
+		}
+		return String.join(DETAIL_SEPARATOR, parts);
 	}
 
 	/**
-	 * The estimated-time segment of the detail line: "~9h 26m left" while discharging, "~45m to full"
-	 * while charging — mirroring the details table's time row (#124/#188), including its gating: a
-	 * trustworthy %/h and a non-degenerate estimate (not already full/empty). Returns null when no
-	 * figure should be shown, so the caller falls back to the temperature alone.
+	 * The speed detail for the notification body: the drain rate ("9%/h", falling back to the raw mA)
+	 * while discharging, or the charge power ("~18 W", falling back to the charge %/h) while charging.
+	 * Numbers only — the qualitative state (Charging/Discharging) is the title's job, so the two lines
+	 * stay non-redundant (issue #108/#125). Gated by the show-rate setting; returns null when nothing
+	 * trustworthy is available.
 	 *
 	 * @param context   The application context
 	 * @param batteryDO Current battery snapshot, or null if unavailable
 	 * @param rate      The precomputed charge/drain rate
+	 * @param showRate  whether the show-rate setting is on
+	 * @return the formatted speed segment, or null when none should be shown
+	 */
+	private static String speedDetailSegment(Context context, BatteryDO batteryDO,
+	                                         BatteryRateTracker.BatteryRate rate, boolean showRate) {
+		if (isNull(batteryDO) || isNull(rate) || !showRate) {
+			return null;
+		}
+		if (rate.charging()) {
+			final String power = chargePowerSegment(context, batteryDO);
+			if (nonNull(power)) {
+				return power;
+			}
+		}
+		if (rate.hasRate()) {
+			return BatteryRateTracker.formatRateValue(context, rate.percentPerHour());
+		}
+		if (rate.hasCurrent()) {
+			return BatteryRateTracker.formatCurrentValue(context, rate.currentMilliAmps());
+		}
+		return null;
+	}
+
+	/**
+	 * The charge power as a wattage-only segment ("~18 W"), or null when it can't be estimated or rounds
+	 * below 1 W. Derived from the snapshot (not a fresh read), so it agrees with the details table and
+	 * {@link SlowChargeDetector} within a tick (#157). The tier label ("Fast charging") is deliberately
+	 * omitted here — it would repeat the "Charging" the title already carries.
+	 *
+	 * @param context   The application context
+	 * @param batteryDO Current battery snapshot (non-null; the caller already checked)
+	 * @return the formatted wattage segment, or null when the charge power is unknown or sub-watt
+	 */
+	private static String chargePowerSegment(Context context, BatteryDO batteryDO) {
+		final ChargeSpeed speed = ChargeSpeed.fromMeasurements(batteryDO.getCurrentMicroAmps(), batteryDO.getVoltage());
+		if (!speed.isKnown() || speed.getWatts() < 1) {
+			return null;
+		}
+		// Western digits (0-9) in every locale (#96).
+		return context.getString(R.string.notification_status_watts, String.valueOf(speed.getWatts()));
+	}
+
+	/**
+	 * The estimated-time segment of the detail line: "~9h 27m left" while discharging, "~45m to full"
+	 * while charging — mirroring the details table's time row (#124/#188), including its gating: a
+	 * trustworthy %/h and a non-degenerate estimate (not already full/empty). Returns null when no
+	 * figure should be shown, so the caller drops it from the joined detail line.
+	 *
+	 * @param context   The application context
+	 * @param batteryDO Current battery snapshot, or null if unavailable
+	 * @param rate      The precomputed charge/drain rate
+	 * @param showRate  whether the show-rate setting is on (governs the estimate too)
 	 * @return the formatted time segment, or null when no estimate is available
 	 */
-	private static String timeEstimateSegment(final Context context, final BatteryDO batteryDO,
-	                                          final BatteryRateTracker.BatteryRate rate) {
-		if (isNull(batteryDO) || isNull(rate) || !rate.hasRate() || !showRateEnabled(context)) {
+	private static String timeEstimateSegment(Context context, BatteryDO batteryDO,
+	                                          BatteryRateTracker.BatteryRate rate, boolean showRate) {
+		if (isNull(batteryDO) || isNull(rate) || !rate.hasRate() || !showRate) {
 			return null;
 		}
 		final int level = batteryDO.getBatteryPercentageInt();
@@ -1195,76 +1253,15 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Whether the "show rate in status notification" setting is on (default on). Governs both the
-	 * rate appended to the status segment and the derived time estimate in the detail line.
+	 * Whether the "show rate & time in status notification" setting is on (default on). Governs the
+	 * rate/power and the derived time estimate in the detail line; the temperature shows regardless.
 	 *
 	 * @param context The application context
-	 * @return true when the rate (and its derived estimate) should be shown
+	 * @return true when the rate/power (and its derived estimate) should be shown
 	 */
-	private static boolean showRateEnabled(final Context context) {
+	private static boolean showRateEnabled(Context context) {
 		return PreferenceManager.getDefaultSharedPreferences(context)
 		                        .getBoolean(context.getString(R.string._pref_key_show_rate_in_notification), true);
-	}
-
-	/**
-	 * The status segment with the rate (or raw mA) appended, e.g. "Discharging 9%/h" — or the plain
-	 * label when no reading is available or the user turned the appended rate off (issue #108).
-	 *
-	 * @param context     The application context
-	 * @param batteryDO   Current battery snapshot, or null if unavailable
-	 * @param statusLabel The plain localized status label
-	 * @param rate        The precomputed charge/drain rate
-	 * @return The status label, optionally with the rate/current appended
-	 */
-	private static String statusWithRate(final Context context, final BatteryDO batteryDO,
-	                                     final String statusLabel, final BatteryRateTracker.BatteryRate rate) {
-		if (isNull(batteryDO) || isNull(rate) || !showRateEnabled(context)) {
-			return statusLabel;
-		}
-		// While charging, humans think in charger speed, not %/h — show the estimated tier + wattage when we
-		// can (#125). The ChargeSpeed read (CURRENT_NOW × voltage) is charging-only, so the discharging path
-		// below is untouched; it falls through to the %/h → mA → plain chain when the speed can't be estimated.
-		if (rate.charging()) {
-			final String chargingSpeed = chargingSpeedSegment(context, batteryDO);
-			if (nonNull(chargingSpeed)) {
-				return chargingSpeed;
-			}
-		}
-		if (rate.hasRate()) {
-			return statusLabel + " " + BatteryRateTracker.formatRateValue(context, rate.percentPerHour());
-		}
-		if (rate.hasCurrent()) {
-			return statusLabel + " " + BatteryRateTracker.formatCurrentValue(context, rate.currentMilliAmps());
-		}
-		return statusLabel;
-	}
-
-	/**
-	 * The charging-speed segment for the ongoing status notification — the estimated tier and wattage, e.g.
-	 * "Fast charging · ~18 W", or just the tier ("Slow charging") when the wattage rounds below 1 W (#125).
-	 * The tier label already reads as "… charging", so it replaces the plain "Charging" status word rather
-	 * than being appended to it. Returns null when the speed can't be estimated (e.g. a device that doesn't
-	 * report {@code CURRENT_NOW}), so the caller falls back to the %/h → mA → plain chain.
-	 * <p>
-	 * The speed is derived from the {@code batteryDO} snapshot, not a fresh hardware read, so this segment
-	 * judges the same reading as the details table and {@link SlowChargeDetector} within one tick (#157).
-	 *
-	 * @param context   The application context
-	 * @param batteryDO Current battery snapshot (non-null; the caller already checked)
-	 * @return the formatted charging-speed segment, or null when the charge speed is unknown
-	 */
-	private static String chargingSpeedSegment(final Context context, final BatteryDO batteryDO) {
-		final ChargeSpeed speed = ChargeSpeed.fromMeasurements(batteryDO.getCurrentMicroAmps(), batteryDO.getVoltage());
-		if (!speed.isKnown()) {
-			return null;
-		}
-		final String tierLabel = context.getString(tierLabelRes(speed.getTier()));
-		final int watts = speed.getWatts();
-		if (watts < 1) {
-			return tierLabel; // sub-watt (e.g. trickle): "~0 W" would read as an error
-		}
-		// %2$s via String.valueOf keeps the wattage in Western digits (0-9) in every locale (#96).
-		return context.getString(R.string.notification_status_charge_power, tierLabel, String.valueOf(watts));
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -137,8 +137,6 @@
     <string name="charge_connected_power">%1$s · %2$s · ~%3$d واط</string>
     <string name="charge_connected_tier">%1$s · %2$s</string>
     <string name="charge_connected_plain">شحن %1$s</string>
-    <!-- #125: إشعار الحالة أثناء الشحن — الفئة + الواط المقدّر، مثل "شحن سريع · ~18 واط" -->
-    <string name="notification_status_charge_power">%1$s · ~%2$s واط</string>
 
     <!-- "Charge notification style" preference (issue #122) -->
     <string name="charge_notification_style_title">أسلوب تنبيه الشحن</string>
@@ -165,12 +163,14 @@
     <string name="notification_status_channel_description">حالة البطارية المستمرة أثناء تفعيل المراقبة</string>
     <string name="notification_quiet_channel_name">تنبيهات صامتة</string>
     <string name="notification_quiet_channel_description">تنبيهات البطارية تُعرض بصمت أثناء ساعات الهدوء</string>
-    <!-- سطر العنوان: البيانات الرئيسية (الترويسة تعرض اسم التطبيق أصلاً فلا يتكرر في العنوان) -->
+    <!-- سطر العنوان: البيانات الثابتة — النسبة المئوية + حالة الشحن (الترويسة تعرض اسم التطبيق،
+         والمعدل/الوقت المتغيّران في سطر المحتوى). مثل "85% · تفريغ" -->
     <string name="notification_status_title">%1$s · %2$s</string>
-    <!-- سطر المحتوى: التفاصيل الثانوية تحت العنوان، مثل "يتبقى ~9h 26m · 34.6 °C" -->
-    <string name="notification_status_detail">%1$s · %2$s</string>
-    <!-- %1$s هي المدة المنسقة ("~9h 26m")، انظر time_to_full_value_hm -->
-    <string name="notification_status_time_left">يتبقى %1$s</string>
+    <!-- سطر المحتوى أثناء الشحن: الواط المقدّر (بدون كلمة الفئة — العنوان يذكر "شحن" أصلاً). %1$s
+         بأرقام غربية (String.valueOf) 0-9 في كل اللغات (#96). مثل "~18 واط" -->
+    <string name="notification_status_watts">~%1$s واط</string>
+    <!-- %1$s هي المدة المنسقة ("~9h 27m")، انظر time_to_full_value_hm -->
+    <string name="notification_status_time_left">يتبقّى %1$s</string>
     <string name="notification_status_time_to_full">%1$s حتى الاكتمال</string>
 
     <!-- High temperature alert -->
@@ -195,9 +195,9 @@
     <string name="time_to_full_value_hm">~%1$sh %2$sm</string>
     <string name="time_to_full_value_m">~%1$sm</string>
     <string name="pref_cat_title_drain">استهلاك البطارية</string>
-    <string name="show_rate_in_notification">إظهار المعدل في إشعار الحالة</string>
-    <string name="show_rate_in_notification_summary_on">يعرض الإشعار المستمر معدل الشحن/الاستهلاك المباشر والوقت المتبقي المقدّر</string>
-    <string name="show_rate_in_notification_summary_off">يعرض الإشعار المستمر تسمية الحالة ودرجة الحرارة فقط</string>
+    <string name="show_rate_in_notification">إظهار المعدل والوقت في إشعار الحالة</string>
+    <string name="show_rate_in_notification_summary_on">يضيف الإشعار المستمر المعدل/القدرة المباشرة والوقت المقدّر إلى النسبة المئوية والحالة ودرجة الحرارة</string>
+    <string name="show_rate_in_notification_summary_off">يعرض الإشعار المستمر النسبة المئوية والحالة ودرجة الحرارة فقط</string>
     <string name="drain_limit">حد الاستهلاك المرتفع</string>
     <string name="drain_limit_summary">يتحول معدل الاستهلاك إلى اللون الكهرماني عند الاقتراب من هذا الحد وإلى الأحمر عند بلوغه أو تجاوزه، ويُطلق تنبيه الاستهلاك السريع عند بقائه عند الحد. يُقاس بنقاط مئوية في الساعة.</string>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -165,7 +165,13 @@
     <string name="notification_status_channel_description">حالة البطارية المستمرة أثناء تفعيل المراقبة</string>
     <string name="notification_quiet_channel_name">تنبيهات صامتة</string>
     <string name="notification_quiet_channel_description">تنبيهات البطارية تُعرض بصمت أثناء ساعات الهدوء</string>
-    <string name="notification_status_content">%1$s · %2$s · %3$s</string>
+    <!-- سطر العنوان: البيانات الرئيسية (الترويسة تعرض اسم التطبيق أصلاً فلا يتكرر في العنوان) -->
+    <string name="notification_status_title">%1$s · %2$s</string>
+    <!-- سطر المحتوى: التفاصيل الثانوية تحت العنوان، مثل "يتبقى ~9h 26m · 34.6 °C" -->
+    <string name="notification_status_detail">%1$s · %2$s</string>
+    <!-- %1$s هي المدة المنسقة ("~9h 26m")، انظر time_to_full_value_hm -->
+    <string name="notification_status_time_left">يتبقى %1$s</string>
+    <string name="notification_status_time_to_full">%1$s حتى الاكتمال</string>
 
     <!-- High temperature alert -->
     <string name="notify_high_temperature">تنبيه ارتفاع الحرارة</string>
@@ -190,8 +196,8 @@
     <string name="time_to_full_value_m">~%1$sm</string>
     <string name="pref_cat_title_drain">استهلاك البطارية</string>
     <string name="show_rate_in_notification">إظهار المعدل في إشعار الحالة</string>
-    <string name="show_rate_in_notification_summary_on">يعرض الإشعار المستمر معدل الشحن/الاستهلاك المباشر بجانب الحالة</string>
-    <string name="show_rate_in_notification_summary_off">يعرض الإشعار المستمر تسمية الحالة فقط</string>
+    <string name="show_rate_in_notification_summary_on">يعرض الإشعار المستمر معدل الشحن/الاستهلاك المباشر والوقت المتبقي المقدّر</string>
+    <string name="show_rate_in_notification_summary_off">يعرض الإشعار المستمر تسمية الحالة ودرجة الحرارة فقط</string>
     <string name="drain_limit">حد الاستهلاك المرتفع</string>
     <string name="drain_limit_summary">يتحول معدل الاستهلاك إلى اللون الكهرماني عند الاقتراب من هذا الحد وإلى الأحمر عند بلوغه أو تجاوزه، ويُطلق تنبيه الاستهلاك السريع عند بقائه عند الحد. يُقاس بنقاط مئوية في الساعة.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,8 +173,14 @@
     <!-- Silent channel used to show an alert quietly during quiet hours (issue #111) -->
     <string name="notification_quiet_channel_name">Quiet Alerts</string>
     <string name="notification_quiet_channel_description">Battery alerts shown silently during your quiet hours</string>
-    <!-- e.g. "85% · Discharging · 32.0 °C" -->
-    <string name="notification_status_content">%1$s · %2$s · %3$s</string>
+    <!-- Title line: the headline data (the header already shows the app name, so the title
+         doesn't repeat it). e.g. "85% · Discharging 9%/h" -->
+    <string name="notification_status_title">%1$s · %2$s</string>
+    <!-- Content line: secondary detail under the headline. e.g. "~9h 26m left · 34.6 °C" -->
+    <string name="notification_status_detail">%1$s · %2$s</string>
+    <!-- %1$s is the formatted duration estimate ("~9h 26m"), see time_to_full_value_hm -->
+    <string name="notification_status_time_left">%1$s left</string>
+    <string name="notification_status_time_to_full">%1$s to full</string>
 
     <!-- High temperature alert -->
     <string name="notify_high_temperature">High Temperature Alert</string>
@@ -202,8 +208,8 @@
     <string name="time_to_full_value_m">~%1$sm</string>
     <string name="pref_cat_title_drain">Battery Drain</string>
     <string name="show_rate_in_notification">Show rate in status notification</string>
-    <string name="show_rate_in_notification_summary_on">The ongoing notification shows the live drain/charge rate next to the status</string>
-    <string name="show_rate_in_notification_summary_off">The ongoing notification shows only the status label</string>
+    <string name="show_rate_in_notification_summary_on">The ongoing notification shows the live drain/charge rate and the estimated time remaining</string>
+    <string name="show_rate_in_notification_summary_off">The ongoing notification shows only the status label and temperature</string>
     <string name="drain_limit">High drain limit</string>
     <string name="drain_limit_summary">The drain rate turns amber near this limit and red at or above it, and the fast-drain alert fires when it stays there. Measured in percentage points per hour.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,11 +155,6 @@
     <string name="charge_connected_tier">%1$s · %2$s</string>
     <!-- e.g. "Wired charging" (when the charging speed can't be estimated) -->
     <string name="charge_connected_plain">%1$s charging</string>
-    <!-- #125: ongoing status notification while charging — tier + estimated watts (no wired/wireless
-         source needed here), e.g. "Fast charging · ~18 W". %2$s is Western-digit (String.valueOf), 0-9
-         in every locale (#96). -->
-    <string name="notification_status_charge_power">%1$s · ~%2$s W</string>
-
     <!-- "Charge notification style" preference (issue #122). The summary shows the current choice
          via useSimpleSummaryProvider, so no separate summary string is needed. -->
     <string name="charge_notification_style_title">Charge notification style</string>
@@ -173,12 +168,13 @@
     <!-- Silent channel used to show an alert quietly during quiet hours (issue #111) -->
     <string name="notification_quiet_channel_name">Quiet Alerts</string>
     <string name="notification_quiet_channel_description">Battery alerts shown silently during your quiet hours</string>
-    <!-- Title line: the headline data (the header already shows the app name, so the title
-         doesn't repeat it). e.g. "85% · Discharging 9%/h" -->
+    <!-- Title line: the stable headline — live percentage + plain charge state (the header already
+         shows the app name, and the volatile rate/time live in the content line). e.g. "85% · Discharging" -->
     <string name="notification_status_title">%1$s · %2$s</string>
-    <!-- Content line: secondary detail under the headline. e.g. "~9h 26m left · 34.6 °C" -->
-    <string name="notification_status_detail">%1$s · %2$s</string>
-    <!-- %1$s is the formatted duration estimate ("~9h 26m"), see time_to_full_value_hm -->
+    <!-- Content line, charging: estimated watts (no tier word — the title already says "Charging").
+         %1$s is Western-digit (String.valueOf), 0-9 in every locale (#96). e.g. "~18 W" -->
+    <string name="notification_status_watts">~%1$s W</string>
+    <!-- %1$s is the formatted duration estimate ("~9h 27m"), see time_to_full_value_hm -->
     <string name="notification_status_time_left">%1$s left</string>
     <string name="notification_status_time_to_full">%1$s to full</string>
 
@@ -207,9 +203,9 @@
     <string name="time_to_full_value_hm">~%1$sh %2$sm</string>
     <string name="time_to_full_value_m">~%1$sm</string>
     <string name="pref_cat_title_drain">Battery Drain</string>
-    <string name="show_rate_in_notification">Show rate in status notification</string>
-    <string name="show_rate_in_notification_summary_on">The ongoing notification shows the live drain/charge rate and the estimated time remaining</string>
-    <string name="show_rate_in_notification_summary_off">The ongoing notification shows only the status label and temperature</string>
+    <string name="show_rate_in_notification">Show rate &amp; time in status notification</string>
+    <string name="show_rate_in_notification_summary_on">The ongoing notification adds the live rate/power and estimated time to the percentage, status and temperature</string>
+    <string name="show_rate_in_notification_summary_off">The ongoing notification shows the percentage, status and temperature only</string>
     <string name="drain_limit">High drain limit</string>
     <string name="drain_limit_summary">The drain rate turns amber near this limit and red at or above it, and the fast-drain alert fires when it stays there. Measured in percentage points per hour.</string>
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
@@ -2,14 +2,18 @@ package com.almothafar.simplebatterynotifier.service;
 
 import android.Manifest;
 import android.app.Application;
+import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.os.BatteryManager;
 
 import androidx.preference.PreferenceManager;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.almothafar.simplebatterynotifier.R;
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.model.ChargeSpeed;
+import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -237,6 +241,70 @@ public class NotificationServiceTest {
 			NotificationService.sendNotification(context, null);
 
 			assertEquals(0, shadowOf(manager).size());
+		}
+	}
+
+	/**
+	 * The two lines of the ongoing status notification: the title carries the headline data
+	 * (percentage + status/rate) instead of repeating the app name the header already shows, and
+	 * the content line carries the time estimate + temperature.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class OngoingStatusLines {
+
+		private Context context;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+		}
+
+		private static BatteryDO discharging85() {
+			return new BatteryDO().setLevel(85).setScale(100)
+					.setStatus(BatteryManager.BATTERY_STATUS_DISCHARGING)
+					.setTemperature(346);
+		}
+
+		private static BatteryRateTracker.BatteryRate rate(final boolean charging, final int pph) {
+			return new BatteryRateTracker.BatteryRate(true, pph, charging, false, 0, false, 0);
+		}
+
+		@Test
+		public void builtNotificationTitle_isHeadlineData_notAppName() {
+			final Notification built = NotificationService.buildOngoingNotification(context, discharging85(), rate(false, 9));
+			assertEquals("85% · Discharging 9%/h", String.valueOf(built.extras.getCharSequence(Notification.EXTRA_TITLE)));
+		}
+
+		@Test
+		public void detail_showsTimeLeftAndTemperature_whileDischarging() {
+			// 85% at 9 %/h → 566.67 min, rounded to 567 → "~9h 27m".
+			final String expected = "~9h 27m left · " + TemperatureUtils.format(context, 346);
+			assertEquals(expected, NotificationService.statusDetail(context, discharging85(), rate(false, 9)));
+		}
+
+		@Test
+		public void detail_showsTimeToFull_whileCharging() {
+			final BatteryDO charging = discharging85().setLevel(80)
+					.setStatus(BatteryManager.BATTERY_STATUS_CHARGING);
+			// 20 points to full at 20 %/h → exactly 60 min → "~1h 0m".
+			final String expected = "~1h 0m to full · " + TemperatureUtils.format(context, 346);
+			assertEquals(expected, NotificationService.statusDetail(context, charging, rate(true, 20)));
+		}
+
+		@Test
+		public void detail_fallsBackToTemperature_whenRateDisplayOff() {
+			PreferenceManager.getDefaultSharedPreferences(context).edit()
+					.putBoolean(context.getString(R.string._pref_key_show_rate_in_notification), false)
+					.commit();
+			assertEquals(TemperatureUtils.format(context, 346),
+					NotificationService.statusDetail(context, discharging85(), rate(false, 9)));
+		}
+
+		@Test
+		public void nullSnapshot_yieldsUnknownTitleAndEmptyDetail() {
+			assertEquals("0% · Unknown", NotificationService.statusTitle(context, null, null));
+			assertEquals("", NotificationService.statusDetail(context, null, null));
 		}
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
@@ -245,9 +245,10 @@ public class NotificationServiceTest {
 	}
 
 	/**
-	 * The two lines of the ongoing status notification: the title carries the headline data
-	 * (percentage + status/rate) instead of repeating the app name the header already shows, and
-	 * the content line carries the time estimate + temperature.
+	 * The two lines of the ongoing status notification (#192): the title carries the stable headline —
+	 * percentage + plain charge state — instead of repeating the app name the header already shows, and
+	 * the content line carries the volatile details (rate/power, time estimate, temperature) with no
+	 * status word, so the two lines never repeat each other.
 	 */
 	@RunWith(RobolectricTestRunner.class)
 	@Config(sdk = 34)
@@ -266,34 +267,45 @@ public class NotificationServiceTest {
 					.setTemperature(346);
 		}
 
-		private static BatteryRateTracker.BatteryRate rate(final boolean charging, final int pph) {
+		private static BatteryRateTracker.BatteryRate rate(boolean charging, int pph) {
 			return new BatteryRateTracker.BatteryRate(true, pph, charging, false, 0, false, 0);
 		}
 
 		@Test
-		public void builtNotificationTitle_isHeadlineData_notAppName() {
+		public void builtNotificationTitle_isStableHeadline_notAppNameNorRate() {
 			final Notification built = NotificationService.buildOngoingNotification(context, discharging85(), rate(false, 9));
-			assertEquals("85% · Discharging 9%/h", String.valueOf(built.extras.getCharSequence(Notification.EXTRA_TITLE)));
+			// Stable metrics only: percentage + status. The rate lives in the content line.
+			assertEquals("85% · Discharging", String.valueOf(built.extras.getCharSequence(Notification.EXTRA_TITLE)));
 		}
 
 		@Test
-		public void detail_showsTimeLeftAndTemperature_whileDischarging() {
+		public void detail_showsRateTimeAndTemperature_whileDischarging() {
 			// 85% at 9 %/h → 566.67 min, rounded to 567 → "~9h 27m".
-			final String expected = "~9h 27m left · " + TemperatureUtils.format(context, 346);
+			final String expected = "9%/h · ~9h 27m left · " + TemperatureUtils.format(context, 346);
 			assertEquals(expected, NotificationService.statusDetail(context, discharging85(), rate(false, 9)));
 		}
 
 		@Test
-		public void detail_showsTimeToFull_whileCharging() {
+		public void detail_showsChargePowerAndTimeToFull_whileCharging() {
+			// 2 A × 5 V = 10 W; 20 points to full at 20 %/h → exactly 60 min → "~1h 0m".
 			final BatteryDO charging = discharging85().setLevel(80)
-					.setStatus(BatteryManager.BATTERY_STATUS_CHARGING);
-			// 20 points to full at 20 %/h → exactly 60 min → "~1h 0m".
-			final String expected = "~1h 0m to full · " + TemperatureUtils.format(context, 346);
+					.setStatus(BatteryManager.BATTERY_STATUS_CHARGING)
+					.setCurrentMicroAmps(2_000_000).setVoltage(5000);
+			final String expected = "~10 W · ~1h 0m to full · " + TemperatureUtils.format(context, 346);
 			assertEquals(expected, NotificationService.statusDetail(context, charging, rate(true, 20)));
 		}
 
 		@Test
-		public void detail_fallsBackToTemperature_whenRateDisplayOff() {
+		public void detail_fallsBackToChargeRate_whenChargePowerUnknown() {
+			// No current/voltage → charge power can't be estimated → the charge %/h stands in.
+			final BatteryDO charging = discharging85().setLevel(80)
+					.setStatus(BatteryManager.BATTERY_STATUS_CHARGING);
+			final String expected = "20%/h · ~1h 0m to full · " + TemperatureUtils.format(context, 346);
+			assertEquals(expected, NotificationService.statusDetail(context, charging, rate(true, 20)));
+		}
+
+		@Test
+		public void detail_fallsBackToTemperatureOnly_whenRateDisplayOff() {
 			PreferenceManager.getDefaultSharedPreferences(context).edit()
 					.putBoolean(context.getString(R.string._pref_key_show_rate_in_notification), false)
 					.commit();
@@ -303,7 +315,7 @@ public class NotificationServiceTest {
 
 		@Test
 		public void nullSnapshot_yieldsUnknownTitleAndEmptyDetail() {
-			assertEquals("0% · Unknown", NotificationService.statusTitle(context, null, null));
+			assertEquals("0% · Unknown", NotificationService.statusTitle(context, null));
 			assertEquals("", NotificationService.statusDetail(context, null, null));
 		}
 	}


### PR DESCRIPTION
## Problem

The persistent status notification's title was hard-coded to the app name — but Android already prints the app name in the notification header, so the boldest, most glanceable line was pure repetition.

## Change

The two lines are now split **by stability**, with no redundancy between them:

- **Title** — the stable, always-available headline: **percentage + plain charge state**, e.g. `85% · Discharging` / `85% · Charging`. No app name, no rate, no tier (those move to the body).
- **Content** — the **volatile details**, each shown only when available, joined by ` · `:
  - the **drain rate** (`9%/h`, or the raw mA) while discharging, or the **charge power** (`~18 W`) while charging;
  - the **estimated time** to empty/full (`~9h 27m left` / `~45m to full`), the same capacity-free projection the details table uses (#124/#188);
  - the **temperature**.
  - e.g. `9%/h · ~9h 27m left · 34.6 °C` or `~18 W · ~45m to full · 34.6 °C`, degrading gracefully down to just the temperature.

The charging body shows the wattage **without** the "Fast charging" tier word, because the title already says the phone is charging — so the title and body never repeat each other.

Details:

- The "Show rate in status notification" toggle is renamed **"Show rate & time in status notification"** and its summaries now match what it governs (the rate/power + the time estimate; the temperature always shows). Turning it off yields `85% · Discharging` + temperature.
- `statusWithRate` / `chargingSpeedSegment` are removed (the title no longer needs them); the charge-tier label stays only on the separate charge-connected popup. New wattage-only string; the old tier+wattage and 2-part detail strings dropped. `showRateEnabled` is read once per build (was twice).
- New/changed strings in `values/` and `values-ar/` (Arabic drafted — pending maintainer review).

## Testing

- `NotificationServiceTest.OngoingStatusLines` (6 tests): stable title from the built notification; discharging rate+time+temp; charging watts+time+temp; charge-rate fallback when power is unknown; temperature-only when the toggle is off; unknown title + empty detail on a null snapshot.
- Full `:app:testDebugUnitTest` (435) + `lintDebug` pass on the local toolchain; installed on the Mate 10 Pro.

Supersedes the original single-commit version (which put the rate in the title); reworked per review.