### PR TITLE
Polish batch: public DND API, NotificationCompat, log tag, dp helper, backup rules, legacy key (#167)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
 
     <application
             android:allowBackup="true"
+            android:dataExtractionRules="@xml/data_extraction_rules"
+            android:fullBackupContent="@xml/backup_rules"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:localeConfig="@xml/locales_config"

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/AlertSounds.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/AlertSounds.java
@@ -1,10 +1,9 @@
 package com.almothafar.simplebatterynotifier.service;
 
+import android.app.NotificationManager;
 import android.content.Context;
 import android.media.AudioManager;
 import android.net.Uri;
-import android.provider.Settings;
-import android.util.Log;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -21,11 +20,6 @@ import static java.util.Objects.isNull;
  * an explicit shutdown to).
  */
 final class AlertSounds {
-	private static final String TAG = AlertSounds.class.getSimpleName();
-
-	// Do Not Disturb mode constants
-	private static final String ZEN_MODE = "zen_mode";
-	private static final int ZEN_MODE_IMPORTANT_INTERRUPTIONS = 1;
 
 	/**
 	 * Thread pool for async sound playback. This single-thread executor is used throughout the app
@@ -69,20 +63,25 @@ final class AlertSounds {
 	}
 
 	/**
-	 * Check if device is in Do Not Disturb mode
+	 * Whether the device is in any Do Not Disturb mode (priority-only, alarms-only or total silence).
+	 * <p>
+	 * Uses the public {@link NotificationManager#getCurrentInterruptionFilter()} instead of the
+	 * undocumented {@code Settings.Global "zen_mode"} (issue #167). Any filter other than
+	 * {@code INTERRUPTION_FILTER_ALL} counts as "silenced": priority-only, alarms-only and total silence
+	 * all suppress the app's alerts, so a user who opted to override silent/DND mode should still be
+	 * alerted — a broader, more correct reading than the old priority-only check. {@code UNKNOWN} (and a
+	 * null service) mean "can't tell", so they are treated as not-DND, leaving the alert on its normal path.
 	 *
 	 * @param context The application context
-	 * @return true if in DND mode, false otherwise
+	 * @return true if the device is in any DND mode
 	 */
 	private static boolean isInDoNotDisturbMode(Context context) {
-		try {
-			return ZEN_MODE_IMPORTANT_INTERRUPTIONS == Settings.Global.getInt(context.getContentResolver(), ZEN_MODE);
-		} catch (Settings.SettingNotFoundException e) {
-			// zen_mode has existed since API 21 and minSdk is 26, so its absence is unexpected, not an
-			// expected-validation case — log it rather than swallow. Falling back to "not in DND" keeps
-			// the alert on its normal audible path.
-			Log.w(TAG, "zen_mode setting not found; assuming not in Do Not Disturb", e);
+		final NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		if (isNull(manager)) {
 			return false;
 		}
+		final int filter = manager.getCurrentInterruptionFilter();
+		return filter != NotificationManager.INTERRUPTION_FILTER_ALL
+				&& filter != NotificationManager.INTERRUPTION_FILTER_UNKNOWN;
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryHealthTracker.java
@@ -40,6 +40,9 @@ public class BatteryHealthTracker {
 	// (percentage-points, 0-99), persisted so a partial charge survives app/process restarts.
 	private static final String PREF_LAST_LEVEL = "_battery_health_last_level";
 	private static final String PREF_CYCLE_ACCRUAL_POINTS = "_battery_health_cycle_accrual_points";
+	// Intentional legacy name — predates the "_battery_health_*" convention its siblings follow. Left as-is
+	// on purpose (#167): renaming would silently drop every user's stored design capacity, which measured
+	// health depends on, so the mismatch is kept rather than migrated.
 	private static final String PREF_DESIGN_CAPACITY = "key_battery_design_capacity";
 	// Debug-only cycle offset kept separate from real tracking so it can be cleared without
 	// destroying genuine data (see the debug menu in BatteryInsightsActivity).

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryRateTracker.java
@@ -3,7 +3,6 @@ package com.almothafar.simplebatterynotifier.service;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.BatteryManager;
-import androidx.preference.PreferenceManager;
 
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
@@ -98,7 +97,8 @@ public final class BatteryRateTracker {
 
 		final long now = System.currentTimeMillis();
 		final boolean charging = isChargingDirection(batteryDO.getStatus());
-		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		// Rate window lives in the backup-excluded transient file (#167), not the default prefs.
+		final SharedPreferences prefs = TransientState.prefs(context);
 
 		final boolean sameDirection = sameDirection(prefs, charging);
 		final List<Sample> window = loadWindow(prefs, charging, now);
@@ -134,7 +134,8 @@ public final class BatteryRateTracker {
 		}
 		final long now = System.currentTimeMillis();
 		final boolean charging = isChargingDirection(batteryDO.getStatus());
-		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		// Rate window lives in the backup-excluded transient file (#167), not the default prefs.
+		final SharedPreferences prefs = TransientState.prefs(context);
 
 		return computeRate(loadWindow(prefs, charging, now), batteryDO.getCapacity(), charging, now, batteryDO.getCurrentMicroAmps());
 	}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
@@ -71,13 +71,16 @@ public final class FastDrainDetector {
 			return;
 		}
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		// Streak state is volatile and device-specific → the backup-excluded transient file (#167); the
+		// user settings above/below stay in the default (backed-up) prefs.
+		final SharedPreferences transientPrefs = TransientState.prefs(context);
 
 		final boolean enabled = prefs.getBoolean(context.getString(R.string._pref_key_notify_fast_drain), true);
 		final boolean discharging = !BatteryRateTracker.isChargingDirection(batteryDO.getStatus());
 		// Only while discharging, and only when enabled. Either way the episode is re-armed (charging, or
 		// the feature being off, ends any streak) so a later fast discharge starts fresh.
 		if (!enabled || !discharging) {
-			STORE.clear(prefs);
+			STORE.clear(transientPrefs);
 			return;
 		}
 
@@ -89,11 +92,11 @@ public final class FastDrainDetector {
 		final boolean activelyUsed = SystemService.isActivelyUsed(context);
 		final long now = System.currentTimeMillis();
 
-		final Streak previous = STORE.load(prefs);
+		final Streak previous = STORE.load(transientPrefs);
 		final Outcome decision = decide(previous, rate.hasRate(), rate.percentPerHour(),
 				limit, sustainedMs, reminderGapMs, activelyUsed, now);
 
-		STORE.saveIfChanged(prefs, decision.newState());
+		STORE.saveIfChanged(transientPrefs, decision.newState());
 		if (decision.shouldNotify()) {
 			final int elapsedMinutes = Math.max(1, Math.round(decision.elapsedMs() / (float) MS_PER_MINUTE));
 			NotificationService.sendFastDrainNotification(context, rate.percentPerHour(), limit, elapsedMinutes);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -15,6 +15,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.widget.Toast;
+import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceManager;
 import com.almothafar.simplebatterynotifier.R;
@@ -103,7 +104,7 @@ public final class NotificationService {
 		final NotificationConfig config = new NotificationConfig(context, prefs, type);
 
 		final String channelId = NotificationChannels.channelFor(context, config.alertsAllowed, config.channelId);
-		final Notification.Builder builder = alertBuilder(context, channelId, config.toAlertSpec(NOTIFICATION_ID));
+		final NotificationCompat.Builder builder = alertBuilder(context, channelId, config.toAlertSpec(NOTIFICATION_ID));
 		if (!type.alertsEveryTime()) {
 			// Non-critical alerts update quietly when re-posted; only critical alerts alert every time.
 			builder.setOnlyAlertOnce(true);
@@ -304,20 +305,20 @@ public final class NotificationService {
 
 		final String collapsed = OngoingStatusContent.statusDetail(context, batteryDO, rate);
 		final String expanded = OngoingStatusContent.statusDetailExpanded(context, batteryDO, rate);
-		final Notification.Builder builder = new Notification.Builder(context, NotificationChannels.CHANNEL_ID_STATUS)
+		final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NotificationChannels.CHANNEL_ID_STATUS)
 				.setSmallIcon(OngoingStatusContent.ongoingIconRes(batteryDO))
 				.setContentTitle(OngoingStatusContent.statusTitle(context, batteryDO))
 				.setContentText(collapsed)
 				.setContentIntent(createMainActivityIntent(context))
 				.setOnlyAlertOnce(true)
 				.setOngoing(true)
-				.setVisibility(Notification.VISIBILITY_PUBLIC)
-				.setCategory(Notification.CATEGORY_STATUS);
+				.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+				.setCategory(NotificationCompat.CATEGORY_STATUS);
 
 		// Make it expandable only when the pull-down actually adds something (a multi-line breakdown);
 		// a single-line expanded view (e.g. temperature only) would show a pointless expand chevron (#194).
 		if (expanded.indexOf('\n') >= 0) {
-			builder.setStyle(new Notification.BigTextStyle().bigText(expanded));
+			builder.setStyle(new NotificationCompat.BigTextStyle().bigText(expanded));
 		}
 		return builder.build();
 	}
@@ -433,7 +434,7 @@ public final class NotificationService {
 		}
 
 		// Charge-connected never dings (even inside the window); it just alerts once, quietly.
-		final Notification.Builder builder = alertBuilder(context, routing.channelId(), spec);
+		final NotificationCompat.Builder builder = alertBuilder(context, routing.channelId(), spec);
 		builder.setOnlyAlertOnce(true);
 		post(context, spec.notificationId(), builder.build());
 	}
@@ -448,10 +449,10 @@ public final class NotificationService {
 	 * @param context   The application context
 	 * @param channelId The resolved channel id to post on
 	 * @param display   What to show: icon + text (an {@link AlertSpec})
-	 * @return a Notification.Builder with the shared content applied
+	 * @return a NotificationCompat.Builder with the shared content applied
 	 */
-	private static Notification.Builder alertBuilder(Context context, String channelId, AlertSpec display) {
-		return new Notification.Builder(context, channelId)
+	private static NotificationCompat.Builder alertBuilder(Context context, String channelId, AlertSpec display) {
+		return new NotificationCompat.Builder(context, channelId)
 				.setSmallIcon(display.iconRes())
 				.setTicker(display.ticker())
 				.setContentTitle(display.title())
@@ -459,8 +460,8 @@ public final class NotificationService {
 				.setWhen(System.currentTimeMillis())
 				.setLargeIcon(getLauncherIcon(context))
 				.setContentIntent(createMainActivityIntent(context))
-				.setVisibility(Notification.VISIBILITY_PUBLIC)
-				.setStyle(new Notification.BigTextStyle().bigText(display.bigContent()));
+				.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+				.setStyle(new NotificationCompat.BigTextStyle().bigText(display.bigContent()));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SlowChargeDetector.java
@@ -80,6 +80,9 @@ public final class SlowChargeDetector {
 			return;
 		}
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		// Streak state is volatile and device-specific → the backup-excluded transient file (#167); the
+		// enable setting stays in the default (backed-up) prefs.
+		final SharedPreferences transientPrefs = TransientState.prefs(context);
 		final boolean enabled = prefs.getBoolean(context.getString(R.string._pref_key_notify_slow_charge), true);
 		final int status = batteryDO.getStatus();
 
@@ -87,7 +90,7 @@ public final class SlowChargeDetector {
 		// unknown or unplugged ends the session and re-arms for next time.
 		if (!enabled || (status != BatteryManager.BATTERY_STATUS_CHARGING
 				&& status != BatteryManager.BATTERY_STATUS_NOT_CHARGING)) {
-			STORE.clear(prefs);
+			STORE.clear(transientPrefs);
 			return;
 		}
 
@@ -104,10 +107,10 @@ public final class SlowChargeDetector {
 		// notification segment, this detector) must see the same reading (#157).
 		final ChargeSpeed speed = ChargeSpeed.fromMeasurements(batteryDO.getCurrentMicroAmps(), batteryDO.getVoltage());
 		final long now = System.currentTimeMillis();
-		final Streak previous = STORE.load(prefs);
+		final Streak previous = STORE.load(transientPrefs);
 		final Outcome decision = decide(previous, speed.isKnown(), speed.getMilliwatts(), FLOOR_MILLIWATTS, SUSTAINED_MS, now);
 
-		STORE.saveIfChanged(prefs, decision.newState());
+		STORE.saveIfChanged(transientPrefs, decision.newState());
 		if (decision.shouldNotify()) {
 			NotificationService.sendSlowChargeWarning(context, speed.getWatts());
 		}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SystemService.java
@@ -34,7 +34,7 @@ import static java.util.Objects.isNull;
  * System service utilities for battery monitoring, sound, and vibration
  */
 public final class SystemService {
-	private static final String TAG = "com.almothafar";
+	private static final String TAG = SystemService.class.getSimpleName();
 
 	// A plausible phone-battery full-capacity range (mAh). Some devices (e.g. certain Kirin/HiSilicon)
 	// report BATTERY_PROPERTY_CHARGE_COUNTER in a non-standard unit, yielding absurd single/double-digit

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/TransientState.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/TransientState.java
@@ -1,0 +1,37 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * The dedicated {@link SharedPreferences} file for volatile, device-specific tracker state (issue #167):
+ * the drain/charge rate sample window (#108) and the fast-drain / slow-charge streak state (#109/#123).
+ * <p>
+ * Kept out of the default preferences so it can be excluded from cloud backup and device transfer — see
+ * {@code res/xml/backup_rules.xml} and {@code res/xml/data_extraction_rules.xml}. Restoring another
+ * device's rate window or alert streaks is meaningless: the window is age-trimmed and the streaks reset on
+ * the next evaluation, so the state self-heals within a tick. (Android backup rules exclude whole files,
+ * not individual keys, which is why this state lives in its own file rather than the default prefs.)
+ * <p>
+ * Note: installs upgraded from before #167 leave inert copies of these keys in the default prefs — nothing
+ * reads them there anymore, so they never affect behaviour; they are simply unused dead weight.
+ */
+final class TransientState {
+	/** SharedPreferences file name; excluded from backup as {@code battery_transient.xml}. */
+	static final String PREFS_FILE = "battery_transient";
+
+	private TransientState() {
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * The transient-state preferences file (private, app-owned), separate from the backed-up default
+	 * preferences.
+	 *
+	 * @param context Application context
+	 * @return the {@code battery_transient} SharedPreferences
+	 */
+	static SharedPreferences prefs(Context context) {
+		return context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -23,6 +23,7 @@ import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.SystemService;
+import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 
 /**
  * Activity displaying battery health insights including charge cycles and estimated health.
@@ -298,7 +299,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 		}
 
 		// Indent the field to match the dialog's message padding
-		final int padding = (int) (24 * getResources().getDisplayMetrics().density);
+		final int padding = GeneralHelper.dpToPixel(getResources(), 24);
 		final FrameLayout container = new FrameLayout(this);
 		final FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
 				FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -433,7 +433,7 @@ public class BatteryDetailsFragment extends Fragment {
 		textView.setTextColor(valueColor != 0
 		                      ? valueColor
 		                      : GeneralHelper.getColor(getResources(), R.color.battery_details_value_color));
-		final int iconPadding = (int) (6 * getResources().getDisplayMetrics().density);
+		final int iconPadding = GeneralHelper.dpToPixel(getResources(), 6);
 		if (unreliable) {
 			// #94: amber warning affordance after the value; tap to learn why the reading can't be trusted.
 			// Same mark as the insights health figure, so the two screens read consistently.

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Legacy full-backup rules (API 26-30). Everything is backed up except the volatile, device-specific
+  tracker state (issue #167): the drain/charge rate sample window and the fast-drain/slow-charge streak
+  state, which live in the battery_transient prefs file. Restoring another device's window/streaks is
+  meaningless (it self-heals within a tick), so exclude that one file; health/cycle history and user
+  settings in the default prefs stay backed up.
+-->
+<full-backup-content>
+    <exclude domain="sharedpref" path="battery_transient.xml"/>
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Backup / device-transfer rules (API 31+). The volatile, device-specific tracker state (issue #167) —
+  the drain/charge rate sample window and the fast-drain/slow-charge streak state, in the
+  battery_transient prefs file — is excluded from BOTH cloud backup and device transfer, since restoring
+  another device's window/streaks is meaningless (it self-heals within a tick). Health/cycle history and
+  user settings in the default prefs are still carried over.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="battery_transient.xml"/>
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="battery_transient.xml"/>
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
Closes #167. Six independent cleanups from the polish batch.

### 1. DND via the public API
`AlertSounds` now checks `NotificationManager.getCurrentInterruptionFilter()` instead of the undocumented `Settings.Global "zen_mode"`. **Semantics (you chose "any DND level"):** any filter other than `INTERRUPTION_FILTER_ALL` counts as silenced — priority / alarms-only / total-silence all suppress alerts, so overriding silent/DND now works in all of them (the old code only caught priority). `UNKNOWN` / a null service = not-DND. Bonus: the `zen_mode` try/catch is gone entirely (the public API doesn't throw), which retires the earlier #43 log too.

### 2. NotificationCompat
All builders in `NotificationService` → `NotificationCompat` (`Builder` / `BigTextStyle` / `VISIBILITY_PUBLIC` / `CATEGORY_STATUS`). The sticky `FLAG_NO_CLEAR|FLAG_ONGOING_EVENT` stays on the built `android.app.Notification`.

### 3. Log tag
`SystemService.TAG` `"com.almothafar"` → the class-name tag every other class uses.

### 4. dp helper
The two hand-rolled `dp*density` sites (`BatteryDetailsFragment`, `BatteryInsightsActivity`) now call the existing `GeneralHelper.dpToPixel` (behavior-identical). Left the `Math.round` scroll-hint site alone — different rounding, not in scope.

### 5. Backup rules (you chose "exclude transient state")
Android backup excludes whole **files**, not keys — and the transient state shared the default prefs file with your settings. So the volatile, device-specific tracker state (the rate sample window + fast-drain/slow-charge streaks) moved into a new backup-excluded **`battery_transient`** file (new `TransientState` helper), and `backup_rules.xml` (API 26–30) + `data_extraction_rules.xml` (API 31+) exclude it from cloud backup **and** device transfer. Health/cycle history + settings stay backed up. **No migration needed:** the state self-heals (window age-trims, streaks reset next tick), so upgraded installs just leave inert, unread copies of these keys in the default prefs.

### 6. Legacy key
`PREF_DESIGN_CAPACITY` (`"key_battery_design_capacity"`, off the `_battery_health_*` convention) commented as intentional-legacy — renaming would silently drop users' stored capacity.

## Verification
- `testDebugUnitTest` (446) + `lintDebug` + `assembleDebug` green. No new user-facing strings → nothing for `values-ar`.
- **On-device (your step):** DND on + "ignore silent mode" → the app still plays its alarm (now covers alarms-only / total-silence too); the ongoing/alert notifications still render (NotificationCompat); nothing regressed. The backup change is invisible day-to-day (only matters on cloud restore / device transfer).

### Acceptance criteria
- [x] DND via `getCurrentInterruptionFilter`, semantics documented
- [x] All builders on `NotificationCompat`
- [x] Log tag fixed; no hand-rolled dp math (at the two named sites)
- [x] Backup decision recorded — rules added, transient state moved to its own excluded file
- [x] Legacy key commented

🤖 Generated with [Claude Code](https://claude.com/claude-code)