### PR TITLE
feat: group settings screens into rounded cards (Material You style)

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/SettingsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/SettingsActivity.java
@@ -2,12 +2,16 @@ package com.almothafar.simplebatterynotifier.ui;
 
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import com.almothafar.simplebatterynotifier.R;
+import com.almothafar.simplebatterynotifier.ui.preference.PreferenceCardDecoration;
+
+import java.util.Set;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -130,6 +134,22 @@ public class SettingsActivity extends BaseActivity implements PreferenceFragment
 	 * Root settings fragment showing preference categories
 	 */
 	public static class HeaderFragment extends PreferenceFragmentCompat {
+		/**
+		 * Apply the card-group (Material You) style to the root preference list (#222). Done here, not
+		 * in onCreateRecyclerView, because clearing the divider touches the fragment's list which isn't
+		 * assigned until the view is created.
+		 *
+		 * @param view               the fragment's root view
+		 * @param savedInstanceState saved state from a previous instance
+		 */
+		@Override
+		public void onViewCreated(@NonNull final View view, final Bundle savedInstanceState) {
+			super.onViewCreated(view, savedInstanceState);
+			// The About/Version footer shares the root screen's parent with the nav entries, so force it
+			// onto its own card instead of joining their group (#222).
+			PreferenceCardDecoration.apply(this, getListView(), Set.of(getString(R.string._pref_key_about)));
+		}
+
 		/**
 		 * Create the preference hierarchy from XML
 		 *

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/SettingsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/SettingsActivity.java
@@ -2,14 +2,13 @@ package com.almothafar.simplebatterynotifier.ui;
 
 import android.os.Bundle;
 import android.view.MenuItem;
-import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import com.almothafar.simplebatterynotifier.R;
-import com.almothafar.simplebatterynotifier.ui.preference.PreferenceCardDecoration;
+import com.almothafar.simplebatterynotifier.ui.fragment.CardPreferenceFragment;
 
 import java.util.Set;
 
@@ -133,21 +132,16 @@ public class SettingsActivity extends BaseActivity implements PreferenceFragment
 	/**
 	 * Root settings fragment showing preference categories
 	 */
-	public static class HeaderFragment extends PreferenceFragmentCompat {
+	public static class HeaderFragment extends CardPreferenceFragment {
 		/**
-		 * Apply the card-group (Material You) style to the root preference list (#222). Done here, not
-		 * in onCreateRecyclerView, because clearing the divider touches the fragment's list which isn't
-		 * assigned until the view is created.
+		 * The About/Version footer shares the root screen's parent with the nav entries, so force it
+		 * onto its own card instead of joining their group (#222).
 		 *
-		 * @param view               the fragment's root view
-		 * @param savedInstanceState saved state from a previous instance
+		 * @return the About footer key, so it starts its own card
 		 */
 		@Override
-		public void onViewCreated(@NonNull final View view, final Bundle savedInstanceState) {
-			super.onViewCreated(view, savedInstanceState);
-			// The About/Version footer shares the root screen's parent with the nav entries, so force it
-			// onto its own card instead of joining their group (#222).
-			PreferenceCardDecoration.apply(this, getListView(), Set.of(getString(R.string._pref_key_about)));
+		protected Set<String> cardBreakKeys() {
+			return Set.of(getString(R.string._pref_key_about));
 		}
 
 		/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/CardPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/CardPreferenceFragment.java
@@ -1,0 +1,35 @@
+package com.almothafar.simplebatterynotifier.ui.fragment;
+
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceFragmentCompat;
+
+import com.almothafar.simplebatterynotifier.ui.preference.PreferenceCardDecoration;
+
+import java.util.Set;
+
+/**
+ * Base for the app's preference screens: applies the card-group (Material You) look to the list once
+ * its view exists (#222). A screen with a footer or other preference that should sit on its own card
+ * overrides {@link #cardBreakKeys()}.
+ * <p>
+ * The styling runs in onViewCreated, not onCreateRecyclerView, because clearing the divider touches
+ * the fragment's list, which isn't assigned until the view is created.
+ */
+public abstract class CardPreferenceFragment extends PreferenceFragmentCompat {
+
+	@Override
+	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+		super.onViewCreated(view, savedInstanceState);
+		PreferenceCardDecoration.apply(this, getListView(), cardBreakKeys());
+	}
+
+	/**
+	 * @return preference keys that should each start their own card (e.g. a footer); empty by default
+	 */
+	protected Set<String> cardBreakKeys() {
+		return Set.of();
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
-import android.view.View;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -23,13 +22,11 @@ import androidx.preference.ListPreference;
 import androidx.preference.MultiSelectListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.SeekBarPreference;
 
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
-import com.almothafar.simplebatterynotifier.ui.preference.PreferenceCardDecoration;
 import com.almothafar.simplebatterynotifier.ui.preference.RingtonePreference;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 import com.almothafar.simplebatterynotifier.ui.preference.TimePickerPreference;
@@ -47,7 +44,7 @@ import static java.util.Objects.nonNull;
  * Uses modern Activity Result API for ringtone picker and provides accessible
  * error feedback via Snackbar.
  */
-public class GenericPreferenceFragment extends PreferenceFragmentCompat
+public class GenericPreferenceFragment extends CardPreferenceFragment
 		implements SharedPreferences.OnSharedPreferenceChangeListener {
 
 	private static final String TAG = "GenericPreferenceFrag";
@@ -130,20 +127,6 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 				}
 			}
 		}
-	}
-
-	/**
-	 * Apply the card-group (Material You) style to the preference list (#222). Done here, not in
-	 * onCreateRecyclerView, because clearing the divider touches the fragment's list which isn't
-	 * assigned until the view is created.
-	 *
-	 * @param view               the fragment's root view
-	 * @param savedInstanceState saved state from a previous instance
-	 */
-	@Override
-	public void onViewCreated(@NonNull final View view, final Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
-		PreferenceCardDecoration.apply(this, getListView());
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.View;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -28,6 +29,7 @@ import androidx.preference.SeekBarPreference;
 
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
+import com.almothafar.simplebatterynotifier.ui.preference.PreferenceCardDecoration;
 import com.almothafar.simplebatterynotifier.ui.preference.RingtonePreference;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 import com.almothafar.simplebatterynotifier.ui.preference.TimePickerPreference;
@@ -128,6 +130,20 @@ public class GenericPreferenceFragment extends PreferenceFragmentCompat
 				}
 			}
 		}
