### PR TITLE
fix: stop shipping hardcoded English placeholders on Battery Insights

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -160,8 +160,9 @@ public class BatteryInsightsActivity extends BaseActivity {
 		                                 ? BatteryHealthTracker.gradeForPercentage(measuredHealth)
 		                                 : BatteryHealthTracker.gradeForCycles(cycles);
 
-		// Update health percentage and color it based on grade
-		healthPercentageText.setText(healthPercentage + "%");
+		// Update health percentage and color it based on grade.
+		// Pass the number as a String so it renders in Western digits (0-9) in every locale (#96).
+		healthPercentageText.setText(getString(R.string.health_percentage_value, String.valueOf(healthPercentage)));
 		healthPercentageText.setTextColor(getHealthColor(grade));
 
 		// Update health status text

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -65,7 +65,7 @@
                             android:id="@+id/healthPercentageText"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="100%"
+                            tools:text="100%"
                             android:textSize="56sp"
                             android:textStyle="bold"
                             android:textColor="@color/top_background_color"
@@ -82,7 +82,7 @@
                                 android:id="@+id/healthStatusText"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="Excellent"
+                                tools:text="Excellent"
                                 android:textSize="20sp"
                                 android:textStyle="bold"
                                 android:textColor="@color/title_bar_background_color"/>
@@ -314,7 +314,7 @@
                                 android:id="@+id/chargeCyclesText"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="0"
+                                tools:text="0"
                                 android:textSize="32sp"
                                 android:textStyle="bold"
                                 android:textColor="@color/battery_details_value_color"/>
@@ -350,7 +350,7 @@
                                 android:id="@+id/daysInUseText"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="0"
+                                tools:text="0"
                                 android:textSize="32sp"
                                 android:textStyle="bold"
                                 android:textColor="@color/battery_details_value_color"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,11 @@
     <string name="battery_insights_menu">Battery Insights</string>
     <string name="view_battery_insights">View Battery Insights</string>
     <string name="battery_health">Battery Health</string>
+    <!-- The big health figure. %1$s is a Western-digit number (passed via String.valueOf) so it stays
+         0-9 in every locale, matching the other Insights numbers (#96). Deliberately not the existing
+         battery_level_percent, which uses %1$d and so renders Eastern Arabic digits under ar-* — right
+         for the preference slider it serves, wrong for this screen. -->
+    <string name="health_percentage_value" translatable="false">%1$s%%</string>
     <string name="charge_cycles">Charge Cycles</string>
     <string name="days_in_use">Days in Use</string>
     <string name="about_battery_health">About Your Battery</string>


### PR DESCRIPTION
Fixes #243.

## The four placeholders

`activity_battery_insights.xml` used real `android:text` attributes for design-time placeholders, so `"100%"`, `"Excellent"` and two `"0"`s **shipped** and were shown until real data loaded — untranslated, in English. `MissingTranslation` can't catch it because no string resource is involved.

All four moved to `tools:text`, the same treatment `activity_main` got in #58/#66. The `xmlns:tools` namespace was already declared. Each of the four views is populated from code on every path — `healthPercentageText`/`healthStatusText` in `showResolvedHealth` (called unconditionally), `chargeCyclesText`/`daysInUseText` in the "shown the same way in every state" block — so nothing is left blank at runtime.

## The `setText` concatenation

`healthPercentageText.setText(healthPercentage + "%")` became a format resource.

**Worth a look during review:** the obvious move was to reuse the existing `battery_level_percent` (`%1$d%%`), but that would have been a quiet regression. It uses `%1$d`, which renders **Eastern Arabic digits** under `ar-*` — and #96 specifically settled that Insights numbers stay Western 0-9, because mixing `٩٥` next to `500` looked inconsistent. `battery_level_percent`'s `%1$d` is right for the preference slider it currently serves, wrong for this screen.

So this adds `health_percentage_value` = `%1$s%%`, with the caller passing `String.valueOf(...)` — exactly the idiom `design_capacity_value` uses a few lines away:

```java
// Pass the number as a String so it renders in Western digits (0-9) in every locale (#96).
healthPercentageText.setText(getString(R.string.health_percentage_value, String.valueOf(healthPercentage)));
```

The two near-identical strings are commented so a future "DRY these up" pass doesn't merge them and silently undo #96.

`translatable="false"`, matching `battery_level_percent`: the string is pure formatting with no words, so there's nothing to translate. Say the word if you'd rather it were translatable so Arabic could use `٪` (U+066A) instead of `%` — that's a typographic call I didn't want to make unilaterally.

## Verification

- `lintDebug`: **48 → 43 warnings**, zero `HardcodedText`, zero `SetTextI18n` — the exact 5 this issue claimed in #245's table.
- Unit tests and `assembleDebug` pass.
- Not checked on a device — no device connected. Worth opening Insights in Arabic to confirm the health figure still reads correctly and shows Western digits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)