### PR TITLE
feat: show averaged measured capacity with min/max in Insights

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryCapacityTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryCapacityTracker.java
@@ -135,6 +135,36 @@ public final class BatteryCapacityTracker {
 	}
 
 	/**
+	 * Reads the learned capacity stats for display <em>without</em> folding a new sample — the
+	 * read-only companion to {@link #observeAndAverage}, for the Insights measured-capacity display
+	 * (#116). Returns the averaged capacity with its running min/max so the shown figure is stable
+	 * across refreshes instead of tracking the live counter.
+	 *
+	 * @param context Application context
+	 *
+	 * @return the averaged capacity summary, or {@code null} before the first trusted sample has been
+	 * learned (or on untrusted-counter devices, where the learner is never fed)
+	 */
+	public static CapacitySummary getCapacitySummary(Context context) {
+		return summarize(loadStats(TransientState.prefs(context)));
+	}
+
+	/**
+	 * The display summary under the warm-up rule. Pure so the boundary is unit-testable.
+	 *
+	 * @param stats the stats so far
+	 *
+	 * @return the averaged capacity and its min/max once {@link #MIN_STABLE_SAMPLES} samples are in,
+	 * else {@code null}
+	 */
+	static CapacitySummary summarize(CapacityStats stats) {
+		if (stats.sampleCount() < MIN_STABLE_SAMPLES) {
+			return null;
+		}
+		return new CapacitySummary(Math.round(stats.averageMah()), stats.minMah(), stats.maxMah());
+	}
+
+	/**
 	 * Loads the persisted stats; package-private so the state tests can assert what was stored.
 	 */
 	static CapacityStats loadStats(SharedPreferences prefs) {
@@ -169,5 +199,16 @@ public final class BatteryCapacityTracker {
 	 * @param lastSampleAt when the last sample was folded in, for the spacing rule
 	 */
 	record CapacityStats(float averageMah, int sampleCount, int minMah, int maxMah, long lastSampleAt) {
+	}
+
+	/**
+	 * The read-only view of the learned capacity for display (#116): the averaged full capacity with
+	 * the spread of accepted samples around it.
+	 *
+	 * @param averageMah the running average, rounded to whole mAh — the stable figure to display
+	 * @param minMah     smallest accepted estimate, in mAh
+	 * @param maxMah     largest accepted estimate, in mAh
+	 */
+	public record CapacitySummary(int averageMah, int minMah, int maxMah) {
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -21,6 +21,7 @@ import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
+import com.almothafar.simplebatterynotifier.service.BatteryCapacityTracker;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.util.GeneralHelper;
@@ -42,6 +43,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 	private TextView daysInUseText;
 	private TextView healthDescriptionText;
 	private TextView designCapacityText;
+	private TextView measuredCapacityText;
+	private TextView measuredCapacityRangeText;
 
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {
@@ -67,6 +70,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 		daysInUseText = findViewById(R.id.daysInUseText);
 		healthDescriptionText = findViewById(R.id.healthDescriptionText);
 		designCapacityText = findViewById(R.id.designCapacityText);
+		measuredCapacityText = findViewById(R.id.measuredCapacityText);
+		measuredCapacityRangeText = findViewById(R.id.measuredCapacityRangeText);
 
 		// Tap the warning icon (shown only when the reading can't be trusted, #94) to explain why
 		healthWarningIcon.setOnClickListener(v -> showUnreliableReadingDialog());
@@ -92,19 +97,25 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 * Updates all health data displays with current values from BatteryHealthTracker.
 	 */
 	private void updateHealthData() {
-		// One sticky read and one capacity estimate per refresh (#161): every cycle- and
-		// capacity-derived figure below is computed from these two values.
+		// One sticky read per refresh (#161): every cycle- and capacity-derived figure below is computed
+		// from these values. The capacity figure prefers the STABLE learned average (#116) so both the
+		// health % and the shown capacity stay steady across refreshes; it falls back to this tick's
+		// estimate while the learner warms up (or on untrusted-counter devices, where it never forms).
 		final int osCycles = SystemService.getChargeCycleCount(this);
 		final int cycles = BatteryHealthTracker.getEffectiveCycleCount(this, osCycles);
-		final int capacityMah = SystemService.getBatteryCapacity(this);
+		final BatteryCapacityTracker.CapacitySummary capacity = BatteryCapacityTracker.getCapacitySummary(this);
+		final int capacityMah = capacity != null ? capacity.averageMah() : SystemService.getBatteryCapacity(this);
 
 		// Always show the resolved health figure (measured, else cycle-based).
 		showResolvedHealth(cycles, BatteryHealthTracker.isCycleCountFromOs(osCycles), capacityMah);
 
 		// When the device's charge counter can't be trusted (#94) the figure may be wrong: keep showing
 		// it, but flag it with a tappable warning that explains why (and the failing-battery edge case).
-		healthWarningIcon.setVisibility(BatteryHealthTracker.isBatteryReadingUnreliable(this, capacityMah)
-		                                ? View.VISIBLE : View.GONE);
+		final boolean unreliable = BatteryHealthTracker.isBatteryReadingUnreliable(this, capacityMah);
+		healthWarningIcon.setVisibility(unreliable ? View.VISIBLE : View.GONE);
+
+		// Averaged measured capacity with its min/max spread (#116).
+		showMeasuredCapacity(capacity, unreliable);
 
 		// Metrics and the design-capacity row are shown the same way in every state.
 		chargeCyclesText.setText(String.valueOf(cycles));
@@ -156,6 +167,28 @@ public class BatteryInsightsActivity extends BaseActivity {
 		healthBasisText.setText(basisRes);
 
 		healthDescriptionText.setText(BatteryHealthTracker.describeHealthGrade(this, grade));
+	}
+
+	/**
+	 * Shows the averaged measured capacity with its min/max spread (#116). The learner averages many
+	 * spaced, trust-gated samples, so the figure is stable across refreshes instead of tracking the
+	 * live counter. Before the average forms, shows "Unknown" when the counter can't be trusted on this
+	 * device (#94) and "calculating" while a trusted device is still warming up.
+	 *
+	 * @param capacity   the learned capacity summary, or null when none has formed yet
+	 * @param unreliable whether this device's charge-counter reading can't be trusted (#94)
+	 */
+	private void showMeasuredCapacity(final BatteryCapacityTracker.CapacitySummary capacity, final boolean unreliable) {
+		if (capacity == null) {
+			measuredCapacityText.setText(unreliable ? R.string.unknown : R.string.battery_value_calculating);
+			measuredCapacityRangeText.setVisibility(View.GONE);
+			return;
+		}
+		// Pass the numbers as Strings so they render in Western digits (0-9) in every locale (#96).
+		measuredCapacityText.setText(getString(R.string.design_capacity_value, String.valueOf(capacity.averageMah())));
+		measuredCapacityRangeText.setText(getString(R.string.measured_capacity_range,
+				String.valueOf(capacity.minMah()), String.valueOf(capacity.maxMah())));
+		measuredCapacityRangeText.setVisibility(View.VISIBLE);
 	}
 
 	/**
@@ -292,7 +325,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 		inputLayout.addView(input);
 
 		final int stored = BatteryHealthTracker.getDesignCapacity(this);
-		final int prefill = stored > 0 ? stored : SystemService.getBatteryCapacity(this);
+		final int prefill = stored > 0 ? stored : measuredCapacityForPrefill();
 		if (prefill > 0) {
 			input.setText(String.valueOf(prefill));
 			input.setSelection(String.valueOf(prefill).length());
@@ -326,6 +359,17 @@ public class BatteryInsightsActivity extends BaseActivity {
 			}
 		});
 		dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(v -> lookUpBatteryModel());
+	}
+
+	/**
+	 * The measured capacity to prefill the design-capacity field with when the user hasn't set one:
+	 * the stable learned average (#116) when available, else this tick's estimate, else 0 (no prefill).
+	 *
+	 * @return a measured capacity in mAh, or 0 when none is available
+	 */
+	private int measuredCapacityForPrefill() {
+		final BatteryCapacityTracker.CapacitySummary capacity = BatteryCapacityTracker.getCapacitySummary(this);
+		return capacity != null ? capacity.averageMah() : SystemService.getBatteryCapacity(this);
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -43,8 +43,11 @@ public class BatteryInsightsActivity extends BaseActivity {
 	private TextView daysInUseText;
 	private TextView healthDescriptionText;
 	private TextView designCapacityText;
+	private ImageView healthMeasuredInfoIcon;
 	private TextView measuredCapacityText;
-	private TextView measuredCapacityRangeText;
+	private View measuredCapacityRange;
+	private TextView measuredCapacityMinText;
+	private TextView measuredCapacityMaxText;
 
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {
@@ -70,11 +73,17 @@ public class BatteryInsightsActivity extends BaseActivity {
 		daysInUseText = findViewById(R.id.daysInUseText);
 		healthDescriptionText = findViewById(R.id.healthDescriptionText);
 		designCapacityText = findViewById(R.id.designCapacityText);
+		healthMeasuredInfoIcon = findViewById(R.id.healthMeasuredInfoIcon);
 		measuredCapacityText = findViewById(R.id.measuredCapacityText);
-		measuredCapacityRangeText = findViewById(R.id.measuredCapacityRangeText);
+		measuredCapacityRange = findViewById(R.id.measuredCapacityRange);
+		measuredCapacityMinText = findViewById(R.id.measuredCapacityMinText);
+		measuredCapacityMaxText = findViewById(R.id.measuredCapacityMaxText);
 
 		// Tap the warning icon (shown only when the reading can't be trusted, #94) to explain why
 		healthWarningIcon.setOnClickListener(v -> showUnreliableReadingDialog());
+
+		// Tap the info icon (shown only when health is measured, #116) to explain the averaging
+		healthMeasuredInfoIcon.setOnClickListener(v -> showMeasuredHealthInfoDialog());
 
 		// Tap the design-capacity card to set/edit the rated capacity
 		findViewById(R.id.designCapacityCard).setOnClickListener(v -> showDesignCapacityDialog());
@@ -165,6 +174,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 		                       ? R.string.health_basis_estimated_os
 		                       : R.string.health_basis_estimated_tracked;
 		healthBasisText.setText(basisRes);
+		// The averaging explainer only applies to the measured figure (#116); hide it for the estimate.
+		healthMeasuredInfoIcon.setVisibility(measured ? View.VISIBLE : View.GONE);
 
 		healthDescriptionText.setText(BatteryHealthTracker.describeHealthGrade(this, grade));
 	}
@@ -181,14 +192,26 @@ public class BatteryInsightsActivity extends BaseActivity {
 	private void showMeasuredCapacity(final BatteryCapacityTracker.CapacitySummary capacity, final boolean unreliable) {
 		if (capacity == null) {
 			measuredCapacityText.setText(unreliable ? R.string.unknown : R.string.battery_value_calculating);
-			measuredCapacityRangeText.setVisibility(View.GONE);
+			measuredCapacityRange.setVisibility(View.GONE);
 			return;
 		}
 		// Pass the numbers as Strings so they render in Western digits (0-9) in every locale (#96).
 		measuredCapacityText.setText(getString(R.string.design_capacity_value, String.valueOf(capacity.averageMah())));
-		measuredCapacityRangeText.setText(getString(R.string.measured_capacity_range,
-				String.valueOf(capacity.minMah()), String.valueOf(capacity.maxMah())));
-		measuredCapacityRangeText.setVisibility(View.VISIBLE);
+		measuredCapacityMinText.setText(String.valueOf(capacity.minMah()));
+		measuredCapacityMaxText.setText(String.valueOf(capacity.maxMah()));
+		measuredCapacityRange.setVisibility(View.VISIBLE);
+	}
+
+	/**
+	 * Explains that the measured health figure is derived from the battery's capacity averaged over
+	 * many spaced readings, so it stays stable instead of tracking a single fluctuating sample (#116).
+	 */
+	private void showMeasuredHealthInfoDialog() {
+		new MaterialAlertDialogBuilder(this)
+				.setTitle(R.string.health_measured_info_dialog_title)
+				.setMessage(R.string.health_measured_info_dialog_message)
+				.setPositiveButton(android.R.string.ok, null)
+				.show();
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -26,6 +26,9 @@ import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
 /**
  * Activity displaying battery health insights including charge cycles and estimated health.
  */
@@ -113,7 +116,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 		final int osCycles = SystemService.getChargeCycleCount(this);
 		final int cycles = BatteryHealthTracker.getEffectiveCycleCount(this, osCycles);
 		final BatteryCapacityTracker.CapacitySummary capacity = BatteryCapacityTracker.getCapacitySummary(this);
-		final int capacityMah = capacity != null ? capacity.averageMah() : SystemService.getBatteryCapacity(this);
+		final int capacityMah = stableOrLiveCapacityMah(capacity);
 
 		// Always show the resolved health figure (measured, else cycle-based).
 		showResolvedHealth(cycles, BatteryHealthTracker.isCycleCountFromOs(osCycles), capacityMah);
@@ -189,8 +192,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 * @param capacity   the learned capacity summary, or null when none has formed yet
 	 * @param unreliable whether this device's charge-counter reading can't be trusted (#94)
 	 */
-	private void showMeasuredCapacity(final BatteryCapacityTracker.CapacitySummary capacity, final boolean unreliable) {
-		if (capacity == null) {
+	private void showMeasuredCapacity(BatteryCapacityTracker.CapacitySummary capacity, boolean unreliable) {
+		if (isNull(capacity)) {
 			measuredCapacityText.setText(unreliable ? R.string.unknown : R.string.battery_value_calculating);
 			measuredCapacityRange.setVisibility(View.GONE);
 			return;
@@ -391,8 +394,20 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 * @return a measured capacity in mAh, or 0 when none is available
 	 */
 	private int measuredCapacityForPrefill() {
-		final BatteryCapacityTracker.CapacitySummary capacity = BatteryCapacityTracker.getCapacitySummary(this);
-		return capacity != null ? capacity.averageMah() : SystemService.getBatteryCapacity(this);
+		return stableOrLiveCapacityMah(BatteryCapacityTracker.getCapacitySummary(this));
+	}
+
+	/**
+	 * The capacity figure to display and measure health from: the stable learned average once one has
+	 * formed (#116), else this tick's live estimate while the learner warms up (or on untrusted-counter
+	 * devices, where no average forms).
+	 *
+	 * @param capacity the learned capacity summary, or null when none has formed yet
+	 *
+	 * @return a capacity in mAh, or 0 when neither the average nor a live estimate is available
+	 */
+	private int stableOrLiveCapacityMah(BatteryCapacityTracker.CapacitySummary capacity) {
+		return nonNull(capacity) ? capacity.averageMah() : SystemService.getBatteryCapacity(this);
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/BatteryDetailsFragment.java
@@ -489,11 +489,14 @@ public class BatteryDetailsFragment extends Fragment {
 			valuesMap.put(getResources().getString(R.string.chipset), soc);
 		}
 
-		// Capacity is an estimate from BatteryManager. Show "Unknown" rather than "0 mAh" when the device
-		// doesn't report the charge counter, and also when the reported figure can't be trusted (#94) —
-		// in that case the row binder adds a tappable info icon explaining why. The snapshot's capacity
-		// is passed down so no second capacity estimate is read this tick (#161).
-		final int capacity = batteryDO.getCapacity();
+		// Capacity is an estimate from BatteryManager. Prefer the STABLE learned average (#116) so the row
+		// doesn't jump between refreshes; fall back to this tick's estimate while the learner warms up or on
+		// untrusted-counter devices (where the average never forms). Show "Unknown" rather than "0 mAh" when
+		// the device doesn't report the charge counter, and also when the reported figure can't be trusted
+		// (#94) — in that case the row binder adds a tappable info icon explaining why. The snapshot's
+		// capacity is passed down so no second capacity estimate is read this tick (#161).
+		final int stableCapacity = batteryDO.getStableCapacityMah();
+		final int capacity = stableCapacity > 0 ? stableCapacity : batteryDO.getCapacity();
 		capacityUnreliable = BatteryHealthTracker.isBatteryReadingUnreliable(view.getContext(), capacity);
 		final String capacityText = (capacity > 0 && !capacityUnreliable)
 		                            ? capacity + " mAh"

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -113,43 +113,100 @@
                 </LinearLayout>
             </androidx.cardview.widget.CardView>
 
-            <!-- Design Capacity Card (tap to set/edit the rated capacity) -->
-            <androidx.cardview.widget.CardView
-                    android:id="@+id/designCapacityCard"
+            <!-- Capacity row: measured (learned average, #116) alongside the user-entered rated capacity -->
+            <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="16dp"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground"
-                    app:cardCornerRadius="8dp"
-                    app:cardElevation="4dp"
-                    app:contentPadding="16dp">
+                    android:orientation="horizontal"
+                    android:weightSum="2"
+                    android:layout_marginBottom="16dp">
 
-                <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical">
+                <!-- Measured Capacity Card (averaged estimate with its min/max spread, #116) -->
+                <androidx.cardview.widget.CardView
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:layout_marginEnd="8dp"
+                        app:cardCornerRadius="8dp"
+                        app:cardElevation="4dp"
+                        app:contentPadding="16dp">
 
-                    <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/design_capacity"
-                            android:textSize="14sp"
-                            android:textColor="@color/battery_details_label_color"
-                            android:layout_marginBottom="8dp"/>
-
-                    <TextView
-                            android:id="@+id/designCapacityText"
+                    <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="@string/set_design_capacity_action"
-                            android:textSize="18sp"
-                            android:textStyle="bold"
-                            android:textColor="@color/battery_details_value_color"/>
+                            android:orientation="vertical">
 
-                </LinearLayout>
-            </androidx.cardview.widget.CardView>
+                        <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/measured_capacity"
+                                android:textSize="14sp"
+                                android:textColor="@color/battery_details_label_color"
+                                android:layout_marginBottom="8dp"/>
+
+                        <TextView
+                                android:id="@+id/measuredCapacityText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/battery_value_calculating"
+                                android:textSize="18sp"
+                                android:textStyle="bold"
+                                android:textColor="@color/battery_details_value_color"/>
+
+                        <TextView
+                                android:id="@+id/measuredCapacityRangeText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:textSize="12sp"
+                                android:textColor="@color/battery_details_label_color"
+                                android:layout_marginTop="4dp"
+                                android:visibility="gone"
+                                tools:text="min / max: 4420 / 4580 mAh"
+                                tools:visibility="visible"/>
+
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+
+                <!-- Design Capacity Card (tap to set/edit the rated capacity) -->
+                <androidx.cardview.widget.CardView
+                        android:id="@+id/designCapacityCard"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:layout_marginStart="8dp"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground"
+                        app:cardCornerRadius="8dp"
+                        app:cardElevation="4dp"
+                        app:contentPadding="16dp">
+
+                    <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical">
+
+                        <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/design_capacity"
+                                android:textSize="14sp"
+                                android:textColor="@color/battery_details_label_color"
+                                android:layout_marginBottom="8dp"/>
+
+                        <TextView
+                                android:id="@+id/designCapacityText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/set_design_capacity_action"
+                                android:textSize="18sp"
+                                android:textStyle="bold"
+                                android:textColor="@color/battery_details_value_color"/>
+
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+
+            </LinearLayout>
 
             <!-- Metrics Grid -->
             <LinearLayout

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -101,14 +101,36 @@
                                 tools:visibility="visible"/>
                     </LinearLayout>
 
-                    <TextView
-                            android:id="@+id/healthBasisText"
+                    <!-- Basis line + (when measured, #116) a tappable info icon explaining the averaging -->
+                    <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/health_basis_estimated_os"
-                            android:textSize="12sp"
-                            android:textColor="@color/battery_details_label_color"
-                            android:layout_marginTop="4dp"/>
+                            android:orientation="horizontal"
+                            android:gravity="center_vertical"
+                            android:layout_marginTop="4dp">
+
+                        <TextView
+                                android:id="@+id/healthBasisText"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/health_basis_estimated_os"
+                                android:textSize="12sp"
+                                android:textColor="@color/battery_details_label_color"/>
+
+                        <ImageView
+                                android:id="@+id/healthMeasuredInfoIcon"
+                                android:layout_width="18dp"
+                                android:layout_height="18dp"
+                                android:layout_marginStart="4dp"
+                                android:src="@drawable/ic_info"
+                                android:background="?attr/selectableItemBackgroundBorderless"
+                                android:clickable="true"
+                                android:focusable="true"
+                                android:contentDescription="@string/health_measured_info_cd"
+                                android:visibility="gone"
+                                tools:visibility="visible"/>
+
+                    </LinearLayout>
 
                 </LinearLayout>
             </androidx.cardview.widget.CardView>
@@ -153,16 +175,64 @@
                                 android:textStyle="bold"
                                 android:textColor="@color/battery_details_value_color"/>
 
-                        <TextView
-                                android:id="@+id/measuredCapacityRangeText"
+                        <!-- min / max spread as a compact two-column mini-table (label above value) -->
+                        <LinearLayout
+                                android:id="@+id/measuredCapacityRange"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:textSize="12sp"
-                                android:textColor="@color/battery_details_label_color"
-                                android:layout_marginTop="4dp"
+                                android:orientation="horizontal"
+                                android:weightSum="2"
+                                android:layout_marginTop="8dp"
                                 android:visibility="gone"
-                                tools:text="min / max: 4420 / 4580 mAh"
-                                tools:visibility="visible"/>
+                                tools:visibility="visible">
+
+                            <LinearLayout
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
+                                    android:orientation="vertical">
+
+                                <TextView
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:text="@string/capacity_min_label"
+                                        android:textSize="11sp"
+                                        android:textColor="@color/battery_details_label_color"/>
+
+                                <TextView
+                                        android:id="@+id/measuredCapacityMinText"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textSize="14sp"
+                                        android:textColor="@color/battery_details_value_color"
+                                        tools:text="4420"/>
+
+                            </LinearLayout>
+
+                            <LinearLayout
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
+                                    android:orientation="vertical">
+
+                                <TextView
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:text="@string/capacity_max_label"
+                                        android:textSize="11sp"
+                                        android:textColor="@color/battery_details_label_color"/>
+
+                                <TextView
+                                        android:id="@+id/measuredCapacityMaxText"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textSize="14sp"
+                                        android:textColor="@color/battery_details_value_color"
+                                        tools:text="4580"/>
+
+                            </LinearLayout>
+
+                        </LinearLayout>
 
                     </LinearLayout>
                 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -254,6 +254,8 @@
     <string name="battery_health_description_placeholder">ستظهر معلومات صحة بطاريتك هنا.</string>
     <string name="design_capacity">السعة التصميمية</string>
     <string name="design_capacity_value">%1$s mAh</string>
+    <string name="measured_capacity">السعة المقاسة</string>
+    <string name="measured_capacity_range">الأدنى / الأعلى: %1$s / %2$s mAh</string>
     <string name="set_design_capacity_action">أدخل السعة المقدّرة لحساب صحة أدق</string>
     <string name="design_capacity_dialog_title">السعة التصميمية للبطارية</string>
     <string name="design_capacity_dialog_message">أدخل السعة المقدّرة لبطاريتك بوحدة mAh من مواصفات الشركة المصنّعة. لقد عبّأنا تقديراً مقاساً — أكّده أو صحّحه للحصول على قيمة صحة دقيقة.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -255,7 +255,11 @@
     <string name="design_capacity">السعة التصميمية</string>
     <string name="design_capacity_value">%1$s mAh</string>
     <string name="measured_capacity">السعة المقاسة</string>
-    <string name="measured_capacity_range">الأدنى / الأعلى: %1$s / %2$s mAh</string>
+    <string name="capacity_min_label">الأدنى</string>
+    <string name="capacity_max_label">الأعلى</string>
+    <string name="health_measured_info_cd">كيف تُقاس صحة البطارية</string>
+    <string name="health_measured_info_dialog_title">كيف يُحسب هذا</string>
+    <string name="health_measured_info_dialog_message">تقارن قيمة الصحة هذه السعة المقاسة لبطاريتك بالسعة المقدّرة التي أدخلتها. تُحسب السعة المقاسة كمتوسط لعدة قراءات على مدى الوقت، لذا تبقى ثابتة بدلاً من التغيّر مع كل تحديث. يوضّح الأدنى والأعلى مدى تفاوت تلك القراءات.</string>
     <string name="set_design_capacity_action">أدخل السعة المقدّرة لحساب صحة أدق</string>
     <string name="design_capacity_dialog_title">السعة التصميمية للبطارية</string>
     <string name="design_capacity_dialog_message">أدخل السعة المقدّرة لبطاريتك بوحدة mAh من مواصفات الشركة المصنّعة. لقد عبّأنا تقديراً مقاساً — أكّده أو صحّحه للحصول على قيمة صحة دقيقة.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -259,7 +259,7 @@
     <string name="capacity_max_label">الأعلى</string>
     <string name="health_measured_info_cd">كيف تُقاس صحة البطارية</string>
     <string name="health_measured_info_dialog_title">كيف يُحسب هذا</string>
-    <string name="health_measured_info_dialog_message">تقارن قيمة الصحة هذه السعة المقاسة لبطاريتك بالسعة المقدّرة التي أدخلتها. تُحسب السعة المقاسة كمتوسط لعدة قراءات على مدى الوقت، لذا تبقى ثابتة بدلاً من التغيّر مع كل تحديث. يوضّح الأدنى والأعلى مدى تفاوت تلك القراءات.</string>
+    <string name="health_measured_info_dialog_message">تقارن قيمة الصحة هذه السعة المقاسة لبطاريتك بالسعة التصميمية التي أدخلتها. تُحسب السعة المقاسة كمتوسط لعدة قراءات على مدى الوقت، لذا تبقى ثابتة بدلاً من التغيّر مع كل تحديث. يوضّح الأدنى والأعلى مدى تفاوت تلك القراءات.</string>
     <string name="set_design_capacity_action">أدخل السعة المقدّرة لحساب صحة أدق</string>
     <string name="design_capacity_dialog_title">السعة التصميمية للبطارية</string>
     <string name="design_capacity_dialog_message">أدخل السعة المقدّرة لبطاريتك بوحدة mAh من مواصفات الشركة المصنّعة. لقد عبّأنا تقديراً مقاساً — أكّده أو صحّحه للحصول على قيمة صحة دقيقة.</string>
@@ -271,7 +271,7 @@
     <string name="save">حفظ</string>
     <string name="clear">مسح</string>
     <string name="error_design_capacity_range">أدخل سعة بين %1$d و %2$d mAh</string>
-    <string name="health_basis_measured">متوسط السعة المقاسة مقابل المقدّرة</string>
+    <string name="health_basis_measured">متوسط السعة المقاسة مقابل التصميمية</string>
     <!-- #114: cycle-based estimate labelled by its source -->
     <string name="health_basis_estimated_os">مقدّرة من دورات الشحن (كما يبلغ عنها أندرويد)</string>
     <string name="health_basis_estimated_tracked">مقدّرة من الدورات المتتبَّعة منذ التثبيت — التآكل الفعلي قد يكون أعلى</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -271,7 +271,7 @@
     <string name="save">حفظ</string>
     <string name="clear">مسح</string>
     <string name="error_design_capacity_range">أدخل سعة بين %1$d و %2$d mAh</string>
-    <string name="health_basis_measured">مقاسة من السعة المقدّرة</string>
+    <string name="health_basis_measured">متوسط السعة المقاسة مقابل المقدّرة</string>
     <!-- #114: cycle-based estimate labelled by its source -->
     <string name="health_basis_estimated_os">مقدّرة من دورات الشحن (كما يبلغ عنها أندرويد)</string>
     <string name="health_basis_estimated_tracked">مقدّرة من الدورات المتتبَّعة منذ التثبيت — التآكل الفعلي قد يكون أعلى</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,10 @@
     <string name="design_capacity">Design Capacity</string>
     <!-- %1$s is a Western-digit number (passed via String.valueOf) so it stays 0-9 in every locale (#96) -->
     <string name="design_capacity_value">%1$s mAh</string>
+    <!-- #116: averaged measured capacity shown in Insights, with its min/max spread as a caption -->
+    <string name="measured_capacity">Measured Capacity</string>
+    <!-- %1$s / %2$s are Western-digit numbers (via String.valueOf) so they stay 0-9 in every locale (#96) -->
+    <string name="measured_capacity_range">min / max: %1$s / %2$s mAh</string>
     <string name="set_design_capacity_action">Set rated capacity for accurate health</string>
     <string name="design_capacity_dialog_title">Battery design capacity</string>
     <string name="design_capacity_dialog_message">Enter your battery\'s rated capacity in mAh from the manufacturer\'s specs. We\'ve prefilled a measured estimate — confirm or correct it for an accurate health figure.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,7 +286,7 @@
     <string name="save">Save</string>
     <string name="clear">Clear</string>
     <string name="error_design_capacity_range">Enter a capacity between %1$d and %2$d mAh</string>
-    <string name="health_basis_measured">Measured from rated capacity</string>
+    <string name="health_basis_measured">Averaged measured capacity vs rated</string>
     <!-- #114: the cycle-based estimate is labelled by its source. OS-reported cycles cover the
          battery's whole life; app-tracked cycles start at install, so they understate real wear. -->
     <string name="health_basis_estimated_os">Estimated from charge cycles (reported by Android)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,10 +267,14 @@
     <string name="design_capacity">Design Capacity</string>
     <!-- %1$s is a Western-digit number (passed via String.valueOf) so it stays 0-9 in every locale (#96) -->
     <string name="design_capacity_value">%1$s mAh</string>
-    <!-- #116: averaged measured capacity shown in Insights, with its min/max spread as a caption -->
+    <!-- #116: averaged measured capacity shown in Insights, with its min/max spread as a mini-table -->
     <string name="measured_capacity">Measured Capacity</string>
-    <!-- %1$s / %2$s are Western-digit numbers (via String.valueOf) so they stay 0-9 in every locale (#96) -->
-    <string name="measured_capacity_range">min / max: %1$s / %2$s mAh</string>
+    <string name="capacity_min_label">min</string>
+    <string name="capacity_max_label">max</string>
+    <!-- Info icon (#116) explaining that the measured health/capacity is averaged over many readings -->
+    <string name="health_measured_info_cd">How battery health is measured</string>
+    <string name="health_measured_info_dialog_title">How this is measured</string>
+    <string name="health_measured_info_dialog_message">This health figure compares your battery\'s measured capacity against the rated capacity you entered. The measured capacity is averaged over many readings taken over time, so it stays steady instead of jumping with each refresh. The min and max show the spread of those readings.</string>
     <string name="set_design_capacity_action">Set rated capacity for accurate health</string>
     <string name="design_capacity_dialog_title">Battery design capacity</string>
     <string name="design_capacity_dialog_message">Enter your battery\'s rated capacity in mAh from the manufacturer\'s specs. We\'ve prefilled a measured estimate — confirm or correct it for an accurate health figure.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -274,7 +274,7 @@
     <!-- Info icon (#116) explaining that the measured health/capacity is averaged over many readings -->
     <string name="health_measured_info_cd">How battery health is measured</string>
     <string name="health_measured_info_dialog_title">How this is measured</string>
-    <string name="health_measured_info_dialog_message">This health figure compares your battery\'s measured capacity against the rated capacity you entered. The measured capacity is averaged over many readings taken over time, so it stays steady instead of jumping with each refresh. The min and max show the spread of those readings.</string>
+    <string name="health_measured_info_dialog_message">This health figure compares your battery\'s measured capacity against the design capacity you entered. The measured capacity is averaged over many readings taken over time, so it stays steady instead of jumping with each refresh. The min and max show the spread of those readings.</string>
     <string name="set_design_capacity_action">Set rated capacity for accurate health</string>
     <string name="design_capacity_dialog_title">Battery design capacity</string>
     <string name="design_capacity_dialog_message">Enter your battery\'s rated capacity in mAh from the manufacturer\'s specs. We\'ve prefilled a measured estimate — confirm or correct it for an accurate health figure.</string>
@@ -286,7 +286,7 @@
     <string name="save">Save</string>
     <string name="clear">Clear</string>
     <string name="error_design_capacity_range">Enter a capacity between %1$d and %2$d mAh</string>
-    <string name="health_basis_measured">Averaged measured capacity vs rated</string>
+    <string name="health_basis_measured">Averaged measured capacity vs design</string>
     <!-- #114: the cycle-based estimate is labelled by its source. OS-reported cycles cover the
          battery's whole life; app-tracked cycles start at install, so they understate real wear. -->
     <string name="health_basis_estimated_os">Estimated from charge cycles (reported by Android)</string>

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryCapacityTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryCapacityTrackerTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 /**
@@ -135,6 +136,28 @@ public class BatteryCapacityTrackerTest {
 		public void matchesExpected() {
 			final CapacityStats stats = new CapacityStats(averageMah, sampleCount, 0, 0, 0L);
 			assertEquals(label, expected, BatteryCapacityTracker.stableCapacityMah(stats));
+		}
+	}
+
+	/**
+	 * {@link BatteryCapacityTracker#summarize(CapacityStats)}: the display summary (#116) — null until
+	 * enough spaced samples are in, then the average (rounded) with its min/max carried through.
+	 */
+	public static class Summarize {
+
+		@Test
+		public void nullBeforeFirstSample() {
+			assertNull(BatteryCapacityTracker.summarize(NOTHING_LEARNED));
+		}
+
+		@Test
+		public void carriesRoundedAverageWithMinMax() {
+			final CapacityStats stats = new CapacityStats(4390.6f, MIN_SAMPLES, 4300, 4480, 1_000_000L);
+			final BatteryCapacityTracker.CapacitySummary summary = BatteryCapacityTracker.summarize(stats);
+
+			assertEquals(4391, summary.averageMah());
+			assertEquals(4300, summary.minMah());
+			assertEquals(4480, summary.maxMah());
 		}
 	}
 


### PR DESCRIPTION
Closes #116.

## Problem

The battery-health figure and the shown capacity both depended on a **single, instantaneous** charge-counter reading, so they jumped between refreshes and could make health look off.

## What this does

The averaging engine already exists: [`BatteryCapacityTracker`](app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryCapacityTracker.java) (added in #204) already folds spaced, trust-gated samples into a running **average** and tracks **min/max** alongside — "for the Insights capacity display (#116)". This PR wires that output into the UI, so the sampling window / spacing / level-gate decisions from the issue's open questions were already settled there.

- **Read-only accessor** `getCapacitySummary()` (+ pure `summarize()`) exposing `{average, min, max}`, `null` until the first trusted sample forms.
- **Home "Capacity" row** now shows the stable average, falling back to this tick's estimate during warm-up / on untrusted-counter devices. The #94 "Unknown" behaviour is preserved.
- **Insights measured-health %** is driven by the average, not a live sample, so it stops jumping.
- **New "Measured Capacity" card** in Insights, beside Design Capacity: averaged mAh with a `min / max: X / Y mAh` caption; shows "calculating" while warming up and "Unknown" when the counter can't be trusted (#94).
- New strings with **Arabic** translations (please review the Arabic).
- Unit test for the summary warm-up gating.

## Testing

- `:app:testDebugUnitTest` passes (incl. the new `Summarize` cases); `assembleDebug`/`assembleRelease` succeed; no `MissingTranslation`.
- Installed on device for on-screen verification.

## Note for review

The new card sits **side-by-side** with Design Capacity (two-column row). When Design Capacity is unset its hint is long and the min/max caption is long too, so at half-width they wrap a little — if that reads as cramped on device, it can fall back to a stacked full-width card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)