### PR TITLE
feat: add a monochrome layer to the launcher icon

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Themed-icon silhouette for Android 13+ (#244).
+
+  Android tints the monochrome layer a single colour and keeps only its alpha, so this cannot reuse
+  @mipmap/ic_launcher_foreground: the papercut waves, the mint shield outline, the amber battery and
+  the gauge ticks all collapse into one flat blob once colour is gone. Redrawn as the two elements
+  that still read at launcher size — the shield, with the bolt knocked out of it via evenOdd.
+
+  Geometry is sized to the 66dp safe-zone circle of the 108dp adaptive canvas, so no launcher mask
+  (circle, squircle, rounded square) clips it.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="108dp"
+        android:height="108dp"
+        android:viewportWidth="108"
+        android:viewportHeight="108">
+
+    <path
+            android:fillColor="#FFFFFFFF"
+            android:fillType="evenOdd"
+            android:pathData="M54,28 L31,37.8 L31,52.5 C31,66.2 40.8,78.9 54,82 C67.2,78.9 77,66.2 77,52.5 L77,37.8 Z M47,42 L47,56.3 L51.2,56.3 L51.2,68 L61,52.4 L55.4,52.4 L61,42 Z"/>
+
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,7 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <!-- Themed icons (#244). Read only on API 33+; older launchers ignore the tag and keep the
+         full-colour foreground, so this is safe to declare here rather than in an -v33 variant. -->
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,7 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <!-- Themed icons (#244). Read only on API 33+; older launchers ignore the tag and keep the
+         full-colour foreground, so this is safe to declare here rather than in an -v33 variant. -->
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
Fixes #244.

Android 13+ themed icons tint every launcher icon to the wallpaper palette. Without a `<monochrome>` layer an adaptive icon can't take part, so BattWatch stayed full-colour and stood out as the odd one on a themed home screen.

## Why it isn't just the foreground

Android tints the monochrome layer one flat colour and keeps only its **alpha**. Reusing `@mipmap/ic_launcher_foreground` would flatten the papercut waves, the mint shield outline, the amber battery and the gauge ticks into a single solid blob — and since that PNG fills its whole square, the result would be a plain filled square.

So it's redrawn as a vector: **the shield, with the bolt knocked out of it** (`fillType="evenOdd"`) — the two elements that still read once colour is gone, which is the direction the issue pointed at.

## Geometry

Sized to the **66dp safe-zone circle** of the 108dp adaptive canvas so no launcher mask (circle, squircle, rounded square) clips it. Furthest point from centre is the shield's shoulder at **28.1**, against a budget of 33 — comfortable margin on every mask.

Declared inside the existing `mipmap-anydpi-v26` icons rather than adding a `-v33` variant: pre-33 launchers ignore an unknown tag and keep the full-colour foreground. Lint confirms this — no `UnusedAttribute` was raised for it.

## Verification

- `lintDebug`: **43 → 41 warnings**, zero `MonochromeLauncherIcon` — the 2 this issue claimed in #245's table.
- `assembleDebug` passes (AAPT2 accepts the vector, so the path data is well-formed).
- **Not yet seen on a device.** The issue's acceptance criterion is a visual check on the S23 with Settings → Wallpaper & style → Themed icons turned on. That's the real test — I can render the geometry but not judge how it sits among your other themed icons.

## One design call worth your eye

I drew a second option too — shield with a **battery window** knocked out and the bolt solid inside it — which is closer to the full-colour icon. I went with the simpler bolt knockout because at 48dp the battery window's gaps thin out to under 2dp and start to look muddy, but that's a taste call on your own app icon, not mine. I've sent you a rendering of both side by side at real launcher size.

Swapping to the busier version is a one-file change to `ic_launcher_monochrome.xml` — say the word and I'll push it onto this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)