### PR TITLE
ci: run the title check on release-please PRs via pull_request

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -5,7 +5,11 @@ name: PR Title
 # every PR title in Conventional Commit form (`type: description`).
 
 on:
-  pull_request_target:
+  # pull_request (not pull_request_target): pull_request_target silently never fires for a PR the
+  # Actions bot opens, which left the required check stuck "expected" forever on release-please's PR.
+  # On pull_request the check also creates a run there — held for approval — that passes once you
+  # click "Approve workflows to run". This is a pinned third-party action, so pull_request is safe.
+  pull_request:
     types: [ opened, edited, synchronize, reopened ]
     branches: [ master ]
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Needed to post the PR-title status onto the Release PR (see the auto-pass step below).
+  statuses: write
 
 # Only one release-please run at a time. It maintains a single standing Release PR, so
 # parallel runs (from rapid successive merges to master) could race and duplicate or
@@ -27,7 +29,26 @@ jobs:
     name: Release PR & tag
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v5
+      - id: release
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The "Conventional Commit title" ruleset check comes from pr-title-lint.yml, which runs on
+      # pull_request_target. GitHub never triggers that workflow for a PR the Actions bot opens (its
+      # own GITHUB_TOKEN can't start further workflow runs), so the required check sits "expected"
+      # forever and blocks the Release PR. Post a passing status for it here: this step runs as the
+      # GitHub Actions app (the app the ruleset pins that check to), so the status satisfies the
+      # requirement. Contributor PRs are unaffected — they still get the genuine check.
+      - name: Auto-pass the PR-title check on the Release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_number='${{ fromJSON(steps.release.outputs.pr).number }}'
+          head_sha="$(gh api "repos/${{ github.repository }}/pulls/${pr_number}" --jq '.head.sha')"
+          gh api --method POST "repos/${{ github.repository }}/statuses/${head_sha}" \
+            -f state=success \
+            -f context='Conventional Commit title' \
+            -f description='Release PR: title check auto-passed (it cannot run on bot-authored PRs)'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # Needed to post the PR-title status onto the Release PR (see the auto-pass step below).
-  statuses: write
 
 # Only one release-please run at a time. It maintains a single standing Release PR, so
 # parallel runs (from rapid successive merges to master) could race and duplicate or
@@ -29,26 +27,7 @@ jobs:
     name: Release PR & tag
     runs-on: ubuntu-latest
     steps:
-      - id: release
-        uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      # The "Conventional Commit title" ruleset check comes from pr-title-lint.yml, which runs on
-      # pull_request_target. GitHub never triggers that workflow for a PR the Actions bot opens (its
-      # own GITHUB_TOKEN can't start further workflow runs), so the required check sits "expected"
-      # forever and blocks the Release PR. Post a passing status for it here: this step runs as the
-      # GitHub Actions app (the app the ruleset pins that check to), so the status satisfies the
-      # requirement. Contributor PRs are unaffected — they still get the genuine check.
-      - name: Auto-pass the PR-title check on the Release PR
-        if: ${{ steps.release.outputs.pr }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pr_number='${{ fromJSON(steps.release.outputs.pr).number }}'
-          head_sha="$(gh api "repos/${{ github.repository }}/pulls/${pr_number}" --jq '.head.sha')"
-          gh api --method POST "repos/${{ github.repository }}/statuses/${head_sha}" \
-            -f state=success \
-            -f context='Conventional Commit title' \
-            -f description='Release PR: title check auto-passed (it cannot run on bot-authored PRs)'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release${component} ${version}",
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
Closes #220.

## Root cause (corrected)

The `Main branch` ruleset requires the **Conventional Commit title** check, which lives in `pr-title-lint.yml`. It was triggered on **`pull_request_target`** — and that event **never fires for a PR the Actions bot opens**. So on release-please's PR the check never created a run, the required status sat *"expected"* forever, and the PR was blocked. `android-ci.yml` uses `pull_request`, which is exactly why Build & Test *did* run there after "Approve workflows to run".

## Fix

- **`pr-title-lint.yml`: `pull_request_target` → `pull_request`.** Now the title check also creates a run on the release PR — held for approval — that passes as soon as you click **"Approve workflows to run"** (the same flow as your other repos). Contributor PRs are unaffected. It's a pinned third-party action, so `pull_request` is safe.
- **`release-please-config.json`: `pull-request-title-pattern`** drops the meaningless `(master)` scope → the release PR reads **`chore: release <version>`**.

No status hacks, no extra permissions (the earlier workaround on this branch was reverted).

## Unblocking #219

Merging this pushes to master → release-please re-runs and updates #219 (new title + a fresh commit) → that fires the title check on #219, held for approval → click **"Approve workflows to run"** → it passes → #219 becomes mergeable, cutting 3.1.0.