### PR TITLE
ci: add concurrency guards to release-please and android-ci workflows

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ master, main ]
 
+# Cancel superseded runs on a PR branch when new commits are pushed (saves minutes),
+# but never cancel a master build — every commit on master should build.
+concurrency:
+  group: android-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     name: Build & Test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,14 @@ permissions:
   contents: write
   pull-requests: write
 
+# Only one release-please run at a time. It maintains a single standing Release PR, so
+# parallel runs (from rapid successive merges to master) could race and duplicate or
+# clobber it. Don't cancel-in-progress — let the running one finish; GitHub keeps only
+# the latest queued run, which sees all the merged commits anyway.
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release PR & tag


### PR DESCRIPTION
Closes #212.

## Why

- **`release-please.yml`** had no `concurrency` guard. It runs on every push to `master`, so two PRs merging close together launch parallel runs that both mutate the single standing Release PR — which can duplicate or clobber it.
- **`android-ci.yml`** piled up redundant ~2-min Build & Test runs on rapid PR pushes.

## What

```yaml
# release-please.yml — serialize; let the running one finish (GitHub coalesces the queue)
concurrency:
  group: release-please-${{ github.ref }}
  cancel-in-progress: false
```

```yaml
# android-ci.yml — cancel superseded PR runs, never master builds
concurrency:
  group: android-ci-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

The Gradle **cache** concurrency was already handled (`cache-read-only` off master) — left untouched. The `GITHUB_TOKEN`-doesn't-trigger-CI gotcha on the Release PR is out of scope (its own fix, only needed if those checks ever become required).

`ci:`-typed, so this does not bump the app version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