+	}
+
+	/**
+	 * Apply the card-group (Material You) style to the preference list (#222). Done here, not in
+	 * onCreateRecyclerView, because clearing the divider touches the fragment's list which isn't
+	 * assigned until the view is created.
+	 *
+	 * @param view               the fragment's root view
+	 * @param savedInstanceState saved state from a previous instance
+	 */
+	@Override
+	public void onViewCreated(@NonNull final View view, final Bundle savedInstanceState) {
+		super.onViewCreated(view, savedInstanceState);
+		PreferenceCardDecoration.apply(this, getListView());
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/PreferenceCardDecoration.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/PreferenceCardDecoration.java
@@ -1,0 +1,207 @@
+package com.almothafar.simplebatterynotifier.ui.preference;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.almothafar.simplebatterynotifier.R;
+
+import java.util.Set;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+/**
+ * Draws the "card group" (Material You) look on a preference list (#222): consecutive preferences
+ * that share a parent are painted as one rounded, filled card, and each {@link PreferenceCategory}
+ * title is left as a plain section label sitting on the neutral background above its card.
+ * <p>
+ * The whole look is a paint-time decoration — no per-preference custom layouts and no new dependency.
+ * Every row is inset horizontally (via {@link #getItemOffsets}) so the row content and the card
+ * outline share one margin; a gap is added above each new section and below the last row so the cards
+ * read as separate blocks with breathing room top and bottom. A screen can also list keys in
+ * {@code breakBeforeKeys} to force a preference onto its own card even when it shares a parent — used
+ * for the root screen's About/Version footer. Row backgrounds are the framework's transparent
+ * {@code selectableItemBackground}, so the card painted behind them shows through (and taps ripple).
+ */
+public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
+
+	private final Paint cardPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+	private final RectF cardRect = new RectF();
+	private final float cornerRadius;
+	private final int horizontalMargin;
+	private final int groupGap;
+	private final Set<String> breakBeforeKeys;
+
+	/**
+	 * @param context         context used to resolve the card colour and spacing dimensions
+	 * @param breakBeforeKeys preference keys that always start a new card, even within one parent
+	 */
+	public PreferenceCardDecoration(Context context, Set<String> breakBeforeKeys) {
+		final Resources resources = context.getResources();
+		cardPaint.setStyle(Paint.Style.FILL);
+		cardPaint.setColor(ContextCompat.getColor(context, R.color.settings_group_card));
+		cornerRadius = resources.getDimension(R.dimen.settings_card_corner_radius);
+		horizontalMargin = resources.getDimensionPixelSize(R.dimen.settings_card_horizontal_margin);
+		groupGap = resources.getDimensionPixelSize(R.dimen.settings_card_group_gap);
+		this.breakBeforeKeys = breakBeforeKeys;
+	}
+
+	/**
+	 * Apply the card-group look to a preference fragment's list, with no forced card breaks.
+	 *
+	 * @param fragment the preference fragment whose divider is being cleared
+	 * @param list     the fragment's preference RecyclerView
+	 */
+	public static void apply(PreferenceFragmentCompat fragment, RecyclerView list) {
+		apply(fragment, list, Set.of());
+	}
+
+	/**
+	 * Apply the card-group look: paint a neutral background behind the list, drop the default row
+	 * dividers (the cards provide the grouping instead), and attach the decoration.
+	 *
+	 * @param fragment        the preference fragment whose divider is being cleared
+	 * @param list            the fragment's preference RecyclerView
+	 * @param breakBeforeKeys preference keys that should each start their own card (e.g. a footer)
+	 */
+	public static void apply(PreferenceFragmentCompat fragment, RecyclerView list, Set<String> breakBeforeKeys) {
+		final Context context = list.getContext();
+		list.setBackgroundColor(ContextCompat.getColor(context, R.color.settings_group_background));
+		fragment.setDivider(null);
+		fragment.setDividerHeight(0);
+		list.addItemDecoration(new PreferenceCardDecoration(context, breakBeforeKeys));
+	}
+
+	@Override
+	public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent,
+	                           @NonNull RecyclerView.State state) {
+		final PreferenceGroupAdapter adapter = adapterOf(parent);
+		if (isNull(adapter)) {
+			return;
+		}
+		final int position = parent.getChildAdapterPosition(view);
+		if (position == RecyclerView.NO_POSITION) {
+			return;
+		}
+		outRect.left = horizontalMargin;
+		outRect.right = horizontalMargin;
+		// A gap above every new section so the cards read as separate blocks. The list also opens with
+		// a gap when its first row is a card (e.g. the root screen's nav card); a leading category
+		// header carries its own top padding, so it needs none.
+		if (position == 0) {
+			if (isCardRow(adapter, 0)) {
+				outRect.top = groupGap;
+			}
+		} else if (startsNewGroup(adapter, position)) {
+			outRect.top = groupGap;
+		}
+		// Matching breathing room below the last row so the final card floats off the bottom edge.
+		if (position == adapter.getItemCount() - 1) {
+			outRect.bottom = groupGap;
+		}
+	}
+
+	@Override
+	public void onDraw(@NonNull Canvas canvas, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+		final PreferenceGroupAdapter adapter = adapterOf(parent);
+		if (isNull(adapter)) {
+			return;
+		}
+		final float left = parent.getPaddingLeft() + horizontalMargin;
+		final float right = parent.getWidth() - parent.getPaddingRight() - horizontalMargin;
+
+		final int childCount = parent.getChildCount();
+		int i = 0;
+		while (i < childCount) {
+			final View child = parent.getChildAt(i);
+			final int position = parent.getChildAdapterPosition(child);
+			if (position == RecyclerView.NO_POSITION || !isCardRow(adapter, position)) {
+				i++;
+				continue;
+			}
+			// Extend the run over every following card row in the same group; those rows share one card.
+			final PreferenceGroup group = adapter.getItem(position).getParent();
+			View lastChild = child;
+			int runEnd = i;
+			for (int j = i + 1; j < childCount; j++) {
+				final View next = parent.getChildAt(j);
+				final int nextPosition = parent.getChildAdapterPosition(next);
+				if (nextPosition != position + (j - i) || !isCardRow(adapter, nextPosition)
+						|| adapter.getItem(nextPosition).getParent() != group
+						|| breakBeforeKeys.contains(adapter.getItem(nextPosition).getKey())) {
+					break;
+				}
+				lastChild = next;
+				runEnd = j;
+			}
+			final float top = child.getTop() + child.getTranslationY();
+			final float bottom = lastChild.getBottom() + lastChild.getTranslationY();
+			cardRect.set(left, top, right, bottom);
+			canvas.drawRoundRect(cardRect, cornerRadius, cornerRadius, cardPaint);
+			i = runEnd + 1;
+		}
+	}
+
+	/**
+	 * A section header sits on the background, so a gap belongs above it; a card row needs a leading
+	 * gap when it opens a new group — a forced footer break, a different parent, or the list start —
+	 * but not when a header directly above it has already spaced it.
+	 *
+	 * @param adapter  the preference adapter
+	 * @param position the adapter position being measured
+	 * @return whether a group gap should precede this position
+	 */
+	private boolean startsNewGroup(PreferenceGroupAdapter adapter, int position) {
+		final Preference pref = adapter.getItem(position);
+		if (pref instanceof PreferenceCategory) {
+			return true;
+		}
+		if (breakBeforeKeys.contains(pref.getKey())) {
+			return true;
+		}
+		final Preference previous = adapter.getItem(position - 1);
+		if (previous instanceof PreferenceCategory) {
+			return false;
+		}
+		return previous.getParent() != pref.getParent();
+	}
+
+	/**
+	 * @param adapter  the preference adapter
+	 * @param position the adapter position to classify
+	 * @return whether the position is a normal preference (a card row), not a category section header
+	 */
+	private boolean isCardRow(PreferenceGroupAdapter adapter, int position) {
+		if (position < 0 || position >= adapter.getItemCount()) {
+			return false;
+		}
+		final Preference pref = adapter.getItem(position);
+		return nonNull(pref) && !(pref instanceof PreferenceCategory);
+	}
+
+	/**
+	 * @param parent the preference RecyclerView
+	 * @return the {@link PreferenceGroupAdapter} backing the list, or null if some other adapter is set
+	 */
+	private PreferenceGroupAdapter adapterOf(RecyclerView parent) {
+		final RecyclerView.Adapter<?> adapter = parent.getAdapter();
+		if (adapter instanceof PreferenceGroupAdapter groupAdapter) {
+			return groupAdapter;
+		}
+		return null;
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/PreferenceCardDecoration.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/PreferenceCardDecoration.java
@@ -13,7 +13,6 @@ import androidx.core.content.ContextCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
-import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceGroupAdapter;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -86,6 +85,11 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 		list.addItemDecoration(new PreferenceCardDecoration(context, breakBeforeKeys));
 	}
 
