### PR TITLE
fix: format quiet-hours time with the shared locale-safe helper

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreferenceDialogFragmentCompat.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreferenceDialogFragmentCompat.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.widget.TimePicker;
 import androidx.annotation.NonNull;
 import androidx.preference.PreferenceDialogFragmentCompat;
+import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 
 /**
  * Dialog fragment for TimePickerPreference
@@ -67,16 +68,28 @@ public class TimePickerPreferenceDialogFragmentCompat extends PreferenceDialogFr
 	public void onDialogClosed(final boolean positiveResult) {
 		if (positiveResult) {
 			// Get the current values from the TimePicker
-			final int hour = timePicker.getHour();
-			final int minute = timePicker.getMinute();
+			savePickedTime((TimePickerPreference) getPreference(), timePicker.getHour(), timePicker.getMinute());
+		}
+	}
 
-			final TimePickerPreference preference = (TimePickerPreference) getPreference();
+	/**
+	 * Write a picked time to the preference in the canonical persisted form.
+	 * <p>
+	 * Formatting goes through {@link GeneralHelper#formatTime(int, int)} rather than a local
+	 * {@code String.format}: the default locale under Arabic renders Eastern Arabic numerals, so a
+	 * hand-rolled format hands {@code ٠٨:٣٠} to the change listeners and to {@code setTime} (issue
+	 * #241 — the same defect as #154, which fixed the helper but not this call site). Split out from
+	 * {@link #onDialogClosed(boolean)} so the writing path is unit-testable without a live dialog.
+	 *
+	 * @param preference the preference being edited
+	 * @param hour       picked hour of day (0-23)
+	 * @param minute     picked minute of hour (0-59)
+	 */
+	static void savePickedTime(final TimePickerPreference preference, final int hour, final int minute) {
+		final String time = GeneralHelper.formatTime(hour, minute);
 
-			final String time = String.format("%02d:%02d", hour, minute);
-
-			if (preference.callChangeListener(time)) {
-				preference.setTime(time);
-			}
+		if (preference.callChangeListener(time)) {
+			preference.setTime(time);
 		}
 	}
 }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreferenceDialogFragmentCompatTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreferenceDialogFragmentCompatTest.java
