### PR TITLE
refactor: drop String.format from logging and document the locale rule

### DIFF
--- a/.claude/guidelines.md
+++ b/.claude/guidelines.md
@@ -236,6 +236,15 @@ The project uses **JUnit 4** for pure logic, with **Robolectric** and **Mockito*
 - Prefix internal keys with underscore: `_pref_key_*`. Internal identifiers (`_pref_key_*`, `_pref_value_*`, `pref_category_*`, `extra_category`, URIs) are **not** translated — leave them out of `values-ar/`.
 - Use descriptive names: `battery_health_good`, not `bh_g`
 
+### Locale in `String.format`
+- **Never call `String.format` without a locale.** `Locale.ROOT` for anything persisted or parsed back by our code; `Locale.getDefault()` only for text a person reads (UI, content descriptions).
+- CLDR selects Eastern Arabic digits for region-bearing Arabic locales (`ar-SA`, `ar-EG`, `ar-JO`), so a locale-less `%d` prints `٨` and a persisted value stops parsing. Shipped twice — #154 and #241.
+- **Locale tests must use a region tag.** Bare `Locale.forLanguageTag("ar")` formats Western digits, so a test using it passes against the defect; that is how #241 survived the #154 fix. Use `ar-EG` and assert the premise (plain `String.format` really does emit `٠٨:٣٠`) before asserting the behaviour.
+
+### Logging
+- Build log messages with `+` concatenation — **never `String.format`**. `android.util.Log` has no placeholder/varargs API, so concatenation is the official Android idiom; it also cannot throw on an argument-type mismatch, which matters inside a `BroadcastReceiver` where a throw becomes a crash loop.
+- Log messages are internal, not user-facing: no string resource, no `values-ar/` entry.
+
 ## Common Patterns in This Codebase
 
 ### Null Safety Pattern

--- a/CODE_REVIEW_GUIDELINES.md
+++ b/CODE_REVIEW_GUIDELINES.md
@@ -468,6 +468,46 @@ Identifiers are **not** copy — leave them out of `values-ar/`:
 - Use positional format args for dynamic content: `<string name="notification_status_content">%1$d%% · %2$s · %3$s</string>`.
 - Use `start`/`end` (not `left`/`right`) in layouts and test with an RTL language.
 
+### 5. Always Pass a `Locale` to `String.format`
+
+**Never call `String.format` without a locale.** Which locale depends on *who reads the result*:
+
+| The text is… | Use | Because |
+|---|---|---|
+| saved to prefs, or parsed back by our code | `Locale.ROOT` | the parser needs plain Western digits |
+| read by a person (UI, content descriptions) | `Locale.getDefault()` | it should follow the user's language |
+
+```java
+// ❌ BAD - no locale: under a region-bearing Arabic locale this yields "٠٨:٣٠"
+String.format("%02d:%02d", hour, minute);
+
+// ✅ GOOD - persisted value, so Western digits regardless of language
+String.format(Locale.ROOT, "%02d:%02d", hour, minute);
+
+// ✅ GOOD - screen-reader text, so it follows the user's language
+String.format(Locale.getDefault(), levelDescriptionFormat, level);
+```
+
+**Why?** CLDR selects the Eastern Arabic numbering system for region-bearing Arabic locales (`ar-SA`, `ar-EG`, `ar-JO`), so `%d` prints `٨` rather than `8` and a persisted value stops parsing. This shipped twice — issues #154 and #241.
+
+> **Testing note:** a locale test *must* use a region tag. Bare `Locale.forLanguageTag("ar")` formats with Western digits, so a test written against it passes even when the bug is present — that is precisely how #241 survived the #154 fix. Use `ar-EG` and assert that plain `String.format` really does produce Eastern digits before asserting your code doesn't.
+
+### 6. Don't Use `String.format` in Logs
+
+**Build log messages with `+` concatenation.**
+
+```java
+// ❌ BAD - runtime crash if the format and the argument types ever disagree
+Log.i(TAG, String.format("Charger connected (Battery: %d%%)", percentage));
+
+// ✅ GOOD - cannot fail, and no locale to get wrong
+Log.i(TAG, "Charger connected (Battery: " + percentage + "%)");
+```
+
+**Why?** `android.util.Log` has no placeholder/varargs API — `Log.i(tag, msg)` and `Log.i(tag, msg, throwable)` are the whole surface, so concatenation is the official Android idiom. It also cannot throw on an argument-type mismatch the way `String.format` can, which matters inside a `BroadcastReceiver` where a throw becomes a crash loop. Concatenating a number always produces Western digits, so no locale is involved.
+
+Log messages are not user-facing, so they are **not** translated and need no string resource.
+
 ---
 
 ## ⚡ Performance
@@ -668,6 +708,8 @@ When reviewing code, check:
 - [ ] All null checks in place
 - [ ] No silent/broad `catch`; expected failures validated, not caught
 - [ ] No hardcoded user-facing strings; `values-ar/` kept in parity
