### PR TITLE
feat: restore a complete landscape layout for the main screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,6 @@
         <activity
                 android:name=".ui.MainActivity"
                 android:exported="true"
-                android:screenOrientation="portrait"
                 android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -62,7 +61,6 @@
         <activity
                 android:name=".ui.SettingsActivity"
                 android:label="@string/title_activity_settings"
-                android:screenOrientation="portrait"
                 android:theme="@style/AppTheme.NoActionBar"
                 android:parentActivityName=".ui.MainActivity"/>
 
@@ -70,7 +68,6 @@
         <activity
                 android:name=".ui.BatteryInsightsActivity"
                 android:label="@string/battery_insights_title"
-                android:screenOrientation="portrait"
                 android:theme="@style/AppTheme.NoActionBar"
                 android:parentActivityName=".ui.MainActivity"/>
 

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Landscape main screen (#231). Two panes below a full-width toolbar: gauge + threshold + actions on
+  one side, the battery details table on the other.
+
+  Every id the portrait layout carries also exists here, because MainActivity looks all of them up
+  unconditionally — a missing one is what crashed the old stale layout-land (#230). The ids are:
+  containerLayout, toolbar, percentageLayout, batteryPercentage, gaugeInfoButton, thresholdSection,
+  thresholdSlider, thresholdCriticalCaption, thresholdWarningCaption, detailsFragmentLayout,
+  homeBottomSection, batteryInsightsButton, signatureFragmentLayout.
+
+  The gauge keeps its portrait 160dp height: the style fixes the title text at 48dp, so a shorter
+  gauge would crowd the text rather than scale it. A short landscape screen therefore scrolls the
+  left column instead of clipping it, while homeBottomSection stays pinned outside the scroller so
+  the Insights button is always reachable and still receives the navigation-bar inset (#102).
+
+  RelativeLayout is used for the two fill-the-rest splits rather than layout_weight, so the only
+  weights in the file are the one pane split — nesting them would cost a second measure pass
+  (NestedWeights) and #245 is aiming at zero warnings.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/containerLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.almothafar.simplebatterynotifier.ui.MainActivity">
+
+    <!-- Full width so Settings / Feedback / About stay reachable in landscape — the old layout-land
+         dropped the toolbar entirely, which is how they became unreachable (#231). -->
+    <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:minHeight="?attr/actionBarSize"
+            android:paddingTop="@dimen/toolbar_status_bar_padding"
+            android:background="@color/title_bar_background_color"
+            android:elevation="4dp"
+            android:theme="@style/ToolBarStyle"
+            app:popupTheme="@style/ThemeOverlay.Material3.Light"
+            app:title="@string/app_name"
+            app:titleTextAppearance="@style/ToolBarStyle.Title"
+            app:titleTextColor="@android:color/white"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar"
+        android:baselineAligned="false"
+        android:orientation="horizontal">
+
+        <!-- Left pane: the gauge and the controls that act on it -->
+        <RelativeLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+            <!-- Pinned so the Insights button is always reachable, and so it still receives the
+                 navigation-bar inset MainActivity applies to it (#102). -->
+            <LinearLayout
+                android:id="@+id/homeBottomSection"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:orientation="vertical"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="8dp"
+                android:paddingBottom="@dimen/content_navigation_bar_padding"
+                android:background="@android:color/white">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/batteryInsightsButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/view_battery_insights"
+                    android:textColor="@android:color/white"
+                    app:backgroundTint="@color/top_background_color"
+                    android:layout_marginBottom="8dp"
+                    style="@style/Widget.Material3.Button" />
+
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/signatureFragmentLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:name="com.almothafar.simplebatterynotifier.ui.fragment.SignatureFragment"
+                    tools:layout="@layout/fragment_signature" />
+
+            </LinearLayout>
+
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_above="@id/homeBottomSection"
+                android:layout_alignParentTop="true"
+                android:fillViewport="true">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <FrameLayout
+                        android:id="@+id/percentageLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@color/top_background_color">
+
+                        <com.almothafar.simplebatterynotifier.ui.widget.HorseshoeProgressBar
+                            android:id="@+id/batteryPercentage"
+                            style="@style/Widget.App.BatteryGauge"
+                            android:layout_width="wrap_content"
+                            android:layout_height="160dp"
+                            android:layout_gravity="center"
+                            tools:gaugeTitle="100%"
+                            tools:gaugeStatusText="Charging"
+                            android:layout_marginTop="-2dp"
+                            android:layout_marginBottom="-10dp" />
+
+                        <!-- Honest info affordance for the smoothed/estimated live percentage (#217). -->
+                        <ImageButton
+                            android:id="@+id/gaugeInfoButton"
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:layout_gravity="top|end"
+                            android:layout_marginTop="6dp"
+                            android:layout_marginEnd="6dp"
+                            android:padding="8dp"
+                            android:src="@drawable/ic_info"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:contentDescription="@string/gauge_info_content_description"
+                            app:tint="@android:color/white" />
+                    </FrameLayout>
+
+                    <!-- In-fly critical/warning threshold adjuster, directly under the gauge it controls. -->
+                    <LinearLayout
+                        android:id="@+id/thresholdSection"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:background="@android:color/white"
+                        android:paddingStart="16dp"
+                        android:paddingEnd="16dp"
+                        android:paddingTop="4dp"
+                        android:paddingBottom="4dp">
+
+                        <com.google.android.material.slider.RangeSlider
+                            android:id="@+id/thresholdSlider"
+                            style="@style/Widget.App.RangeSlider"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:stepSize="1"
+                            android:valueFrom="10"
+                            android:valueTo="50" />
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="-6dp"
+                            android:orientation="horizontal">
+
+                            <TextView
+                                android:id="@+id/thresholdCriticalCaption"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:gravity="start"
+                                android:textColor="@color/circular_progress_default_progress_alert"
+                                android:textSize="12sp"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:id="@+id/thresholdWarningCaption"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:gravity="end"
+                                android:textColor="@color/circular_progress_default_progress_warning"
+                                android:textSize="12sp"
+                                android:textStyle="bold" />
+
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+            </ScrollView>
+
+        </RelativeLayout>
+
+        <!-- Right pane: the details table. It brings its own ScrollView with the fading edge (#75). -->
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/detailsFragmentLayout"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:name="com.almothafar.simplebatterynotifier.ui.fragment.BatteryDetailsFragment"
+            tools:layout="@layout/fragment_battery_details" />
+
+    </LinearLayout>
+
+</RelativeLayout>


### PR DESCRIPTION
Fixes #231.

The portrait lock was a crash workaround (#232): the old `layout-land/activity_main.xml` had drifted badly out of sync with portrait — no toolbar, no threshold slider, no Insights button, no gauge info button, no signature — so `MainActivity` dereferenced views that weren't there and crashed (#230).

This adds a fresh landscape layout and removes the lock from all three activities.

## Layout

Full-width toolbar over two panes: gauge + threshold + actions on one side, the details table on the other. I've sent you a rendering of how it lays out at S23 landscape proportions.

**The thing that caused #230, checked directly.** Every id `MainActivity` looks up must exist in both layouts. Cross-checked mechanically against every `R.id.*` reference in `MainActivity` and `BaseActivity`:

| id | portrait | landscape |
|---|---|---|
| `containerLayout`, `toolbar`, `batteryPercentage`, `gaugeInfoButton`, `thresholdSlider`, `thresholdCriticalCaption`, `thresholdWarningCaption`, `detailsFragmentLayout`, `homeBottomSection`, `batteryInsightsButton` | ✅ | ✅ |
| `action_settings`, `action_feedback`, `action_about` | — | — |

The last three are menu items in `menu_main.xml`, correctly absent from both layouts. `percentageLayout`, `thresholdSection` and `signatureFragmentLayout` are structural and carried over too, so the two files stay id-for-id comparable.

## Two decisions worth reviewing

**The gauge keeps its 160dp height.** My first instinct was to shrink it for the shorter landscape viewport, but `Widget.App.BatteryGauge` pins `gaugeTitleTextSize` at **48dp** and `gaugeStatusTextSize` at 20dp — fixed dp, not scaled. At 120dp the horseshoe's inner area is ~60dp against ~68dp of text, so the text would crowd rather than shrink. Shrinking it properly means a landscape style override too, which is more moving parts than this is worth. Instead the left column scrolls, and `homeBottomSection` sits *outside* the scroller so the Insights button is always reachable and still receives the nav-bar inset (#102).

Arithmetic says it won't actually scroll on either test device: ~208dp of content against ~245dp available at S23/Mate 10 Pro landscape heights.

**`RelativeLayout` for the fill-the-rest splits, not `layout_weight`.** The first draft used weights throughout and lint returned two new `NestedWeights` warnings — a weighted child inside a weighted parent costs a second measure pass. Since #245 is aiming at real zero, I restructured so the only weights left are the single pane split. Worth a look if you'd rather have consistency with the portrait layout's LinearLayout style than the zero-warning count.

## Settings and Insights

Unlocked too, with no layout work: `activity_battery_insights.xml` already wraps its content in a `ScrollView`, and Settings uses a `PreferenceFragmentCompat` RecyclerView. Both scroll in landscape as-is. Worth a rotate during testing to confirm nothing looks cramped, but nothing there can crash the way the main screen did.

Also worth noting from your own comment on the issue: on **Android 16+ the `screenOrientation` lock stops being honoured anyway**, so this was going to happen with or without us.

## Verification

- `lintDebug`: **43 → 37 warnings**, zero `LockedOrientationActivity`, zero `DiscouragedApi` — the 6 this issue claimed in #245's table — and zero new warnings from the added layout.
- Unit tests and `assembleDebug` pass.
- **Not run on a device.** This is the one where that matters most: the acceptance criteria are launch in landscape, rotate back and forth, no crash, nothing clipped or cramped — on both the S23 and the Mate 10 Pro. Everything above is static analysis and arithmetic; it cannot tell you whether the two panes actually *feel* right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)