@@ -1,0 +1,125 @@
+package com.almothafar.simplebatterynotifier.ui.preference;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Robolectric tests for the dialog's save path (issue #241).
+ * <p>
+ * {@code GeneralHelperTest} already pins {@link com.almothafar.simplebatterynotifier.util.GeneralHelper#formatTime}
+ * to Western digits, but that test passes whether or not this dialog calls it — which is exactly how
+ * the #154 fix left a hand-rolled {@code String.format("%02d:%02d", ...)} here for another release.
+ * These tests exercise the <em>call site</em> under an Arabic default locale, so the writer can't
+ * silently stop using the shared helper again.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class TimePickerPreferenceDialogFragmentCompatTest {
+
+	/**
+	 * The Arabic locale that actually reproduces the bug. CLDR selects the {@code arab} numbering
+	 * system only for region-bearing Arabic locales: under bare {@code "ar"} the zero digit is
+	 * Western {@code '0'}, so a test written against {@code Locale.forLanguageTag("ar")} passes even
+	 * with the defect present — which is how issue #241 survived the #154 fix.
+	 */
+	private static final Locale ARABIC_EASTERN_DIGITS = Locale.forLanguageTag("ar-EG");
+
+	private Locale originalLocale;
+	private Context context;
+
+	@Before
+	public void setUp() {
+		originalLocale = Locale.getDefault();
+		Locale.setDefault(ARABIC_EASTERN_DIGITS);
+		// Premise first: without it these tests pass against the defect they exist to catch.
+		assertEquals("guard locale no longer emits Eastern Arabic digits — pick one that does",
+				"٠٨:٣٠", String.format("%02d:%02d", 8, 30));
+		context = ApplicationProvider.getApplicationContext();
+	}
+
+	@After
+	public void tearDown() {
+		Locale.setDefault(originalLocale);
+	}
+
+	/**
+	 * The value handed to the change listeners is the raw string the dialog built — nothing
+	 * normalizes it on the way out, so this is where Eastern Arabic digits escape.
+	 */
+	@Test
+	public void offersWesternDigitsToChangeListeners() {
+		final TimePickerPreference preference = new TimePickerPreference(context);
+		final List<Object> offered = new ArrayList<>();
+		preference.setOnPreferenceChangeListener((pref, newValue) -> {
+			offered.add(newValue);
+			return true;
+		});
+
+		TimePickerPreferenceDialogFragmentCompat.savePickedTime(preference, 8, 30);
+
+		assertEquals(List.of("08:30"), offered);
+	}
+
+	/**
+	 * A listener that vetoes the change must leave the stored time untouched — the guard around
+	 * {@code setTime} is part of the save path, so it is worth holding in place.
+	 */
+	@Test
+	public void keepsPreviousTimeWhenChangeIsVetoed() {
+		final TimePickerPreference preference = new TimePickerPreference(context);
+		preference.setTime("06:30");
+		preference.setOnPreferenceChangeListener((pref, newValue) -> false);
+
+		TimePickerPreferenceDialogFragmentCompat.savePickedTime(preference, 8, 30);
+
+		assertEquals(6, preference.getHour());
+		assertEquals(30, preference.getMinute());
+	}
+
+	/**
+	 * End to end through the preference: the picked time survives the round trip as the same
+	 * hour/minute, and reads back in the canonical Western-digit form.
+	 */
+	@Test
+	public void storesPickedTimeInCanonicalForm() {
+		final TimePickerPreference preference = new TimePickerPreference(context);
+
+		TimePickerPreferenceDialogFragmentCompat.savePickedTime(preference, 8, 30);
+
+		assertEquals(8, preference.getHour());
+		assertEquals(30, preference.getMinute());
+		assertEquals("08:30", preference.getTime());
+	}
+
+	/**
+	 * Midnight is the value a corrupt-pref reset falls back to, so pinning it here keeps a passing
+	 * "00:00" from being mistaken for a real save in the other tests.
+	 */
+	@Test
+	public void zeroPadsMidnight() {
+		final TimePickerPreference preference = new TimePickerPreference(context);
+		final List<Object> offered = new ArrayList<>();
+		preference.setOnPreferenceChangeListener((pref, newValue) -> {
+			offered.add(newValue);
+			return true;
+		});
+
+		TimePickerPreferenceDialogFragmentCompat.savePickedTime(preference, 0, 0);
+
+		assertEquals(List.of("00:00"), offered);
+	}
+}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/util/GeneralHelperTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/util/GeneralHelperTest.java
@@ -72,6 +72,14 @@ public class GeneralHelperTest {
 	 */
 	public static class FormatTime {
 
+		/**
+		 * The Arabic locale that actually reproduces the bug. CLDR selects the {@code arab} numbering
+		 * system only for region-bearing Arabic locales: under bare {@code "ar"} the zero digit is
+		 * Western {@code '0'}, so a test written against {@code Locale.forLanguageTag("ar")} passes
+		 * even with the defect present — which is how issue #241 survived the #154 fix.
+		 */
+		private static final Locale ARABIC_EASTERN_DIGITS = Locale.forLanguageTag("ar-EG");
+
 		@Test
 		public void writesZeroPaddedHhMm() {
 			assertEquals("06:30", GeneralHelper.formatTime(6, 30));
@@ -83,7 +91,10 @@ public class GeneralHelperTest {
 		public void keepsWesternDigitsUnderArabicDefaultLocale() {
 			final Locale original = Locale.getDefault();
 			try {
-				Locale.setDefault(Locale.forLanguageTag("ar"));
+				Locale.setDefault(ARABIC_EASTERN_DIGITS);
+				// Premise first: without it this test passes against the defect it exists to catch.
+				assertEquals("guard locale no longer emits Eastern Arabic digits — pick one that does",
+						"٠٦:٣٠", String.format("%02d:%02d", 6, 30));
 				assertEquals("06:30", GeneralHelper.formatTime(6, 30));
 			} finally {
 				Locale.setDefault(original);


### PR DESCRIPTION
Closes #241.

## The fix

`TimePickerPreferenceDialogFragmentCompat` built the persisted `"HH:MM"` with its own `String.format`, so under a region-bearing Arabic locale it produced Eastern Arabic numerals. It now calls `GeneralHelper.formatTime`, so there is exactly one writer of the persisted format.

The save logic moved into a package-private `savePickedTime(preference, hour, minute)` — the dialog otherwise needs a live `TargetFragment` and a real `TimePicker` to test, and the point of the ticket is to cover the *call site*, not the helper.

Grepped for other hand-rolled writers: only `GeneralHelper:112` and `BatteryPercentFormatter:70` remain, both already `Locale.ROOT`.

## Two corrections to the issue

**The stored value was never actually corrupt.** `setTime()` parses the Arabic-digit string (the parser accepts Eastern digits as #154 back-compat) and re-persists via `formatTime`, so `08:30` really did land on disk. What escaped un-normalized is `callChangeListener(time)`, and nothing is registered as a change listener on either time preference today — so this was latent, not live. The tests demonstrate it: with the fix reverted, only the two listener-facing cases fail; the two that go through `setTime` still pass.

It goes live the moment someone adds an `OnPreferenceChangeListener` to a quiet-hours preference, or removes the Eastern-digit tolerance from `parseTimeToMinutes` as legacy cleanup.

**The #154 regression test was guarding nothing.** This is the actual reason nothing caught the regression. `GeneralHelperTest.keepsWesternDigitsUnderArabicDefaultLocale` used `Locale.forLanguageTag("ar")`, and on this JDK:

| locale | zeroDigit | `String.format("%02d:%02d", 8, 30)` |
|---|---|---|
| `ar` | 48 (`0`) | `08:30` — **does not reproduce** |
| `ar-SA` / `ar-EG` / `ar-JO` | 1632 (`٠`) | `٠٨:٣٠` — reproduces |

CLDR selects the `arab` numbering system only for *region-bearing* Arabic locales, so that test passed against broken code. Both tests now use `ar-EG` and assert the premise (`String.format` under this locale really does emit Eastern digits) before asserting the behaviour, so they cannot silently go vacuous again.

Relevant to #246: any locale test in that audit needs a region, or it proves nothing.

## Verification

- New `TimePickerPreferenceDialogFragmentCompatTest` (Robolectric, 4 cases) fails against the reverted fix — confirmed by reverting and re-running.
- Full `testDebugUnitTest` suite green with the fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
