### PR TITLE
style: drop final from the params of the two methods #247 touched

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreferenceDialogFragmentCompat.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/TimePickerPreferenceDialogFragmentCompat.java
@@ -65,7 +65,7 @@ public class TimePickerPreferenceDialogFragmentCompat extends PreferenceDialogFr
 	 * @param positiveResult True if the positive button was clicked
 	 */
 	@Override
-	public void onDialogClosed(final boolean positiveResult) {
+	public void onDialogClosed(boolean positiveResult) {
 		if (positiveResult) {
 			// Get the current values from the TimePicker
 			savePickedTime((TimePickerPreference) getPreference(), timePicker.getHour(), timePicker.getMinute());
@@ -85,7 +85,7 @@ public class TimePickerPreferenceDialogFragmentCompat extends PreferenceDialogFr
 	 * @param hour       picked hour of day (0-23)
 	 * @param minute     picked minute of hour (0-59)
 	 */
-	static void savePickedTime(final TimePickerPreference preference, final int hour, final int minute) {
+	static void savePickedTime(TimePickerPreference preference, int hour, int minute) {
 		final String time = GeneralHelper.formatTime(hour, minute);
 
 		if (preference.callChangeListener(time)) {


### PR DESCRIPTION
Follow-up to #247. Two lines.

`CODE_REVIEW_GUIDELINES.md` says parameters must not be marked `final` in new or edited code, and that legacy methods migrate as they are otherwise touched. #247 added `savePickedTime` and edited `onDialogClosed`, but matched the file's older `final`-params style instead of the standard.

Scope is exactly those two methods. The file's four untouched methods keep `final` params until something else brings them into a diff — the guideline explicitly does not ask for a full sweep.

`assembleDebug` + full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
