### PR TITLE
feat: rebrand app display name to BattWatch

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">منبه البطارية البسيط</string>
+    <string name="app_name">BattWatch</string>
     <string name="action_settings">الإعدادات</string>
     <string name="title_activity_settings">الإعدادات</string>
     <string name="charging">تشحن</string>
@@ -308,7 +308,7 @@
     <string name="feedback_option_github">الإبلاغ عبر GitHub</string>
     <string name="feedback_option_email">مراسلة المطوّر</string>
     <!-- %1$s is the app version, e.g. 2.0.71 -->
-    <string name="feedback_email_subject">ملاحظات حول تطبيق منبّه البطارية البسيط (v%1$s)</string>
+    <string name="feedback_email_subject">ملاحظات حول تطبيق BattWatch (v%1$s)</string>
     <string name="no_email_app">لا يوجد تطبيق بريد</string>
 
     <!-- About the app -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Simple Battery Notifier</string>
+    <string name="app_name">BattWatch</string>
     <string name="action_settings">Settings</string>
     <string name="title_activity_settings">Settings</string>
     <string name="charging">Charging</string>
@@ -327,7 +327,7 @@
     <string name="feedback_option_github">Report on GitHub</string>
     <string name="feedback_option_email">Email the developer</string>
     <!-- %1$s is the app version, e.g. 2.0.71 -->
-    <string name="feedback_email_subject">Simple Battery Notifier feedback (v%1$s)</string>
+    <string name="feedback_email_subject">BattWatch feedback (v%1$s)</string>
     <string name="no_email_app">No email app found</string>
 
     <!-- About the app -->


### PR DESCRIPTION
## What

Renames the app **display name** from "Simple Battery Notifier" to **BattWatch** in both locales.

This is a display-name change **only** — `applicationId` stays `com.almothafar.simplebatterynotifier`, so Play treats it as a normal in-place update: installs, reviews (the 3.6★ history), and ranking are all preserved. No new listing is created.

## Changes

- `values/strings.xml` + `values-ar/strings.xml`: `app_name` → `BattWatch` (kept **Latin** in Arabic, as a coined brand usually stays Latin even in RTL).
- `feedback_email_subject` (en + ar): use the new name.
- The About dialog title and toolbar already resolve `@string/app_name`, so they update automatically — no manifest or layout edit needed.

## Not in this PR (still tracked in #171)

- Play Store listing copy (title / short / long description, "What's new") — console metadata, submitted manually.
- Launcher / adaptive icon refresh (called out as optional/follow-up).
- Release sequencing: don't flip the name to production on a still-buggy build — this only lands the code; the coordinated relaunch is controlled separately.

## Testing

Built and installed to a Galaxy S23. Verified "BattWatch" shows in the launcher label, main-screen toolbar, Settings header, and About dialog, in both English and Arabic.

Refs #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
