### PR TITLE
fix: stop the Insights cards being clipped, and clear the layout lint nits

### DIFF
--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -27,11 +27,16 @@
             android:layout_weight="1"
             android:fillViewport="true">
 
+        <!-- clipChildren/clipToPadding are off so the cards' 4dp elevation shadows can draw past their
+             row and into this padding instead of being sliced flat at the edges (#258). Without it the
+             cards fill their row exactly and the shadow has nowhere to go. -->
         <LinearLayout
                 android:id="@+id/insightsScrollContent"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
+                android:clipChildren="false"
+                android:clipToPadding="false"
                 android:paddingStart="16dp"
                 android:paddingEnd="16dp"
                 android:paddingTop="16dp"
@@ -139,6 +144,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
+                    android:clipChildren="false"
                     android:weightSum="2"
                     android:layout_marginBottom="16dp">
 
@@ -147,7 +153,7 @@
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        android:layout_marginEnd="8dp"
+                        android:layout_marginEnd="4dp"
                         app:cardCornerRadius="8dp"
                         app:cardElevation="4dp"
                         app:contentPadding="16dp">
@@ -243,7 +249,7 @@
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="4dp"
                         android:clickable="true"
                         android:focusable="true"
                         android:foreground="?attr/selectableItemBackground"
@@ -283,6 +289,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
+                    android:clipChildren="false"
                     android:weightSum="2"
                     android:layout_marginBottom="16dp">
 
@@ -291,7 +298,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:layout_marginEnd="8dp"
+                        android:layout_marginEnd="4dp"
                         app:cardCornerRadius="8dp"
                         app:cardElevation="4dp"
                         app:contentPadding="16dp">
@@ -327,7 +334,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="4dp"
                         app:cardCornerRadius="8dp"
                         app:cardElevation="4dp"
                         app:contentPadding="16dp">

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -4,8 +4,7 @@
               xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
-              android:orientation="vertical"
-              android:background="@android:color/white">
+              android:orientation="vertical">
 
     <!-- Toolbar matching main activity -->
     <androidx.appcompat.widget.Toolbar
@@ -181,6 +180,7 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:orientation="horizontal"
+                                android:baselineAligned="false"
                                 android:weightSum="2"
                                 android:layout_marginTop="8dp"
                                 android:visibility="gone"

--- a/app/src/main/res/layout/fragment_signature.xml
+++ b/app/src/main/res/layout/fragment_signature.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Developer Signature Fragment - Reusable across activities -->
+<!-- Overdraw is suppressed rather than fixed: this background is not a fill but the ripple for a
+     clickable row (SignatureFragment opens the developer link from it), and selectableItemBackground
+     is transparent at rest, so it costs no overdraw. Dropping it would silently remove the row's
+     touch feedback. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/developerSignatureLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -10,7 +15,8 @@
     android:paddingBottom="4dp"
     android:background="?attr/selectableItemBackground"
     android:clickable="true"
-    android:focusable="true">
+    android:focusable="true"
+    tools:ignore="Overdraw">
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -7,7 +7,7 @@
         android:icon="@drawable/ic_settings"
         android:orderInCategory="100"
         android:title="@string/action_settings"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_feedback"
         android:orderInCategory="200"


### PR DESCRIPTION
Fixes #258, and clears 4 warnings for #245 (2 `Overdraw`, `DisableBaselineAlignment`, `AlwaysShowAction`).

Retitled from `chore:` to `fix:` — it now carries a user-visible bug fix, so it should drive a patch bump.

**`lintDebug`: 35 → 31 warnings.**

## The cards looked cut (#258)

Measured on the S23 with `uiautomator dump`:

```
capacity row (LinearLayout)   y: 883 .. 1235
card inside it                y: 886 .. 1232
```

**Three pixels of slack for a shadow that needs about ten.** Elevation shadows draw *outside* a view's bounds; the cards fill their row exactly (`match_parent` in one row, `wrap_content` in the other) and `clipChildren` defaults to `true`, so the shadow was sliced flat on every edge. The full-width cards escaped it only by accident — their `layout_marginBottom` left the shadow somewhere to go.

Fixed by turning off `clipChildren` on the two card rows, and `clipChildren`/`clipToPadding` on the scroll content, so shadows draw into padding that already exists.

### Why not `cardUseCompatPadding`

That's the usual fix and it's what I tried first — but it's wrong for this layout. It reserves the shadow's space *inside* each card, measured at **9dp per edge**, which stacks on top of the existing margins:

| | gap between cards | screen margin |
|---|---|---|
| before | 19.8dp | 16dp |
| with `cardUseCompatPadding` | **33.5dp** | 25.1dp |
| this PR | ~10dp | 16dp |

The channel ended up wider than the screen margin, and every card got narrower. Unclipping keeps the cards at their full slot width instead.

### The gap

With shadows no longer eating into it, the facing margins turned out to be `8dp` **on each card** — 16dp of gutter, which read as one oversized channel. Both drop to `4dp`, giving an 8dp gutter against the 16dp screen margin.

Confirmed by eye on the S23 after install. The numbers above are measured; the final gap is arithmetic plus your visual check rather than a fresh `uiautomator` reading, since you were using the phone.

## The lint nits (unrelated, cosmetic)

- Insights root no longer paints `@android:color/white` — the theme already paints the window. Background becomes `md_theme_light_background` (`#FFFBFF`); a 4/255 shift in one channel.
- `measuredCapacityRange` gets `baselineAligned="false"` — a weighted row of stacked label/value pairs has no baselines worth aligning.
- Settings gear: `showAsAction="always"` → `"ifRoom"`. With three items, two of them `never`, there's always room.
- **`fragment_signature`'s `Overdraw` is suppressed, not fixed** — that background is `?attr/selectableItemBackground`, the ripple for a clickable row (`SignatureFragment:43`), transparent at rest. Deleting it would have silently removed touch feedback for a cosmetic warning.

## Verification

- `lintDebug`: **35 → 31**, zero `Overdraw`, `DisableBaselineAlignment`, `AlwaysShowAction`.
- Unit tests and `assembleDebug` pass.
- Installed and checked on the S23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)