### PR TITLE
chore: rebrand repo and docs to BattWatch

### DIFF
--- a/CODE_REVIEW_GUIDELINES.md
+++ b/CODE_REVIEW_GUIDELINES.md
@@ -1,6 +1,6 @@
 # Code Review Guidelines
 
-These are the coding standards and best practices for the SimpleBatteryNotifier Android project.
+These are the coding standards and best practices for the BattWatch Android project (formerly Simple Battery Notifier).
 
 > **Audience:** this is the human-facing standard for contributors and reviewers. The AI code-review agent has a machine-facing companion at [`.claude/guidelines.md`](.claude/guidelines.md); keep the two in sync when a standard changes.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# 📱 SimpleBatteryNotifier
+# 📱 BattWatch
 
-[![Android CI](https://github.com/almothafar/SimpleBatteryNotifier/workflows/Android%20CI/badge.svg)](https://github.com/almothafar/SimpleBatteryNotifier/actions)
+*Formerly Simple Battery Notifier.*
+
+[![Android CI](https://github.com/almothafar/BattWatch/workflows/Android%20CI/badge.svg)](https://github.com/almothafar/BattWatch/actions)
 [![Android](https://img.shields.io/badge/Android-8.0%2B%20(API%2026%2B)-green?logo=android)](https://developer.android.com/about/versions/oreo)
 [![Java](https://img.shields.io/badge/Java-25-orange?logo=openjdk)](https://openjdk.org/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE.md)
 
 A lightweight Android app to keep you informed about your battery status — without heavy resource usage or unnecessary "power saver" bloat.
 
-## 💡 Why SimpleBatteryNotifier?
+## 💡 Why BattWatch?
 Ever been busy at work or home and suddenly realized your phone is almost out of battery?  
 Or worse — your phone dies while you’re traveling and you can’t recharge it.
 
-Unlike heavy battery saver apps (which Android doesn’t actually need), SimpleBatteryNotifier is designed to:
+Unlike heavy battery saver apps (which Android doesn’t actually need), BattWatch is designed to:
 - Monitor your battery efficiently
 - Send you timely notifications
 - Avoid slowing down your phone or draining your resources
@@ -66,8 +68,8 @@ A packaged release (Google Play / F-Droid / APK) is not published yet. For now, 
 
 ```bash
 # Clone the repository
-git clone https://github.com/almothafar/SimpleBatteryNotifier.git
-cd SimpleBatteryNotifier
+git clone https://github.com/almothafar/BattWatch.git
+cd BattWatch
 
 # Build debug APK
 ./gradlew assembleDebug
@@ -108,7 +110,7 @@ Every pull request and push to master automatically:
 - ✅ Generates test reports
 - ✅ Uploads build artifacts
 
-Check the [Actions tab](https://github.com/almothafar/SimpleBatteryNotifier/actions) for build status.
+Check the [Actions tab](https://github.com/almothafar/BattWatch/actions) for build status.
 
 ---
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/widget/HorseshoeProgressBar.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/widget/HorseshoeProgressBar.java
@@ -1,6 +1,6 @@
 /*
  * HorseshoeProgressBar - an animated horseshoe-shaped progress gauge for Android.
- * Part of Simple Battery Notifier <https://github.com/almothafar/SimpleBatteryNotifier>.
+ * Part of BattWatch (formerly Simple Battery Notifier) <https://github.com/almothafar/BattWatch>.
  *
  * Copyright (C) 2016-2026 Al-Mothafar Al-Hasan <https://github.com/almothafar>
  *

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,7 +340,7 @@
     <string name="about_open_source">Free and open-source software, licensed under the GNU General Public License v3.0.</string>
     <string name="about_disclaimer">Battery readings, health and charging figures come from your device and are estimates — treat them as guidance, not exact measurements. This app is provided “as is”, without warranty of any kind.</string>
     <string name="about_view_github">View on GitHub</string>
-    <string name="about_github_url" translatable="false">https://github.com/almothafar/SimpleBatteryNotifier</string>
+    <string name="about_github_url" translatable="false">https://github.com/almothafar/BattWatch</string>
     <!-- Summary of the version footer at the bottom of the Settings root screen (#113) -->
     <string name="about_footer_hint">Tap for more about this app</string>
 
@@ -416,7 +416,7 @@
     <string name="_default_notification_sound_uri" translatable="false">content://settings/system/notification_sound</string>
 
     <!-- External endpoints — single source of truth for the links/emails used in code -->
-    <string name="feedback_github_url" translatable="false">https://github.com/almothafar/SimpleBatteryNotifier/issues/new/choose</string>
+    <string name="feedback_github_url" translatable="false">https://github.com/almothafar/BattWatch/issues/new/choose</string>
     <string name="feedback_support_email" translatable="false">support@almothafar.com</string>
 
     <!-- Accessibility -->

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,5 +12,5 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "SimpleBatteryNotifier"
+rootProject.name = "BattWatch"
 include(":app")


### PR DESCRIPTION
## What

Rebrands the repo's public-facing docs and URLs to **BattWatch**, and renames the GitHub repo `SimpleBatteryNotifier` → `BattWatch`. Follow-up to #171 (display-name rebrand).

## Changes

- **README.md** — title, "Why" heading + body, clone dir, CI badge + Actions links; added a *"Formerly Simple Battery Notifier."* subtitle for continuity/search.
- **CODE_REVIEW_GUIDELINES.md** — project name (with "formerly" note).
- **strings.xml** — `about_github_url` and `feedback_github_url` → `/BattWatch`.
- **settings.gradle** — `rootProject.name` → `BattWatch`.
- **HorseshoeProgressBar.java** — license-header project name + repo URL.
- **GitHub repo renamed** to `almothafar/BattWatch` (done alongside this PR; GitHub redirects the old URLs, clone URLs, and every issue/PR permalink indefinitely).

## Explicitly NOT touched (identity)

- `applicationId = com.almothafar.simplebatterynotifier` and `namespace` — unchanged, so this stays a normal in-place Play update.
- Every `com.almothafar.simplebatterynotifier.*` reference (package path, `tools:context`, fragment names, custom-view tags) — follows the package, not the repo.
- `developer_link` (`github.com/almothafar`) — that's the profile, not the repo.
- `CHANGELOG.md` — release-please-managed history; its old links redirect.

## Verification

- Debug build passes.
- Old repo URL redirects confirmed working (GitHub 301s `SimpleBatteryNotifier` → `BattWatch`).

Refs #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