+	/**
+	 * Insets every row so the card outline and row content share one margin, adds a gap above each new
+	 * section (and the opening card) so the cards read as separate blocks, and leaves matching room
+	 * below the last row so the final card floats off the bottom edge.
+	 */
 	@Override
 	public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent,
 	                           @NonNull RecyclerView.State state) {
@@ -115,6 +119,12 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 		}
 	}
 
+	/**
+	 * Paints each card as one rounded, filled rectangle behind the run of rows that share it. Each
+	 * run's true extent is read from the adapter, not just the visible children, so a card that
+	 * continues past the top or bottom edge extends its rounded corner off-screen — clipping to a
+	 * straight edge at the viewport instead of leaving a stray corner mid-card while scrolling.
+	 */
 	@Override
 	public void onDraw(@NonNull Canvas canvas, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
 		final PreferenceGroupAdapter adapter = adapterOf(parent);
@@ -127,33 +137,66 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 		final int childCount = parent.getChildCount();
 		int i = 0;
 		while (i < childCount) {
-			final View child = parent.getChildAt(i);
-			final int position = parent.getChildAdapterPosition(child);
-			if (position == RecyclerView.NO_POSITION || !isCardRow(adapter, position)) {
+			final View firstChild = parent.getChildAt(i);
+			final int startPosition = parent.getChildAdapterPosition(firstChild);
+			if (startPosition == RecyclerView.NO_POSITION || !isCardRow(adapter, startPosition)) {
 				i++;
 				continue;
 			}
-			// Extend the run over every following card row in the same group; those rows share one card.
-			final PreferenceGroup group = adapter.getItem(position).getParent();
-			View lastChild = child;
-			int runEnd = i;
-			for (int j = i + 1; j < childCount; j++) {
-				final View next = parent.getChildAt(j);
-				final int nextPosition = parent.getChildAdapterPosition(next);
-				if (nextPosition != position + (j - i) || !isCardRow(adapter, nextPosition)
-						|| adapter.getItem(nextPosition).getParent() != group
-						|| breakBeforeKeys.contains(adapter.getItem(nextPosition).getKey())) {
-					break;
-				}
-				lastChild = next;
-				runEnd = j;
-			}
-			final float top = child.getTop() + child.getTranslationY();
-			final float bottom = lastChild.getBottom() + lastChild.getTranslationY();
+			final int endIndex = lastVisibleIndexOfCard(parent, adapter, i);
+			final View lastChild = parent.getChildAt(endIndex);
+			final int endPosition = parent.getChildAdapterPosition(lastChild);
+			// Extend a corner off-screen (it clips to a straight edge) whenever the card runs past an edge.
+			final boolean openTop = sameCard(adapter, startPosition - 1, startPosition);
+			final boolean openBottom = sameCard(adapter, endPosition, endPosition + 1);
+			final float top = openTop ? -cornerRadius : firstChild.getTop() + firstChild.getTranslationY();
+			final float bottom = openBottom ? parent.getHeight() + cornerRadius : lastChild.getBottom() + lastChild.getTranslationY();
 			cardRect.set(left, top, right, bottom);
 			canvas.drawRoundRect(cardRect, cornerRadius, cornerRadius, cardPaint);
-			i = runEnd + 1;
+			i = endIndex + 1;
 		}
+	}
+
+	/**
+	 * Walk the visible children after {@code startIndex} while they keep continuing the same card, so
+	 * the card can be painted as a single rectangle across its visible rows.
+	 *
+	 * @param parent     the preference RecyclerView
+	 * @param adapter    the preference adapter
+	 * @param startIndex the index, among the visible children, of the card's first visible row
+	 * @return the index of the card's last visible row
+	 */
+	private int lastVisibleIndexOfCard(RecyclerView parent, PreferenceGroupAdapter adapter, int startIndex) {
+		final int childCount = parent.getChildCount();
+		int endIndex = startIndex;
+		int endPosition = parent.getChildAdapterPosition(parent.getChildAt(startIndex));
+		for (int j = startIndex + 1; j < childCount; j++) {
+			final int nextPosition = parent.getChildAdapterPosition(parent.getChildAt(j));
+			if (nextPosition != endPosition + 1 || !sameCard(adapter, endPosition, nextPosition)) {
+				break;
+			}
+			endPosition = nextPosition;
+			endIndex = j;
+		}
+		return endIndex;
+	}
+
+	/**
+	 * @param adapter       the preference adapter
+	 * @param upperPosition the adapter position of the upper row (may be out of range)
+	 * @param lowerPosition the adapter position directly below it (may be out of range)
+	 * @return whether the two adjacent positions belong to the same card: both are card rows sharing a
+	 *         parent, and the lower one isn't forced onto its own card
+	 */
+	private boolean sameCard(PreferenceGroupAdapter adapter, int upperPosition, int lowerPosition) {
+		if (!isCardRow(adapter, upperPosition) || !isCardRow(adapter, lowerPosition)) {
+			return false;
+		}
+		final Preference lower = adapter.getItem(lowerPosition);
+		if (breakBeforeKeys.contains(lower.getKey())) {
+			return false;
+		}
+		return adapter.getItem(upperPosition).getParent() == lower.getParent();
 	}
 
 	/**
@@ -173,11 +216,10 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 		if (breakBeforeKeys.contains(pref.getKey())) {
 			return true;
 		}
-		final Preference previous = adapter.getItem(position - 1);
-		if (previous instanceof PreferenceCategory) {
+		if (adapter.getItem(position - 1) instanceof PreferenceCategory) {
 			return false;
 		}
-		return previous.getParent() != pref.getParent();
+		return !sameCard(adapter, position - 1, position);
 	}
 
 	/**

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -32,4 +32,9 @@
          at/above it. Reuse the circular gauge's warning/alert hues so the app reads as one system. -->
     <color name="battery_rate_warn">#FFB100</color>
     <color name="battery_rate_high">#E01A00</color>
+
+    <!-- Settings "card group" style (#222): a subtle neutral behind the preference list so the white
+         grouped cards stand out, Material-You style. -->
+    <color name="settings_group_background">#F0F1F4</color>
+    <color name="settings_group_card">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,4 +11,10 @@
     <!-- Small content breathing room at the bottom. On API < 35 the system already insets content
          above the navigation bar, so a large fixed value here just wastes space (see issue #70). -->
     <dimen name="content_navigation_bar_padding">16dp</dimen>
+
+    <!-- Settings "card group" style (#222). horizontal_margin insets both the card outline and the
+         row content so they share one edge; group_gap is the space above each section. -->
+    <dimen name="settings_card_corner_radius">20dp</dimen>
+    <dimen name="settings_card_horizontal_margin">16dp</dimen>
+    <dimen name="settings_card_group_gap">14dp</dimen>
 </resources>


### PR DESCRIPTION
Closes #222.

Restyles all preference screens — the root headers screen plus General / Alerts / Behaviour — from flat rows into grouped rounded **cards**, like modern Android (Material You) settings.

## Approach — native, no new dependency
The whole look is a single paint-time [`PreferenceCardDecoration`](app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/PreferenceCardDecoration.java) (`RecyclerView.ItemDecoration`):

- Consecutive preferences that share a parent are painted as **one rounded, filled card**.
- `PreferenceCategory` titles are left as plain **section labels** on the neutral background above each card.
- Rows are inset horizontally so the row content and the card outline share one margin; the framework's row dividers are dropped (the cards do the grouping).
- A screen can list `breakBeforeKeys` to force a preference onto its own card — used so the root screen's **About/Version footer** sits on a separate card from the nav entries.
- Breathing room is added above the first card and below the last so the groups float top and bottom.

No third-party preference library. Material Components (already a dependency) provides the surfaces; two new colours (`settings_group_background`, `settings_group_card`) and three dimens carry the style.

## Wiring
`GenericPreferenceFragment` and `SettingsActivity.HeaderFragment` apply the decoration in `onViewCreated` (not `onCreateRecyclerView` — clearing the divider there NPEs, since the fragment's list isn't assigned yet).

## Testing
Built and installed to both test devices and reviewed on-device (per the issue's "prototype approved on-device before full rollout"):
- **Huawei Mate 10 Pro** (Android 9)
- **Samsung Galaxy S23+** (One UI)

Verified: root nav card + separated About footer, section labels + cards on each sub-screen, and top/bottom spacing.

## Notes
- **Dark theme:** #222's acceptance lists "light + dark themed", but the app has no dark theme yet (base theme is `Theme.Material3.Light`, no `values-night/`). Split out to #225; the new card colours are named resources so a night variant drops in without touching the decoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