+- [ ] Every `String.format` passes a `Locale` — `ROOT` if persisted/parsed, `getDefault()` if a person reads it
+- [ ] Log messages use `+` concatenation, not `String.format`
 - [ ] Permissions checked (Android 13+)
 - [ ] Modern APIs used (no deprecated)
 - [ ] Thread-safe for static fields
@@ -698,4 +740,4 @@ When reviewing code, check:
 
 ---
 
-*Last updated: 2026-07-02*
+*Last updated: 2026-07-25*

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java
@@ -145,7 +145,7 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 		// the best speed seen rather than freezing on the first low reading (#227). No best reading yet.
 		scheduleChargeSample(appContext, wireless, 1, ChargeSpeed.unknown());
 
-		Log.i(TAG, String.format("Charger connected (Battery: %d%%, Wireless: %s)", percentage, wireless));
+		Log.i(TAG, "Charger connected (Battery: " + percentage + "%, Wireless: " + wireless + ")");
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/PowerConnectionService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/PowerConnectionService.java
@@ -8,10 +8,13 @@ import android.content.pm.ServiceInfo;
 import android.os.BatteryManager;
 import android.os.Build;
 import android.os.IBinder;
+import android.util.Log;
 import androidx.core.app.ServiceCompat;
 import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver;
 import com.almothafar.simplebatterynotifier.receiver.PowerConnectionReceiver;
+
+import java.util.Locale;
 
 import static java.util.Objects.nonNull;
 
@@ -20,6 +23,7 @@ import static java.util.Objects.nonNull;
  * Registers PowerConnectionReceiver and BatteryLevelReceiver on service creation.
  */
 public class PowerConnectionService extends Service {
+	private static final String TAG = "PowerConnectionService";
 
 	private PowerConnectionReceiver powerConnectionReceiver;
 	private BatteryLevelReceiver batteryLevelReceiver;
@@ -32,6 +36,12 @@ public class PowerConnectionService extends Service {
 	@Override
 	public void onCreate() {
 		super.onCreate();
+		// The active language, stated once where a log is guaranteed to start: this service is the
+		// long-lived component and it starts on boot. Worth having explicitly because locale changes
+		// behaviour that is otherwise invisible in a log — most of all the digit shapes CLDR picks for
+		// region-bearing Arabic locales, which is what corrupted a stored value in #154/#241. Reading
+		// it off a formatted number instead would be guesswork: bare "ar" formats Western digits too.
+		Log.i(TAG, "Starting with locale: " + Locale.getDefault().toLanguageTag());
 		// Promote to foreground first so the OS keeps the process (and our receivers) alive on Android 8+.
 		startForegroundWithStatus();
 		registerPowerConnectionReceiver();


### PR DESCRIPTION
Closes #246.

## What changed

**Logging** — [PowerConnectionReceiver:148](app/src/main/java/com/almothafar/simplebatterynotifier/receiver/PowerConnectionReceiver.java#L148) was the only one of 35 log calls that built its message with `String.format`. It now concatenates like the other 34.

`android.util.Log` has no placeholder/varargs API — `Log.i(tag, msg)` and `Log.i(tag, msg, throwable)` are the entire surface — so concatenation is the official Android idiom, not a compromise. It also can't throw on an argument-type mismatch, which matters in a `BroadcastReceiver` where a throw becomes a crash loop (the #154 failure mode). And concatenating a number is always Western digits, so the locale question disappears rather than being answered.

**Locale in logs** — logged explicitly once in `PowerConnectionService.onCreate` (the long-lived component; it starts on boot):

```java
Log.i(TAG, "Starting with locale: " + Locale.getDefault().toLanguageTag());   // "ar-SA"
```

Knowing the user's language when reading a log is genuinely useful, but inferring it from the digit shapes of a formatted number would not have worked: bare `ar` formats Western digits too, so absence of Eastern digits proves nothing, and only 1 of 35 lines would have carried the signal at all.

**Documentation** — the locale rule and the logging rule, in both `CODE_REVIEW_GUIDELINES.md` and its machine-facing companion `.claude/guidelines.md`, plus two review-checklist entries. Includes the testing note: a locale test must use a region tag, because bare `ar` passes against the defect — which is how #241 survived the #154 fix.

## Verification

```
String.format without a Locale arg:   none
String.format inside a Log call:      none
```

`assembleDebug` + full unit suite green.

## Deliberately not done

**Release log stripping** (the `-assumenosideeffects` R8 rule the issue recommended). Two reasons the issue's framing overstated the case:

- **The privacy angle is weak.** logcat has not been readable by other apps since Android 4.1 — `READ_LOGS` is privileged. These logs are visible only over adb or in a bug report.
- **There is a real cost.** The `Log.i` calls are charger-connected, cycle-completed, design-capacity-detected — exactly the breadcrumbs needed when someone reports "it didn't notify me". Given this app's history with notification-timing bugs (#5/#6/#7), discarding them in release is a net loss.

**Timber / an `AppLog` wrapper** (options B and C). The issue itself notes the usual slf4j performance argument doesn't apply at 35 rare call sites, which leaves style — not worth a dependency plus rewriting every call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
