### PR TITLE
Align coding-standards docs + AppPrefs with the no-final-on-parameters convention (#200)

### DIFF
--- a/.claude/guidelines.md
+++ b/.claude/guidelines.md
@@ -14,7 +14,7 @@ SimpleBatteryNotifier is an Android application that monitors battery status and
   - Records for simple data carriers
 - **Resource Management**: Use try-with-resources for automatic resource cleanup
 - **Null Safety**: Use `isNull()` and `nonNull()` from `java.util.Objects`
-- **Immutability**: Use `final` for all method parameters and local variables where possible
+- **Immutability**: Use `final` for local variables where possible. Do **not** put `final` on method/constructor parameters in new or edited code — effectively-final already covers lambda capture, so the keyword is just noise. Legacy code carries `final` params (an older convention) and migrates incrementally as methods are otherwise touched; a full sweep isn't required.
 - **Static Imports**: Import commonly used static methods (e.g., `isNull`, `nonNull`)
 
 ### Naming Conventions

--- a/CODE_REVIEW_GUIDELINES.md
+++ b/CODE_REVIEW_GUIDELINES.md
@@ -242,6 +242,19 @@ final int age = 25;
 
 **Why?** Improves readability and prevents accidental reassignment.
 
+> **Parameters are the exception — do not mark method/constructor parameters `final`** in new or edited code. Effectively-final already covers lambda capture, so the keyword only adds noise. Legacy code still carries `final` params (an older convention) and migrates as methods are otherwise touched — a full sweep isn't required.
+>
+> ```java
+> // ❌ BAD - final on parameters
+> public int criticalLevel(final Context context) { ... }
+>
+> // ✅ GOOD - final on locals, not parameters
+> public int criticalLevel(Context context) {
+> 	final SharedPreferences prefs = getPrefs(context);
+> 	// ...
+> }
+> ```
+
 ### 2. Declare Variables Close to Usage
 
 ```java
@@ -278,7 +291,7 @@ public void process(String input) {
 }
 
 // ✅ GOOD - Early returns
-public void process(final String input) {
+public void process(String input) {
 	if (isNull(input)) {
 		return;
 	}
@@ -308,12 +321,12 @@ public void processUserDataAndSendEmail(User user) {
 }
 
 // ✅ GOOD - Separate concerns
-public void processUser(final User user) {
+public void processUser(User user) {
 	validateUser(user);
 	saveToDatabase(user);
 }
 
-public void sendWelcomeEmail(final User user) {
+public void sendWelcomeEmail(User user) {
 	// Email logic only
 }
 ```
@@ -331,7 +344,7 @@ final NotificationManager manager2 = (NotificationManager) context.getSystemServ
 manager2.notify(id2, notification2);
 
 // ✅ GOOD - Extracted to method
-private void sendNotification(final Context context, final int id, final Notification notification) {
+private void sendNotification(Context context, int id, Notification notification) {
 	final NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 	if (nonNull(manager)) {
 		manager.notify(id, notification);
@@ -371,7 +384,7 @@ public void unusedMethod() {
 notificationManager.notify(id, notification);
 
 // ✅ GOOD - Check permission first (Android 13+)
-private boolean hasNotificationPermission(final Context context) {
+private boolean hasNotificationPermission(Context context) {
 	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
 		return ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
 				== PackageManager.PERMISSION_GRANTED;
@@ -534,7 +547,7 @@ public void method2() {
 }
 
 // ✅ GOOD - Extract to helper
-private NotificationManager getNotificationManager(final Context context) {
+private NotificationManager getNotificationManager(Context context) {
 	return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 }
 ```
@@ -603,7 +616,7 @@ private boolean isInDoNotDisturbMode() {
  * @param context The application context
  * @param type    Notification type (CRITICAL_TYPE, WARNING_TYPE, or FULL_LEVEL_TYPE)
  */
-public static void sendNotification(final Context context, final int type) {
+public static void sendNotification(Context context, int type) {
 	// Implementation
 }
 ```
@@ -646,7 +659,7 @@ When reviewing code, check:
 
 - [ ] Uses `isNull()`/`nonNull()` instead of `== null`/`!= null`
 - [ ] All curly brackets present (even single-line)
-- [ ] Variables marked `final` where appropriate
+- [ ] Locals marked `final` where appropriate; parameters **not** marked `final`
 - [ ] No FQNs (uses imports)
 - [ ] Line width ≤ 160 characters
 - [ ] Early returns instead of deep nesting

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/util/AppPrefs.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/util/AppPrefs.java
@@ -54,7 +54,7 @@ public final class AppPrefs {
 	 *
 	 * @return the configured critical level
 	 */
-	public static int criticalLevel(final Context context) {
+	public static int criticalLevel(Context context) {
 		return prefs(context).getInt(context.getString(R.string._pref_key_critical_battery_level), DEFAULT_CRITICAL_LEVEL);
 	}
 
@@ -66,7 +66,7 @@ public final class AppPrefs {
 	 *
 	 * @return the configured warning level
 	 */
-	public static int warningLevel(final Context context) {
+	public static int warningLevel(Context context) {
 		return prefs(context).getInt(context.getString(R.string._pref_key_warn_battery_level), DEFAULT_WARNING_LEVEL);
 	}
 
@@ -78,7 +78,7 @@ public final class AppPrefs {
 	 *
 	 * @return the configured {@code (critical, warning)} thresholds
 	 */
-	public static LevelThresholds batteryLevels(final Context context) {
+	public static LevelThresholds batteryLevels(Context context) {
 		return new LevelThresholds(criticalLevel(context), warningLevel(context));
 	}
 
@@ -89,7 +89,7 @@ public final class AppPrefs {
 	 * @param context Application context
 	 * @param levels  the thresholds to store
 	 */
-	public static void setBatteryLevels(final Context context, final LevelThresholds levels) {
+	public static void setBatteryLevels(Context context, LevelThresholds levels) {
 		prefs(context).edit()
 		              .putInt(context.getString(R.string._pref_key_critical_battery_level), levels.critical())
 		              .putInt(context.getString(R.string._pref_key_warn_battery_level), levels.warning())
@@ -106,7 +106,7 @@ public final class AppPrefs {
 	 *
 	 * @return the configured limit in %/h
 	 */
-	public static int drainLimitPph(final Context context) {
+	public static int drainLimitPph(Context context) {
 		return clampDrainLimit(prefs(context).getInt(
 				context.getString(R.string._pref_key_fast_drain_limit), DEFAULT_DRAIN_LIMIT_PPH));
 	}
@@ -120,11 +120,11 @@ public final class AppPrefs {
 	 *
 	 * @return the limit clamped to {@code [MIN_DRAIN_LIMIT_PPH, MAX_DRAIN_LIMIT_PPH]}
 	 */
-	public static int clampDrainLimit(final int stored) {
+	public static int clampDrainLimit(int stored) {
 		return Math.max(MIN_DRAIN_LIMIT_PPH, Math.min(MAX_DRAIN_LIMIT_PPH, stored));
 	}
 
-	private static SharedPreferences prefs(final Context context) {
+	private static SharedPreferences prefs(Context context) {
 		return PreferenceManager.getDefaultSharedPreferences(context);
 	}
 }


### PR DESCRIPTION
Closes #200.

The guideline docs said to use `final` on method parameters, but the actual convention is **`final` on locals, not on parameters** (new/edited code; legacy migrates incrementally). This surfaced in the two-axis review of #166 / PR #199, where `AppPrefs.vibrateEnabled`'s `final` param was flagged as a hard violation the docs technically endorsed.

## Changes

**Docs — both kept in sync:**
- `.claude/guidelines.md` (AI rulebook): the Immutability line now says `final` on locals, **not** parameters; notes legacy migrates as touched.
- `CODE_REVIEW_GUIDELINES.md` (human-facing): added a bad/good callout in the Variables section, dropped `final` from every parameter in the code examples, and updated the review-checklist item (`parameters **not** marked final`).

**Code:**
- `AppPrefs`: dropped `final` from the parameters of all remaining legacy methods (`criticalLevel`, `warningLevel`, `batteryLevels`, `setBatteryLevels`, `drainLimitPph`, `clampDrainLimit`, private `prefs`), so the file is internally consistent — a concrete reference application. (#199 had already dropped it on the one new method, leaving the file mixed.) `final` on locals is unchanged.

## Not in scope
A codebase-wide `final`-param sweep. Legacy files migrate incrementally as they're touched, per the convention now documented.

## Verification
- `testDebugUnitTest` + `lintDebug` + `assembleDebug` green. Removing `final` from a parameter is a no-op modifier change — no behaviour change.

### Acceptance criteria
- [x] Both guideline docs state "final on locals, not on parameters" and stay in sync; no example shows a `final` parameter (except the deliberate ❌ BAD sample).
- [x] `AppPrefs` has no `final` on parameters; `final` on locals unchanged.
- [x] Build + unit tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)