### PR TITLE
ci: bump android-ci actions (checkout v7, upload-artifact v7, setup-gradle v6)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5
@@ -28,8 +28,11 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
+          # v6 defaults cache-provider to the proprietary 'enhanced' service; 'basic' keeps the
+          # open-source GitHub Actions cache — no Gradle Terms-of-Use to accept (see #210).
+          cache-provider: basic
           cache-read-only: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
 
       - name: Grant execute permission for gradlew
@@ -46,7 +49,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: |
@@ -56,7 +59,7 @@ jobs:
 
       - name: Upload APK artifacts
         if: success()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: apk-builds
           path: |


### PR DESCRIPTION
Closes #210.

Bumps the three `android-ci.yml` actions that were a major behind. `actions/setup-java@v5` and `googleapis/release-please-action@v5` were already current.

| Action | From | To | Note |
|---|---|---|---|
| `actions/checkout` | v6 | **v7** | ESM/Node runtime; v7's fork-PR restriction doesn't affect our `push` + `pull_request` checkout |
| `actions/upload-artifact` | v6 | **v7** | both usages; ESM + opt-in direct uploads, default glob behaviour unchanged |
| `gradle/actions/setup-gradle` | v5 | **v6** | with **`cache-provider: basic`** |

### Why `cache-provider: basic`

v6 defaults `cache-provider` to `enhanced` — the proprietary `gradle-actions-caching` service, which means accepting Gradle's [Terms of Use](https://gradle.com/legal/terms-of-use/). `basic` keeps the open-source GitHub Actions cache, so CI stays fully open-source for this GPLv3 project. Context: gradle/actions#917.

`ci:`-typed, so no app version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
