### PR TITLE
fix: clear the RestrictedApi lint errors and run lint in CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test --stacktrace
 
+      # Lint is not part of assemble, so it needs its own step — without one it silently rots
+      # (that is how the formatted="false" blocker in #146 and the RestrictedApi errors in #242
+      # both reached master). It runs before the APK builds because it is the cheaper gate.
+      - name: Run lint
+        run: ./gradlew :app:lintDebug --stacktrace
+
       - name: Build debug APK
         run: ./gradlew assembleDebug --stacktrace
 
@@ -55,6 +61,14 @@ jobs:
           path: |
             app/build/reports/tests/
             app/build/test-results/
+          retention-days: 30
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lint-report
+          path: app/build/reports/lint-results-debug.*
           retention-days: 30
 
       - name: Upload APK artifacts
@@ -83,5 +97,6 @@ jobs:
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Build Artifacts" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Lint passed with no errors" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Debug APK built successfully" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Release APK built successfully" >> $GITHUB_STEP_SUMMARY

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/PreferenceCardDecoration.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/preference/PreferenceCardDecoration.java
@@ -1,5 +1,6 @@
 package com.almothafar.simplebatterynotifier.ui.preference;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Canvas;
@@ -93,12 +94,8 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 	@Override
 	public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent,
 	                           @NonNull RecyclerView.State state) {
-		final PreferenceGroupAdapter adapter = adapterOf(parent);
-		if (isNull(adapter)) {
-			return;
-		}
 		final int position = parent.getChildAdapterPosition(view);
-		if (position == RecyclerView.NO_POSITION) {
+		if (position == RecyclerView.NO_POSITION || isNull(rowAt(parent, position))) {
 			return;
 		}
 		outRect.left = horizontalMargin;
@@ -107,14 +104,14 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 		// a gap when its first row is a card (e.g. the root screen's nav card); a leading category
 		// header carries its own top padding, so it needs none.
 		if (position == 0) {
-			if (isCardRow(adapter, 0)) {
+			if (isCardRow(parent, 0)) {
 				outRect.top = groupGap;
 			}
-		} else if (startsNewGroup(adapter, position)) {
+		} else if (startsNewGroup(parent, position)) {
 			outRect.top = groupGap;
 		}
 		// Matching breathing room below the last row so the final card floats off the bottom edge.
-		if (position == adapter.getItemCount() - 1) {
+		if (isLastRow(parent, position)) {
 			outRect.bottom = groupGap;
 		}
 	}
@@ -127,10 +124,6 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 	 */
 	@Override
 	public void onDraw(@NonNull Canvas canvas, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
-		final PreferenceGroupAdapter adapter = adapterOf(parent);
-		if (isNull(adapter)) {
-			return;
-		}
 		final float left = parent.getPaddingLeft() + horizontalMargin;
 		final float right = parent.getWidth() - parent.getPaddingRight() - horizontalMargin;
 
@@ -139,16 +132,16 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 		while (i < childCount) {
 			final View firstChild = parent.getChildAt(i);
 			final int startPosition = parent.getChildAdapterPosition(firstChild);
-			if (startPosition == RecyclerView.NO_POSITION || !isCardRow(adapter, startPosition)) {
+			if (startPosition == RecyclerView.NO_POSITION || !isCardRow(parent, startPosition)) {
 				i++;
 				continue;
 			}
-			final int endIndex = lastVisibleIndexOfCard(parent, adapter, i);
+			final int endIndex = lastVisibleIndexOfCard(parent, i);
 			final View lastChild = parent.getChildAt(endIndex);
 			final int endPosition = parent.getChildAdapterPosition(lastChild);
 			// Extend a corner off-screen (it clips to a straight edge) whenever the card runs past an edge.
-			final boolean openTop = sameCard(adapter, startPosition - 1, startPosition);
-			final boolean openBottom = sameCard(adapter, endPosition, endPosition + 1);
+			final boolean openTop = sameCard(parent, startPosition - 1, startPosition);
+			final boolean openBottom = sameCard(parent, endPosition, endPosition + 1);
 			final float top = openTop ? -cornerRadius : firstChild.getTop() + firstChild.getTranslationY();
 			final float bottom = openBottom ? parent.getHeight() + cornerRadius : lastChild.getBottom() + lastChild.getTranslationY();
 			cardRect.set(left, top, right, bottom);
@@ -162,17 +155,16 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 	 * the card can be painted as a single rectangle across its visible rows.
 	 *
 	 * @param parent     the preference RecyclerView
-	 * @param adapter    the preference adapter
 	 * @param startIndex the index, among the visible children, of the card's first visible row
 	 * @return the index of the card's last visible row
 	 */
-	private int lastVisibleIndexOfCard(RecyclerView parent, PreferenceGroupAdapter adapter, int startIndex) {
+	private int lastVisibleIndexOfCard(RecyclerView parent, int startIndex) {
 		final int childCount = parent.getChildCount();
 		int endIndex = startIndex;
 		int endPosition = parent.getChildAdapterPosition(parent.getChildAt(startIndex));
 		for (int j = startIndex + 1; j < childCount; j++) {
 			final int nextPosition = parent.getChildAdapterPosition(parent.getChildAt(j));
-			if (nextPosition != endPosition + 1 || !sameCard(adapter, endPosition, nextPosition)) {
+			if (nextPosition != endPosition + 1 || !sameCard(parent, endPosition, nextPosition)) {
 				break;
 			}
 			endPosition = nextPosition;
@@ -182,21 +174,21 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 	}
 
 	/**
-	 * @param adapter       the preference adapter
+	 * @param parent        the preference RecyclerView
 	 * @param upperPosition the adapter position of the upper row (may be out of range)
 	 * @param lowerPosition the adapter position directly below it (may be out of range)
 	 * @return whether the two adjacent positions belong to the same card: both are card rows sharing a
 	 *         parent, and the lower one isn't forced onto its own card
 	 */
-	private boolean sameCard(PreferenceGroupAdapter adapter, int upperPosition, int lowerPosition) {
-		if (!isCardRow(adapter, upperPosition) || !isCardRow(adapter, lowerPosition)) {
+	private boolean sameCard(RecyclerView parent, int upperPosition, int lowerPosition) {
+		if (!isCardRow(parent, upperPosition) || !isCardRow(parent, lowerPosition)) {
 			return false;
 		}
-		final Preference lower = adapter.getItem(lowerPosition);
+		final Preference lower = rowAt(parent, lowerPosition);
 		if (breakBeforeKeys.contains(lower.getKey())) {
 			return false;
 		}
-		return adapter.getItem(upperPosition).getParent() == lower.getParent();
+		return rowAt(parent, upperPosition).getParent() == lower.getParent();
 	}
 
 	/**
@@ -204,46 +196,67 @@ public class PreferenceCardDecoration extends RecyclerView.ItemDecoration {
 	 * gap when it opens a new group — a forced footer break, a different parent, or the list start —
 	 * but not when a header directly above it has already spaced it.
 	 *
-	 * @param adapter  the preference adapter
+	 * @param parent   the preference RecyclerView
 	 * @param position the adapter position being measured
 	 * @return whether a group gap should precede this position
 	 */
-	private boolean startsNewGroup(PreferenceGroupAdapter adapter, int position) {
-		final Preference pref = adapter.getItem(position);
+	private boolean startsNewGroup(RecyclerView parent, int position) {
+		final Preference pref = rowAt(parent, position);
 		if (pref instanceof PreferenceCategory) {
 			return true;
 		}
 		if (breakBeforeKeys.contains(pref.getKey())) {
 			return true;
 		}
-		if (adapter.getItem(position - 1) instanceof PreferenceCategory) {
+		if (rowAt(parent, position - 1) instanceof PreferenceCategory) {
 			return false;
 		}
-		return !sameCard(adapter, position - 1, position);
+		return !sameCard(parent, position - 1, position);
 	}
 
 	/**
-	 * @param adapter  the preference adapter
+	 * @param parent   the preference RecyclerView
 	 * @param position the adapter position to classify
 	 * @return whether the position is a normal preference (a card row), not a category section header
 	 */
-	private boolean isCardRow(PreferenceGroupAdapter adapter, int position) {
-		if (position < 0 || position >= adapter.getItemCount()) {
-			return false;
-		}
-		final Preference pref = adapter.getItem(position);
+	private boolean isCardRow(RecyclerView parent, int position) {
+		final Preference pref = rowAt(parent, position);
 		return nonNull(pref) && !(pref instanceof PreferenceCategory);
 	}
 
 	/**
-	 * @param parent the preference RecyclerView
-	 * @return the {@link PreferenceGroupAdapter} backing the list, or null if some other adapter is set
+	 * @param parent   the preference RecyclerView
+	 * @param position the adapter position to test
+	 * @return whether this is the list's last row — nothing is rendered after it
 	 */
-	private PreferenceGroupAdapter adapterOf(RecyclerView parent) {
-		final RecyclerView.Adapter<?> adapter = parent.getAdapter();
-		if (adapter instanceof PreferenceGroupAdapter groupAdapter) {
-			return groupAdapter;
+	private boolean isLastRow(RecyclerView parent, int position) {
+		return isNull(rowAt(parent, position + 1));
+	}
+
+	/**
+	 * The single place in the app that touches {@link PreferenceGroupAdapter}. That adapter is internal
+	 * to androidx ({@code @RestrictTo(LIBRARY_GROUP_PREFIX)}), yet it is the only thing that knows the
+	 * flattened row order the list actually renders — the public {@code PreferenceScreen} tree carries
+	 * no adapter positions. Reading it is therefore a deliberate coupling rather than an oversight, and
+	 * it is confined to this one method so an androidx-preference bump has a single site to fix (#242).
+	 * <p>
+	 * The failure mode is soft by design: should a future release change or drop the adapter, the type
+	 * check simply stops matching, every position reads as "no preference here", and the settings
+	 * screens quietly lose their card backgrounds instead of crashing.
+	 *
+	 * @param parent   the preference RecyclerView
+	 * @param position the adapter position to read
+	 * @return the preference rendered at that position, or null when the position is out of range or
+	 *         the list is backed by some other adapter
+	 */
+	@SuppressLint("RestrictedApi")
+	private static Preference rowAt(RecyclerView parent, int position) {
+		if (!(parent.getAdapter() instanceof PreferenceGroupAdapter adapter)) {
+			return null;
 		}
-		return null;
+		if (position < 0 || position >= adapter.getItemCount()) {
+			return null;
+		}
+		return adapter.getItem(position);
 	}
 }


### PR DESCRIPTION
Fixes #242.

`./gradlew lintDebug` failed on master with **15 errors** (`0 errors, 48 warnings` after this PR), all `RestrictedApi` from `PreferenceCardDecoration` reaching into `androidx.preference.PreferenceGroupAdapter` — a `@RestrictTo(LIBRARY_GROUP_PREFIX)` class — across 15 separate lines. CI never ran lint, so nothing caught it.

## 1. One seam instead of 15 restricted references

Of the options in the issue, this is the "isolate every use behind one small seam with a documented suppression" route. The whole coupling is now a single method:

```java
@SuppressLint("RestrictedApi")
private static Preference rowAt(RecyclerView parent, int position) {
	if (!(parent.getAdapter() instanceof PreferenceGroupAdapter adapter)) {
		return null;
	}
	if (position < 0 || position >= adapter.getItemCount()) {
		return null;
	}
	return adapter.getItem(position);
}
```

Folding the bounds check *into* the seam made it smaller than expected, because two of the old adapter uses stopped being needed at all:

- `isCardRow` no longer needs its own range guard — `rowAt` returns null out of range.
- `position == adapter.getItemCount() - 1` became `isLastRow(...)`, i.e. "nothing renders after this row", so `getItemCount()` isn't called anywhere else.

That in turn let `adapterOf()` and both of its null-adapter guards go: with no matching adapter, every position reads as "no preference", so the decoration draws nothing on its own. Five helpers now take the `RecyclerView` rather than the restricted type, and no method signature mentions `PreferenceGroupAdapter`.

**The drawing logic is untouched** — same card-run walk, same offsets, same off-screen corner handling. It just asks a different question for each row.

### Why a suppression rather than public API only

Worth recording, since the issue asked for a deliberate decision. `PreferenceGroupAdapter` implements the *public* `PreferenceGroup.PreferencePositionCallback`, so a fully public-API version is genuinely possible: walk the fragment's `PreferenceScreen` and index each preference by `getPreferenceAdapterPosition`. It was rejected as the worse trade here — it adds ~60 lines of index + invalidation machinery to what is currently a pure paint-time decoration, and it carries a silent failure mode: any adapter row absent from the preference tree (a collapsed group's expand button) drops out of the index and paints the wrong card shape, with no lint error to warn you. No screen uses `initialExpandedChildrenCount` today, but nothing stops one from doing so.

The seam's javadoc records the coupling and its failure mode: if a future androidx-preference release changes the adapter, the type check stops matching and the settings screens quietly lose their card backgrounds rather than crashing. One site to fix.

## 2. Lint in CI

Lint does not run as part of `assemble`, so it needs its own step — that gap is what let both this and the `formatted="false"` blocker in #146 reach master:

- `./gradlew :app:lintDebug` after the unit tests, before the APK builds (cheaper gate first).
- A `lint-report` artifact uploaded with `if: always()`, so failures are readable without re-running locally.
- A line in the build summary.

The 48 remaining warnings stay non-blocking; they belong to the umbrella "zero warnings and errors" issue.

## Verification

- `lintDebug`: 15 errors → **0 errors**, zero `RestrictedApi` findings in the report.
- Unit tests and `assembleDebug` pass.
- Not yet checked on a device — the change is behaviour-neutral by construction, but the settings screens are worth a visual glance before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)