### PR TITLE
feat: show the battery temperature range since the last full charge

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,6 +27,12 @@ The battery's rated full capacity when new (mAh), from the manufacturer's spec. 
 best-effort auto-detected from the kernel. Distinct from the measured current full capacity.
 _Avoid_: rated capacity (in prose only), max capacity.
 
+**Temperature range**:
+The lowest and highest battery temperature seen since the battery last finished charging, in the
+user's display unit. Accumulated from the readings the monitoring service observes; completing a
+charge is the only thing that starts a new range.
+_Avoid_: temperature history, heat range, thermal range.
+
 **Stable capacity**:
 The learned running average of the measured full capacity (mAh), built from spaced, trusted
 per-tick estimates. Slow-moving by design: it is the denominator of the sub-percent battery

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -11,6 +11,7 @@ import com.almothafar.simplebatterynotifier.model.BatteryDO;
 import com.almothafar.simplebatterynotifier.service.AlertType;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.BatteryRateTracker;
+import com.almothafar.simplebatterynotifier.service.BatteryTemperatureTracker;
 import com.almothafar.simplebatterynotifier.service.FastDrainDetector;
 import com.almothafar.simplebatterynotifier.service.NotificationService;
 import com.almothafar.simplebatterynotifier.service.SlowChargeDetector;
@@ -102,6 +103,10 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 
 		// Track battery health and charge cycles
 		BatteryHealthTracker.recordBatteryState(context, percentage, status);
+
+		// #260: keep the coldest/hottest reading of the current charge for the Insights temperature
+		// range. The status and level go in too — finishing a charge is what starts a new range.
+		BatteryTemperatureTracker.record(context, batteryDO.getTemperature(), percentage, status);
 
 		final SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
 		final LevelAlertConfig config = new LevelAlertConfig(

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -105,8 +105,9 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		BatteryHealthTracker.recordBatteryState(context, percentage, status);
 
 		// #260: keep the coldest/hottest reading of the current charge for the Insights temperature
-		// range. The status and level go in too — finishing a charge is what starts a new range.
-		BatteryTemperatureTracker.record(context, batteryDO.getTemperature(), percentage, status);
+		// range. The whole reading goes in — finishing a charge is what starts a new range, so the
+		// tracker needs the level and status as well as the temperature.
+		BatteryTemperatureTracker.record(context, batteryDO);
 
 		final SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
 		final LevelAlertConfig config = new LevelAlertConfig(

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryTemperatureTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryTemperatureTracker.java
@@ -1,0 +1,190 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.BatteryManager;
+
+/**
+ * Tracks the lowest and highest battery temperature seen since the battery last finished charging —
+ * the <b>temperature range</b> shown on the Battery Insights screen (issue #260).
+ * <p>
+ * <b>Why per charge.</b> The temperature is read on every battery broadcast but was never retained,
+ * so after the fact there was no way to tell whether the battery brushed the alert threshold for a
+ * minute or spent the afternoon there. A range bounded by the charge the user just completed answers
+ * that in the terms people already think in, and needs no history or database — just a running
+ * minimum and maximum.
+ * <p>
+ * <b>When the range resets.</b> Only when a charge completes. Plugging in, unplugging and the clock
+ * do nothing. "Charge complete" is {@link BatteryManager#BATTERY_STATUS_FULL} <em>or</em> a level of
+ * {@link #FULL_LEVEL_PERCENT}: the status alone misses devices whose charge cap stops them short of
+ * 100%, and the level alone misses OEMs that report full a percent early. The reset is edge-triggered
+ * through {@link TemperatureStats#fullSeen()} — it fires once per completed charge and re-arms when
+ * the battery leaves the full state, so sitting plugged in at full does not keep wiping the range.
+ * <p>
+ * <b>Storage.</b> The stats live in the backup-excluded transient file ({@link TransientState}):
+ * another device's temperature range says nothing about this one, and a fresh install fills in on the
+ * next broadcast. There is deliberately no sample count — it would change on every tick and defeat
+ * the save-on-change rule the other trackers follow, so after {@code hasData} flips only a genuinely
+ * wider range writes. The pure helpers carry the correctness and are unit-tested without Android,
+ * mirroring {@link BatteryCapacityTracker}.
+ */
+public final class BatteryTemperatureTracker {
+
+	// Persisted range state, kept in the backup-excluded transient file (TransientState, #167).
+	private static final String PREF_MIN_TENTHS = "_temperature_min_tenths";
+	private static final String PREF_MAX_TENTHS = "_temperature_max_tenths";
+	private static final String PREF_HAS_DATA = "_temperature_has_data";
+	private static final String PREF_FULL_SEEN = "_temperature_full_seen";
+
+	/** The level at which a charge counts as complete even if the status never reports FULL. */
+	static final int FULL_LEVEL_PERCENT = 100;
+	// Plausibility band in tenths of a degree Celsius: -20 C to 100 C. A reading outside it is a
+	// driver artefact, not a battery, and folding it in would freeze the range on a bogus extreme.
+	static final int MIN_PLAUSIBLE_TENTHS_C = -200;
+	static final int MAX_PLAUSIBLE_TENTHS_C = 1000;
+
+	private BatteryTemperatureTracker() {
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Folds one battery reading into the persisted range. The single entry point, called from
+	 * {@link com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver} on every
+	 * {@code ACTION_BATTERY_CHANGED} broadcast.
+	 *
+	 * @param context      Application context
+	 * @param rawTenthsC   battery temperature in tenths of a degree Celsius
+	 * @param levelPercent the battery level as a whole percent
+	 * @param status       the {@code BatteryManager} status extra from this broadcast
+	 */
+	public static void record(Context context, int rawTenthsC, int levelPercent, int status) {
+		final SharedPreferences prefs = TransientState.prefs(context);
+		final TemperatureStats previous = loadStats(prefs);
+		final TemperatureStats updated = fold(previous, rawTenthsC, levelPercent, status);
+
+		// Persist only on change: most broadcasts sit well inside the range already recorded, and
+		// rewriting an identical state would churn SharedPreferences on every tick.
+		if (!updated.equals(previous)) {
+			saveStats(prefs, updated);
+		}
+	}
+
+	/**
+	 * Folds one reading into the range. Pure so it is unit-testable. A completed charge starts a fresh
+	 * range at that reading; otherwise the reading widens the existing one. Implausible readings are
+	 * rejected — the same instance returns, so the caller skips the persist.
+	 *
+	 * @param previous     the range so far
+	 * @param rawTenthsC   battery temperature in tenths of a degree Celsius
+	 * @param levelPercent the battery level as a whole percent
+	 * @param status       the {@code BatteryManager} status extra from this broadcast
+	 *
+	 * @return the updated stats, or {@code previous} itself when the reading was rejected
+	 */
+	static TemperatureStats fold(TemperatureStats previous, int rawTenthsC, int levelPercent, int status) {
+		// Exactly 0 is not "0.0 °C": SystemService reads EXTRA_TEMPERATURE with a default of 0, so on a
+		// device that doesn't report a temperature every tick would look like a freezing battery.
+		if (rawTenthsC == 0 || rawTenthsC < MIN_PLAUSIBLE_TENTHS_C || rawTenthsC > MAX_PLAUSIBLE_TENTHS_C) {
+			return previous;
+		}
+
+		final boolean chargeComplete = isChargeComplete(levelPercent, status);
+		if (chargeComplete && !previous.fullSeen()) {
+			return new TemperatureStats(rawTenthsC, rawTenthsC, true, true);
+		}
+		// chargeComplete doubles as the new fullSeen: leaving the full state re-arms the next reset,
+		// staying in it holds the flag so the range is not wiped again on the following tick.
+		if (!previous.hasData()) {
+			return new TemperatureStats(rawTenthsC, rawTenthsC, true, chargeComplete);
+		}
+		return new TemperatureStats(
+				Math.min(previous.minTenthsC(), rawTenthsC),
+				Math.max(previous.maxTenthsC(), rawTenthsC),
+				true,
+				chargeComplete);
+	}
+
+	/**
+	 * Whether this broadcast says the charge has finished. Both signals count, because neither is
+	 * reliable alone: a device with a charge cap can report FULL well below 100%, and some OEMs report
+	 * 100% a tick before the status catches up.
+	 *
+	 * @param levelPercent the battery level as a whole percent
+	 * @param status       the {@code BatteryManager} status extra from this broadcast
+	 *
+	 * @return true when the battery counts as fully charged
+	 */
+	static boolean isChargeComplete(int levelPercent, int status) {
+		return status == BatteryManager.BATTERY_STATUS_FULL || levelPercent >= FULL_LEVEL_PERCENT;
+	}
+
+	/**
+	 * Reads the recorded temperature range for display (#260).
+	 *
+	 * @param context Application context
+	 *
+	 * @return the range, or {@code null} before any usable reading has been recorded
+	 */
+	public static TemperatureRange getRange(Context context) {
+		return summarize(loadStats(TransientState.prefs(context)));
+	}
+
+	/**
+	 * The display view of the recorded stats. Pure so the empty boundary is unit-testable.
+	 *
+	 * @param stats the range so far
+	 *
+	 * @return the recorded range, or {@code null} when nothing has been recorded yet
+	 */
+	static TemperatureRange summarize(TemperatureStats stats) {
+		if (!stats.hasData()) {
+			return null;
+		}
+		return new TemperatureRange(stats.minTenthsC(), stats.maxTenthsC());
+	}
+
+	/**
+	 * Loads the persisted stats; package-private so the state tests can assert what was stored.
+	 */
+	static TemperatureStats loadStats(SharedPreferences prefs) {
+		return new TemperatureStats(
+				prefs.getInt(PREF_MIN_TENTHS, 0),
+				prefs.getInt(PREF_MAX_TENTHS, 0),
+				prefs.getBoolean(PREF_HAS_DATA, false),
+				prefs.getBoolean(PREF_FULL_SEEN, false));
+	}
+
+	/**
+	 * Persists the stats; package-private so the state tests can seed a recorded range.
+	 */
+	static void saveStats(SharedPreferences prefs, TemperatureStats stats) {
+		prefs.edit()
+		     .putInt(PREF_MIN_TENTHS, stats.minTenthsC())
+		     .putInt(PREF_MAX_TENTHS, stats.maxTenthsC())
+		     .putBoolean(PREF_HAS_DATA, stats.hasData())
+		     .putBoolean(PREF_FULL_SEEN, stats.fullSeen())
+		     .apply();
+	}
+
+	/**
+	 * The persistent temperature-range state.
+	 *
+	 * @param minTenthsC coldest reading this charge, in tenths of a degree Celsius
+	 * @param maxTenthsC hottest reading this charge, in tenths of a degree Celsius
+	 * @param hasData    whether any usable reading has been folded in (the min/max are meaningless
+	 *                   until it is true)
+	 * @param fullSeen   whether the current full state has already reset the range, so the reset
+	 *                   fires once per completed charge rather than on every tick while full
+	 */
+	record TemperatureStats(int minTenthsC, int maxTenthsC, boolean hasData, boolean fullSeen) {
+	}
+
+	/**
+	 * The read-only view of the recorded range for display (#260).
+	 *
+	 * @param minTenthsC coldest reading this charge, in tenths of a degree Celsius
+	 * @param maxTenthsC hottest reading this charge, in tenths of a degree Celsius
+	 */
+	public record TemperatureRange(int minTenthsC, int maxTenthsC) {
+	}
+}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryTemperatureTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/BatteryTemperatureTracker.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.BatteryManager;
 
+import com.almothafar.simplebatterynotifier.model.BatteryDO;
+
 /**
  * Tracks the lowest and highest battery temperature seen since the battery last finished charging —
  * the <b>temperature range</b> shown on the Battery Insights screen (issue #260).
@@ -18,8 +20,9 @@ import android.os.BatteryManager;
  * do nothing. "Charge complete" is {@link BatteryManager#BATTERY_STATUS_FULL} <em>or</em> a level of
  * {@link #FULL_LEVEL_PERCENT}: the status alone misses devices whose charge cap stops them short of
  * 100%, and the level alone misses OEMs that report full a percent early. The reset is edge-triggered
- * through {@link TemperatureStats#fullSeen()} — it fires once per completed charge and re-arms when
- * the battery leaves the full state, so sitting plugged in at full does not keep wiping the range.
+ * through {@link TemperatureStats#fullSeen()} — it fires once per completed charge and re-arms only
+ * once the battery has genuinely dropped out of the full band (see {@link #nextFullSeen}), so neither
+ * sitting plugged in at full nor the overnight top-up cycle keeps wiping the range.
  * <p>
  * <b>Storage.</b> The stats live in the backup-excluded transient file ({@link TransientState}):
  * another device's temperature range says nothing about this one, and a fresh install fills in on the
@@ -38,10 +41,10 @@ public final class BatteryTemperatureTracker {
 
 	/** The level at which a charge counts as complete even if the status never reports FULL. */
 	static final int FULL_LEVEL_PERCENT = 100;
-	// Plausibility band in tenths of a degree Celsius: -20 C to 100 C. A reading outside it is a
-	// driver artefact, not a battery, and folding it in would freeze the range on a bogus extreme.
-	static final int MIN_PLAUSIBLE_TENTHS_C = -200;
-	static final int MAX_PLAUSIBLE_TENTHS_C = 1000;
+
+	// The range a completed charge starts over from. Only its min/max/hasData are ever read — fold
+	// always supplies the reset flag itself.
+	private static final TemperatureStats NO_RANGE = new TemperatureStats(0, 0, false, false);
 
 	private BatteryTemperatureTracker() {
 		// Utility class - prevent instantiation
@@ -52,15 +55,18 @@ public final class BatteryTemperatureTracker {
 	 * {@link com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver} on every
 	 * {@code ACTION_BATTERY_CHANGED} broadcast.
 	 *
-	 * @param context      Application context
-	 * @param rawTenthsC   battery temperature in tenths of a degree Celsius
-	 * @param levelPercent the battery level as a whole percent
-	 * @param status       the {@code BatteryManager} status extra from this broadcast
+	 * @param context   Application context
+	 * @param batteryDO the reading from this broadcast — the temperature, the level and the status all
+	 *                  matter, because finishing a charge is what starts a new range
 	 */
-	public static void record(Context context, int rawTenthsC, int levelPercent, int status) {
+	public static void record(Context context, BatteryDO batteryDO) {
 		final SharedPreferences prefs = TransientState.prefs(context);
 		final TemperatureStats previous = loadStats(prefs);
-		final TemperatureStats updated = fold(previous, rawTenthsC, levelPercent, status);
+		final TemperatureStats updated = fold(
+				previous,
+				batteryDO.getTemperature(),
+				batteryDO.getBatteryPercentageInt(),
+				batteryDO.getStatus());
 
 		// Persist only on change: most broadcasts sit well inside the range already recorded, and
 		// rewriting an identical state would churn SharedPreferences on every tick.
@@ -71,37 +77,76 @@ public final class BatteryTemperatureTracker {
 
 	/**
 	 * Folds one reading into the range. Pure so it is unit-testable. A completed charge starts a fresh
-	 * range at that reading; otherwise the reading widens the existing one. Implausible readings are
-	 * rejected — the same instance returns, so the caller skips the persist.
+	 * range; otherwise the reading widens the existing one. A broadcast that carried no temperature
+	 * ({@link #isUnreported}) leaves the min/max alone but still moves the reset flag.
 	 *
 	 * @param previous     the range so far
 	 * @param rawTenthsC   battery temperature in tenths of a degree Celsius
 	 * @param levelPercent the battery level as a whole percent
 	 * @param status       the {@code BatteryManager} status extra from this broadcast
 	 *
-	 * @return the updated stats, or {@code previous} itself when the reading was rejected
+	 * @return the range to persist, value-equal to {@code previous} when nothing changed
 	 */
 	static TemperatureStats fold(TemperatureStats previous, int rawTenthsC, int levelPercent, int status) {
-		// Exactly 0 is not "0.0 °C": SystemService reads EXTRA_TEMPERATURE with a default of 0, so on a
-		// device that doesn't report a temperature every tick would look like a freezing battery.
-		if (rawTenthsC == 0 || rawTenthsC < MIN_PLAUSIBLE_TENTHS_C || rawTenthsC > MAX_PLAUSIBLE_TENTHS_C) {
-			return previous;
-		}
-
+		// The end-of-charge bookkeeping is decided before the reading is judged. Deciding it after
+		// would couple the two: on a device that reports no temperature the flag could never move, so
+		// the reset would stay stuck at whatever a fresh install left it on.
 		final boolean chargeComplete = isChargeComplete(levelPercent, status);
-		if (chargeComplete && !previous.fullSeen()) {
-			return new TemperatureStats(rawTenthsC, rawTenthsC, true, true);
+		final boolean fullSeen = nextFullSeen(previous, levelPercent, chargeComplete);
+		final TemperatureStats base = chargeComplete && previous.resetArmed() ? NO_RANGE : previous;
+
+		if (isUnreported(rawTenthsC)) {
+			return new TemperatureStats(base.minTenthsC(), base.maxTenthsC(), base.hasData(), fullSeen);
 		}
-		// chargeComplete doubles as the new fullSeen: leaving the full state re-arms the next reset,
-		// staying in it holds the flag so the range is not wiped again on the following tick.
-		if (!previous.hasData()) {
-			return new TemperatureStats(rawTenthsC, rawTenthsC, true, chargeComplete);
+		if (base.isEmpty()) {
+			return new TemperatureStats(rawTenthsC, rawTenthsC, true, fullSeen);
 		}
 		return new TemperatureStats(
-				Math.min(previous.minTenthsC(), rawTenthsC),
-				Math.max(previous.maxTenthsC(), rawTenthsC),
+				Math.min(base.minTenthsC(), rawTenthsC),
+				Math.max(base.maxTenthsC(), rawTenthsC),
 				true,
-				chargeComplete);
+				fullSeen);
+	}
+
+	/**
+	 * Whether this broadcast carried no temperature at all. Exactly 0 is not "0.0 °C": {@link
+	 * SystemService} reads {@code EXTRA_TEMPERATURE} with a default of 0, so on a device that doesn't
+	 * report one every tick would look like a freezing battery. Only 0 is filtered — a genuinely
+	 * alarming reading is the single most useful thing this card can show, so nothing else is second-
+	 * guessed here.
+	 *
+	 * @param rawTenthsC battery temperature in tenths of a degree Celsius
+	 *
+	 * @return true when the reading is the "not reported" default
+	 */
+	static boolean isUnreported(int rawTenthsC) {
+		return rawTenthsC == 0;
+	}
+
+	/**
+	 * The reset flag to carry into the next broadcast. Set the moment a charge completes; cleared only
+	 * once the battery has genuinely dropped out of the full band
+	 * ({@link NotificationService#FULL_PERCENTAGE}).
+	 * <p>
+	 * Re-arming on a bare "no longer full" would fire the reset repeatedly overnight: a phone left on
+	 * the charger drifts 100 → 99 (status {@code CHARGING}) and tops back up again and again, and each
+	 * of those dips would re-arm, so by morning the range would span the last few minutes instead of
+	 * the night. The drop-out band is the one the full-battery alert already re-arms on
+	 * ({@code fullNotified} in {@code BatteryLevelReceiver}). It also holds the flag on charge-capped
+	 * devices, which report FULL well below 100% and would otherwise re-arm on their own resting level
+	 * and reset on every following tick.
+	 *
+	 * @param previous       the range so far
+	 * @param levelPercent   the battery level as a whole percent
+	 * @param chargeComplete whether this broadcast says the charge has finished
+	 *
+	 * @return the new {@code fullSeen} flag
+	 */
+	static boolean nextFullSeen(TemperatureStats previous, int levelPercent, boolean chargeComplete) {
+		if (chargeComplete) {
+			return true;
+		}
+		return levelPercent > NotificationService.FULL_PERCENTAGE && previous.fullSeen();
 	}
 
 	/**
@@ -137,7 +182,7 @@ public final class BatteryTemperatureTracker {
 	 * @return the recorded range, or {@code null} when nothing has been recorded yet
 	 */
 	static TemperatureRange summarize(TemperatureStats stats) {
-		if (!stats.hasData()) {
+		if (stats.isEmpty()) {
 			return null;
 		}
 		return new TemperatureRange(stats.minTenthsC(), stats.maxTenthsC());
@@ -177,6 +222,27 @@ public final class BatteryTemperatureTracker {
 	 *                   fires once per completed charge rather than on every tick while full
 	 */
 	record TemperatureStats(int minTenthsC, int maxTenthsC, boolean hasData, boolean fullSeen) {
+
+		/**
+		 * Whether no usable reading has been folded in yet, so there is no range to widen. Named for
+		 * how it is read — every call site asks about the empty state, and {@code !hasData()} is
+		 * exactly the always-inverted call CODE_REVIEW_GUIDELINES.md asks us to name away.
+		 *
+		 * @return true when the min/max mean nothing yet
+		 */
+		boolean isEmpty() {
+			return !hasData;
+		}
+
+		/**
+		 * Whether a completed charge would still reset the range. The inverse of {@link #fullSeen()},
+		 * named for its one reader for the same reason as {@link #isEmpty()}.
+		 *
+		 * @return true when the next completed charge starts a fresh range
+		 */
+		boolean resetArmed() {
+			return !fullSeen;
+		}
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -23,8 +23,10 @@ import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.model.BatteryHealthGrade;
 import com.almothafar.simplebatterynotifier.service.BatteryCapacityTracker;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
+import com.almothafar.simplebatterynotifier.service.BatteryTemperatureTracker;
 import com.almothafar.simplebatterynotifier.service.SystemService;
 import com.almothafar.simplebatterynotifier.util.GeneralHelper;
+import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -51,6 +53,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 	private View measuredCapacityRange;
 	private TextView measuredCapacityMinText;
 	private TextView measuredCapacityMaxText;
+	private TextView temperatureMinText;
+	private TextView temperatureMaxText;
 
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {
@@ -81,6 +85,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 		measuredCapacityRange = findViewById(R.id.measuredCapacityRange);
 		measuredCapacityMinText = findViewById(R.id.measuredCapacityMinText);
 		measuredCapacityMaxText = findViewById(R.id.measuredCapacityMaxText);
+		temperatureMinText = findViewById(R.id.temperatureMinText);
+		temperatureMaxText = findViewById(R.id.temperatureMaxText);
 
 		// Tap the warning icon (shown only when the reading can't be trusted, #94) to explain why
 		healthWarningIcon.setOnClickListener(v -> showUnreliableReadingDialog());
@@ -128,6 +134,9 @@ public class BatteryInsightsActivity extends BaseActivity {
 
 		// Averaged measured capacity with its min/max spread (#116).
 		showMeasuredCapacity(capacity, unreliable);
+
+		// Coldest/hottest reading since the battery last finished charging (#260).
+		showTemperatureRange(BatteryTemperatureTracker.getRange(this));
 
 		// Metrics and the design-capacity row are shown the same way in every state.
 		chargeCyclesText.setText(String.valueOf(cycles));
@@ -204,6 +213,24 @@ public class BatteryInsightsActivity extends BaseActivity {
 		measuredCapacityMinText.setText(String.valueOf(capacity.minMah()));
 		measuredCapacityMaxText.setText(String.valueOf(capacity.maxMah()));
 		measuredCapacityRange.setVisibility(View.VISIBLE);
+	}
+
+	/**
+	 * Shows the coldest and hottest battery temperature seen since the battery last finished charging
+	 * (#260), in the user's display unit. Both cells read "—" until the monitoring service has folded
+	 * in its first usable reading — on a fresh install, or right after a completed charge reset the
+	 * range.
+	 *
+	 * @param range the recorded temperature range, or null when nothing has been recorded yet
+	 */
+	private void showTemperatureRange(BatteryTemperatureTracker.TemperatureRange range) {
+		if (isNull(range)) {
+			temperatureMinText.setText(R.string.battery_value_pending);
+			temperatureMaxText.setText(R.string.battery_value_pending);
+			return;
+		}
+		temperatureMinText.setText(TemperatureUtils.format(this, range.minTenthsC()));
+		temperatureMaxText.setText(TemperatureUtils.format(this, range.maxTenthsC()));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/BatteryInsightsActivity.java
@@ -25,6 +25,7 @@ import com.almothafar.simplebatterynotifier.service.BatteryCapacityTracker;
 import com.almothafar.simplebatterynotifier.service.BatteryHealthTracker;
 import com.almothafar.simplebatterynotifier.service.BatteryTemperatureTracker;
 import com.almothafar.simplebatterynotifier.service.SystemService;
+import com.almothafar.simplebatterynotifier.ui.widget.MinMaxRangeView;
 import com.almothafar.simplebatterynotifier.util.GeneralHelper;
 import com.almothafar.simplebatterynotifier.util.TemperatureUtils;
 
@@ -50,11 +51,8 @@ public class BatteryInsightsActivity extends BaseActivity {
 	private TextView designCapacityText;
 	private ImageView healthMeasuredInfoIcon;
 	private TextView measuredCapacityText;
-	private View measuredCapacityRange;
-	private TextView measuredCapacityMinText;
-	private TextView measuredCapacityMaxText;
-	private TextView temperatureMinText;
-	private TextView temperatureMaxText;
+	private MinMaxRangeView measuredCapacityRange;
+	private MinMaxRangeView temperatureRange;
 
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {
@@ -83,10 +81,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 		healthMeasuredInfoIcon = findViewById(R.id.healthMeasuredInfoIcon);
 		measuredCapacityText = findViewById(R.id.measuredCapacityText);
 		measuredCapacityRange = findViewById(R.id.measuredCapacityRange);
-		measuredCapacityMinText = findViewById(R.id.measuredCapacityMinText);
-		measuredCapacityMaxText = findViewById(R.id.measuredCapacityMaxText);
-		temperatureMinText = findViewById(R.id.temperatureMinText);
-		temperatureMaxText = findViewById(R.id.temperatureMaxText);
+		temperatureRange = findViewById(R.id.temperatureRange);
 
 		// Tap the warning icon (shown only when the reading can't be trusted, #94) to explain why
 		healthWarningIcon.setOnClickListener(v -> showUnreliableReadingDialog());
@@ -210,8 +205,7 @@ public class BatteryInsightsActivity extends BaseActivity {
 		}
 		// Pass the numbers as Strings so they render in Western digits (0-9) in every locale (#96).
 		measuredCapacityText.setText(getString(R.string.design_capacity_value, String.valueOf(capacity.averageMah())));
-		measuredCapacityMinText.setText(String.valueOf(capacity.minMah()));
-		measuredCapacityMaxText.setText(String.valueOf(capacity.maxMah()));
+		measuredCapacityRange.setRange(String.valueOf(capacity.minMah()), String.valueOf(capacity.maxMah()));
 		measuredCapacityRange.setVisibility(View.VISIBLE);
 	}
 
@@ -225,12 +219,12 @@ public class BatteryInsightsActivity extends BaseActivity {
 	 */
 	private void showTemperatureRange(BatteryTemperatureTracker.TemperatureRange range) {
 		if (isNull(range)) {
-			temperatureMinText.setText(R.string.battery_value_pending);
-			temperatureMaxText.setText(R.string.battery_value_pending);
+			temperatureRange.setPending();
 			return;
 		}
-		temperatureMinText.setText(TemperatureUtils.format(this, range.minTenthsC()));
-		temperatureMaxText.setText(TemperatureUtils.format(this, range.maxTenthsC()));
+		temperatureRange.setRange(
+				TemperatureUtils.format(this, range.minTenthsC()),
+				TemperatureUtils.format(this, range.maxTenthsC()));
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/widget/MinMaxRangeView.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/widget/MinMaxRangeView.java
@@ -1,0 +1,87 @@
+package com.almothafar.simplebatterynotifier.ui.widget;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Typeface;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.almothafar.simplebatterynotifier.R;
+
+/**
+ * The two-column "min / max" mini-table (caption above value) used by the Battery Insights cards that
+ * show a spread rather than a single figure — the measured capacity (#116) and the temperature range
+ * (#260).
+ * <p>
+ * Both cards drew the same eight nested views inline before this existed. An {@code <include>} cannot
+ * carry them: the two instances live in the same layout, so their child ids would collide and the
+ * activity's {@code findViewById} would resolve both cards to whichever came first. A compound view
+ * scopes the lookup to its own subtree, and hands each card a single {@link #setRange} call instead of
+ * two {@code TextView} fields.
+ * <p>
+ * The captions are fixed; the caller styles the values through {@code rangeValueTextSize} and
+ * {@code rangeValueBold}, because the capacity card shows its spread underneath a larger primary
+ * value while the temperature card's spread <em>is</em> its primary value.
+ */
+public class MinMaxRangeView extends LinearLayout {
+
+	// Matches the measured-capacity card, the smaller of the two callers.
+	private static final float DEFAULT_VALUE_TEXT_SIZE_SP = 14f;
+
+	private final TextView minValue;
+	private final TextView maxValue;
+
+	public MinMaxRangeView(Context context, AttributeSet attrs) {
+		super(context, attrs);
+
+		// The row shape belongs to the view, not to every instance tag that uses it.
+		setOrientation(HORIZONTAL);
+		setBaselineAligned(false);
+		setWeightSum(2);
+		inflate(context, R.layout.view_min_max_range, this);
+
+		minValue = findViewById(R.id.rangeMinValue);
+		maxValue = findViewById(R.id.rangeMaxValue);
+		applyValueStyle(context, attrs);
+	}
+
+	/**
+	 * Shows a spread. Both ends are set together — half a range is never meaningful.
+	 *
+	 * @param min the low end, already formatted for display
+	 * @param max the high end, already formatted for display
+	 */
+	public void setRange(CharSequence min, CharSequence max) {
+		minValue.setText(min);
+		maxValue.setText(max);
+	}
+
+	/**
+	 * Shows the placeholder in both cells, for a range that has nothing recorded in it yet.
+	 */
+	public void setPending() {
+		minValue.setText(R.string.battery_value_pending);
+		maxValue.setText(R.string.battery_value_pending);
+	}
+
+	private void applyValueStyle(Context context, AttributeSet attrs) {
+		final float defaultSizePx = TypedValue.applyDimension(
+				TypedValue.COMPLEX_UNIT_SP,
+				DEFAULT_VALUE_TEXT_SIZE_SP,
+				getResources().getDisplayMetrics());
+
+		final TypedArray styled = context.obtainStyledAttributes(attrs, R.styleable.MinMaxRangeView);
+		final float valueSizePx = styled.getDimension(R.styleable.MinMaxRangeView_rangeValueTextSize, defaultSizePx);
+		final boolean bold = styled.getBoolean(R.styleable.MinMaxRangeView_rangeValueBold, false);
+		styled.recycle();
+
+		minValue.setTextSize(TypedValue.COMPLEX_UNIT_PX, valueSizePx);
+		maxValue.setTextSize(TypedValue.COMPLEX_UNIT_PX, valueSizePx);
+		if (bold) {
+			minValue.setTypeface(minValue.getTypeface(), Typeface.BOLD);
+			maxValue.setTypeface(maxValue.getTypeface(), Typeface.BOLD);
+		}
+	}
+}

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -180,65 +180,14 @@
                                 android:textStyle="bold"
                                 android:textColor="@color/battery_details_value_color"/>
 
-                        <!-- min / max spread as a compact two-column mini-table (label above value) -->
-                        <LinearLayout
+                        <!-- min / max spread (shared with the temperature-range card, #260) -->
+                        <com.almothafar.simplebatterynotifier.ui.widget.MinMaxRangeView
                                 android:id="@+id/measuredCapacityRange"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:orientation="horizontal"
-                                android:baselineAligned="false"
-                                android:weightSum="2"
                                 android:layout_marginTop="8dp"
                                 android:visibility="gone"
-                                tools:visibility="visible">
-
-                            <LinearLayout
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_weight="1"
-                                    android:orientation="vertical">
-
-                                <TextView
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/capacity_min_label"
-                                        android:textSize="11sp"
-                                        android:textColor="@color/battery_details_label_color"/>
-
-                                <TextView
-                                        android:id="@+id/measuredCapacityMinText"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:textSize="14sp"
-                                        android:textColor="@color/battery_details_value_color"
-                                        tools:text="4420"/>
-
-                            </LinearLayout>
-
-                            <LinearLayout
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_weight="1"
-                                    android:orientation="vertical">
-
-                                <TextView
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/capacity_max_label"
-                                        android:textSize="11sp"
-                                        android:textColor="@color/battery_details_label_color"/>
-
-                                <TextView
-                                        android:id="@+id/measuredCapacityMaxText"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:textSize="14sp"
-                                        android:textColor="@color/battery_details_value_color"
-                                        tools:text="4580"/>
-
-                            </LinearLayout>
-
-                        </LinearLayout>
+                                tools:visibility="visible"/>
 
                     </LinearLayout>
                 </androidx.cardview.widget.CardView>
@@ -396,67 +345,15 @@
                             android:textColor="@color/battery_details_label_color"
                             android:layout_marginBottom="8dp"/>
 
-                    <!-- min / max as a compact two-column mini-table (label above value), matching the
-                         measured-capacity card. Always visible: the values read "—" until the first
-                         reading lands, so the card never changes height under the user. -->
-                    <LinearLayout
+                    <!-- min / max spread, shared with the measured-capacity card. Always visible: the
+                         values read "—" until the first reading lands, so the card never changes
+                         height under the user. -->
+                    <com.almothafar.simplebatterynotifier.ui.widget.MinMaxRangeView
+                            android:id="@+id/temperatureRange"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
-                            android:baselineAligned="false"
-                            android:weightSum="2">
-
-                        <LinearLayout
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:orientation="vertical">
-
-                            <TextView
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/temperature_min_label"
-                                    android:textSize="11sp"
-                                    android:textColor="@color/battery_details_label_color"/>
-
-                            <TextView
-                                    android:id="@+id/temperatureMinText"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/battery_value_pending"
-                                    android:textSize="18sp"
-                                    android:textStyle="bold"
-                                    android:textColor="@color/battery_details_value_color"
-                                    tools:text="28.4 °C"/>
-
-                        </LinearLayout>
-
-                        <LinearLayout
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:orientation="vertical">
-
-                            <TextView
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/temperature_max_label"
-                                    android:textSize="11sp"
-                                    android:textColor="@color/battery_details_label_color"/>
-
-                            <TextView
-                                    android:id="@+id/temperatureMaxText"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/battery_value_pending"
-                                    android:textSize="18sp"
-                                    android:textStyle="bold"
-                                    android:textColor="@color/battery_details_value_color"
-                                    tools:text="41.9 °C"/>
-
-                        </LinearLayout>
-
-                    </LinearLayout>
+                            app:rangeValueTextSize="18sp"
+                            app:rangeValueBold="true"/>
 
                 </LinearLayout>
             </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/activity_battery_insights.xml
+++ b/app/src/main/res/layout/activity_battery_insights.xml
@@ -367,6 +367,100 @@
 
             </LinearLayout>
 
+            <!-- Temperature Range Card (coldest/hottest of the current charge, #260) -->
+            <androidx.cardview.widget.CardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="16dp"
+                    app:cardCornerRadius="8dp"
+                    app:cardElevation="4dp"
+                    app:contentPadding="16dp">
+
+                <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                    <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/temperature_range"
+                            android:textSize="14sp"
+                            android:textColor="@color/battery_details_label_color"/>
+
+                    <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/temperature_range_basis"
+                            android:textSize="12sp"
+                            android:textColor="@color/battery_details_label_color"
+                            android:layout_marginBottom="8dp"/>
+
+                    <!-- min / max as a compact two-column mini-table (label above value), matching the
+                         measured-capacity card. Always visible: the values read "—" until the first
+                         reading lands, so the card never changes height under the user. -->
+                    <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:baselineAligned="false"
+                            android:weightSum="2">
+
+                        <LinearLayout
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:orientation="vertical">
+
+                            <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/temperature_min_label"
+                                    android:textSize="11sp"
+                                    android:textColor="@color/battery_details_label_color"/>
+
+                            <TextView
+                                    android:id="@+id/temperatureMinText"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/battery_value_pending"
+                                    android:textSize="18sp"
+                                    android:textStyle="bold"
+                                    android:textColor="@color/battery_details_value_color"
+                                    tools:text="28.4 °C"/>
+
+                        </LinearLayout>
+
+                        <LinearLayout
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:orientation="vertical">
+
+                            <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/temperature_max_label"
+                                    android:textSize="11sp"
+                                    android:textColor="@color/battery_details_label_color"/>
+
+                            <TextView
+                                    android:id="@+id/temperatureMaxText"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/battery_value_pending"
+                                    android:textSize="18sp"
+                                    android:textStyle="bold"
+                                    android:textColor="@color/battery_details_value_color"
+                                    tools:text="41.9 °C"/>
+
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
             <!-- Health Description Card -->
             <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/view_min_max_range.xml
+++ b/app/src/main/res/layout/view_min_max_range.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Body of MinMaxRangeView: the two-column "min / max" mini-table shared by the measured-capacity
+     (#116) and temperature-range (#260) cards. Merged into the view itself, which supplies the
+     horizontal orientation and the weight sum, and styles the two value cells from its attributes. -->
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:tools="http://schemas.android.com/tools"
+       tools:parentTag="android.widget.LinearLayout">
+
+    <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/range_min_label"
+                android:textSize="11sp"
+                android:textColor="@color/battery_details_label_color"/>
+
+        <TextView
+                android:id="@+id/rangeMinValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/battery_details_value_color"
+                tools:text="28.4 °C"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/range_max_label"
+                android:textSize="11sp"
+                android:textColor="@color/battery_details_label_color"/>
+
+        <TextView
+                android:id="@+id/rangeMaxValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/battery_details_value_color"
+                tools:text="41.9 °C"/>
+
+    </LinearLayout>
+
+</merge>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -246,12 +246,10 @@
     <string name="design_capacity">السعة التصميمية</string>
     <string name="design_capacity_value">%1$s mAh</string>
     <string name="measured_capacity">السعة المقاسة</string>
-    <string name="capacity_min_label">الأدنى</string>
-    <string name="capacity_max_label">الأعلى</string>
+    <string name="range_min_label">الأدنى</string>
+    <string name="range_max_label">الأعلى</string>
     <string name="temperature_range">نطاق الحرارة</string>
-    <string name="temperature_range_basis">منذ آخر شحن كامل</string>
-    <string name="temperature_min_label">الأدنى</string>
-    <string name="temperature_max_label">الأعلى</string>
+    <string name="temperature_range_basis">منذ آخر مرة اكتمل شحن البطارية</string>
     <string name="health_measured_info_cd">كيف تُقاس صحة البطارية</string>
     <string name="health_measured_info_dialog_title">كيف يُحسب هذا</string>
     <string name="health_measured_info_dialog_message">تقارن قيمة الصحة هذه السعة المقاسة لبطاريتك بالسعة التصميمية التي أدخلتها. تُحسب السعة المقاسة كمتوسط لعدة قراءات على مدى الوقت، لذا تبقى ثابتة بدلاً من التغيّر مع كل تحديث. يوضّح الأدنى والأعلى مدى تفاوت تلك القراءات.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -248,6 +248,10 @@
     <string name="measured_capacity">السعة المقاسة</string>
     <string name="capacity_min_label">الأدنى</string>
     <string name="capacity_max_label">الأعلى</string>
+    <string name="temperature_range">نطاق الحرارة</string>
+    <string name="temperature_range_basis">منذ آخر شحن كامل</string>
+    <string name="temperature_min_label">الأدنى</string>
+    <string name="temperature_max_label">الأعلى</string>
     <string name="health_measured_info_cd">كيف تُقاس صحة البطارية</string>
     <string name="health_measured_info_dialog_title">كيف يُحسب هذا</string>
     <string name="health_measured_info_dialog_message">تقارن قيمة الصحة هذه السعة المقاسة لبطاريتك بالسعة التصميمية التي أدخلتها. تُحسب السعة المقاسة كمتوسط لعدة قراءات على مدى الوقت، لذا تبقى ثابتة بدلاً من التغيّر مع كل تحديث. يوضّح الأدنى والأعلى مدى تفاوت تلك القراءات.</string>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -17,6 +17,13 @@
         <attr name="gaugeLevelDescription" format="string"/>
     </declare-styleable>
 
+    <declare-styleable name="MinMaxRangeView">
+        <!-- Size of the two value cells; the "min"/"max" captions above them are fixed -->
+        <attr name="rangeValueTextSize" format="dimension"/>
+        <!-- Whether the values are the card's primary figure, and so shown bold -->
+        <attr name="rangeValueBold" format="boolean"/>
+    </declare-styleable>
+
     <declare-styleable name="BatteryRangeSliderPreference">
         <!-- SharedPreferences keys the two thumbs persist to -->
         <attr name="criticalKey" format="string"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,12 @@
     <string name="measured_capacity">Measured Capacity</string>
     <string name="capacity_min_label">min</string>
     <string name="capacity_max_label">max</string>
+    <!-- #260: coldest/hottest battery temperature of the current charge, shown in Insights. The range
+         only starts over when a charge finishes, which is what the basis line tells the user. -->
+    <string name="temperature_range">Temperature Range</string>
+    <string name="temperature_range_basis">Since the last full charge</string>
+    <string name="temperature_min_label">min</string>
+    <string name="temperature_max_label">max</string>
     <!-- Info icon (#116) explaining that the measured health/capacity is averaged over many readings -->
     <string name="health_measured_info_cd">How battery health is measured</string>
     <string name="health_measured_info_dialog_title">How this is measured</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,14 +264,14 @@
     <string name="design_capacity_value">%1$s mAh</string>
     <!-- #116: averaged measured capacity shown in Insights, with its min/max spread as a mini-table -->
     <string name="measured_capacity">Measured Capacity</string>
-    <string name="capacity_min_label">min</string>
-    <string name="capacity_max_label">max</string>
+    <!-- Captions of the shared min/max mini-table (MinMaxRangeView), used by the measured-capacity
+         card and the temperature-range card alike -->
+    <string name="range_min_label">min</string>
+    <string name="range_max_label">max</string>
     <!-- #260: coldest/hottest battery temperature of the current charge, shown in Insights. The range
          only starts over when a charge finishes, which is what the basis line tells the user. -->
     <string name="temperature_range">Temperature Range</string>
-    <string name="temperature_range_basis">Since the last full charge</string>
-    <string name="temperature_min_label">min</string>
-    <string name="temperature_max_label">max</string>
+    <string name="temperature_range_basis">Since the battery last finished charging</string>
     <!-- Info icon (#116) explaining that the measured health/capacity is averaged over many readings -->
     <string name="health_measured_info_cd">How battery health is measured</string>
     <string name="health_measured_info_dialog_title">How this is measured</string>

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryTemperatureTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryTemperatureTrackerTest.java
@@ -10,13 +10,13 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the per-charge temperature range (issue #260). The pure helpers carry the feature's
- * correctness: the running min/max, the edge-triggered reset at the end of a charge, and the
- * plausibility gate. Temperatures are tenths of a degree Celsius throughout.
+ * correctness: the running min/max, the edge-triggered reset at the end of a charge with its drop-out
+ * band, and the "device reported no temperature" gate. Temperatures are tenths of a degree Celsius
+ * throughout.
  */
 public class BatteryTemperatureTrackerTest {
 
@@ -61,36 +61,64 @@ public class BatteryTemperatureTrackerTest {
 		stats = BatteryTemperatureTracker.fold(stats, 400, 79, DISCHARGING);
 
 		// An equal state back, so record()'s !equals check skips the write — the save-on-change rule
-		// the trackers share. (Record value equality, not identity: only rejected readings return the
-		// same instance.)
+		// the trackers share.
 		assertEquals(stats, BatteryTemperatureTracker.fold(stats, 300, 78, DISCHARGING));
 	}
 
-	// --- the plausibility gate -----------------------------------------------
+	@Test
+	public void alarminglyHotReading_isRecordedNotDropped() {
+		// 105 °C. "How hot did it actually get?" is the whole question this card answers, so the only
+		// reading ever filtered out is the one that means "no reading" — nothing is second-guessed for
+		// being extreme.
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 250, 80, DISCHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 1050, 78, DISCHARGING);
+
+		assertEquals(1050, stats.maxTenthsC());
+	}
+
+	// --- the "no reading" gate -----------------------------------------------
 
 	@Test
-	public void zeroReading_isRejectedAsNotReported() {
+	public void unreportedReading_isIgnored() {
 		// SystemService defaults EXTRA_TEMPERATURE to 0, so 0 means "this device didn't report one".
-		assertSame(NOTHING_RECORDED, BatteryTemperatureTracker.fold(NOTHING_RECORDED, 0, 80, DISCHARGING));
+		assertEquals(NOTHING_RECORDED, BatteryTemperatureTracker.fold(NOTHING_RECORDED, 0, 80, DISCHARGING));
 	}
 
 	@Test
-	public void readingBelowThePlausibleBand_isRejected() {
-		final int tooCold = BatteryTemperatureTracker.MIN_PLAUSIBLE_TENTHS_C - 1;
-		assertSame(NOTHING_RECORDED, BatteryTemperatureTracker.fold(NOTHING_RECORDED, tooCold, 80, DISCHARGING));
-	}
-
-	@Test
-	public void readingAboveThePlausibleBand_isRejected() {
-		final int tooHot = BatteryTemperatureTracker.MAX_PLAUSIBLE_TENTHS_C + 1;
-		assertSame(NOTHING_RECORDED, BatteryTemperatureTracker.fold(NOTHING_RECORDED, tooHot, 80, DISCHARGING));
-	}
-
-	@Test
-	public void implausibleReading_leavesAnExistingRangeUntouched() {
+	public void unreportedReading_leavesAnExistingRangeUntouched() {
 		final TemperatureStats seeded = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 305, 80, DISCHARGING);
 
-		assertSame(seeded, BatteryTemperatureTracker.fold(seeded, 0, 79, DISCHARGING));
+		assertEquals(seeded, BatteryTemperatureTracker.fold(seeded, 0, 79, DISCHARGING));
+	}
+
+	@Test
+	public void unreportedReading_stillMovesTheResetFlag() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 330, 100, FULL);
+		assertTrue(stats.fullSeen());
+
+		// The flag must not be gated behind a usable reading: on a device that never reports a
+		// temperature it would freeze on whatever a fresh install left it holding.
+		stats = BatteryTemperatureTracker.fold(stats, 0, 60, DISCHARGING);
+
+		assertFalse(stats.fullSeen());
+		assertEquals(330, stats.minTenthsC());
+		assertEquals(330, stats.maxTenthsC());
+	}
+
+	@Test
+	public void chargeCompletingWithNoReading_clearsTheRangeForTheNextOne() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 200, 60, DISCHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 450, 80, CHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 0, 100, FULL);
+
+		// The charge finished, so the old range is stale even though this tick brought nothing to
+		// replace it with.
+		assertTrue(stats.isEmpty());
+		assertTrue(stats.fullSeen());
+
+		stats = BatteryTemperatureTracker.fold(stats, 330, 100, FULL);
+		assertEquals(330, stats.minTenthsC());
+		assertEquals(330, stats.maxTenthsC());
 	}
 
 	// --- the end-of-charge reset ---------------------------------------------
@@ -118,6 +146,33 @@ public class BatteryTemperatureTrackerTest {
 	}
 
 	@Test
+	public void overnightTopUpCycle_doesNotResetTheRangeAgain() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 330, 100, FULL);
+
+		// A phone left on the charger drifts 100 → 99 and tops back up, over and over. Re-arming on a
+		// bare "not full" would wipe the range on each of those cycles, so by morning it would span a
+		// few minutes instead of the night.
+		stats = BatteryTemperatureTracker.fold(stats, 360, 99, CHARGING);
+		assertTrue(stats.fullSeen());
+
+		stats = BatteryTemperatureTracker.fold(stats, 310, 100, FULL);
+
+		assertEquals(310, stats.minTenthsC());
+		assertEquals(360, stats.maxTenthsC());
+	}
+
+	@Test
+	public void leavingFull_reArmsOnlyOnceOutOfTheFullBand() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 330, 100, FULL);
+
+		stats = BatteryTemperatureTracker.fold(stats, 340, 96, DISCHARGING);
+		assertTrue(stats.fullSeen());
+
+		stats = BatteryTemperatureTracker.fold(stats, 350, NotificationService.FULL_PERCENTAGE, DISCHARGING);
+		assertFalse(stats.fullSeen());
+	}
+
+	@Test
 	public void leavingFull_reArmsTheResetForTheNextCharge() {
 		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 330, 100, FULL);
 		stats = BatteryTemperatureTracker.fold(stats, 420, 70, DISCHARGING);
@@ -126,6 +181,18 @@ public class BatteryTemperatureTrackerTest {
 		stats = BatteryTemperatureTracker.fold(stats, 350, 100, FULL);
 		assertEquals(350, stats.minTenthsC());
 		assertEquals(350, stats.maxTenthsC());
+	}
+
+	@Test
+	public void chargeCappedDeviceRestingAtFull_doesNotReArmOnItsOwnLevel() {
+		// A device whose charge cap stops it at 80% reports FULL there. Its resting level is below the
+		// drop-out band, so re-arming on the level alone would reset the range on every tick.
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 300, 80, FULL);
+		stats = BatteryTemperatureTracker.fold(stats, 340, 80, FULL);
+		stats = BatteryTemperatureTracker.fold(stats, 290, 80, FULL);
+
+		assertEquals(290, stats.minTenthsC());
+		assertEquals(340, stats.maxTenthsC());
 	}
 
 	@Test

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryTemperatureTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/BatteryTemperatureTrackerTest.java
@@ -1,0 +1,181 @@
+package com.almothafar.simplebatterynotifier.service;
+
+import android.os.BatteryManager;
+
+import com.almothafar.simplebatterynotifier.service.BatteryTemperatureTracker.TemperatureRange;
+import com.almothafar.simplebatterynotifier.service.BatteryTemperatureTracker.TemperatureStats;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the per-charge temperature range (issue #260). The pure helpers carry the feature's
+ * correctness: the running min/max, the edge-triggered reset at the end of a charge, and the
+ * plausibility gate. Temperatures are tenths of a degree Celsius throughout.
+ */
+public class BatteryTemperatureTrackerTest {
+
+	private static final int DISCHARGING = BatteryManager.BATTERY_STATUS_DISCHARGING;
+	private static final int CHARGING = BatteryManager.BATTERY_STATUS_CHARGING;
+	private static final int FULL = BatteryManager.BATTERY_STATUS_FULL;
+
+	private static final TemperatureStats NOTHING_RECORDED = new TemperatureStats(0, 0, false, false);
+
+	// --- the running range ---------------------------------------------------
+
+	@Test
+	public void firstReading_seedsBothEnds() {
+		final TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 305, 80, DISCHARGING);
+
+		assertEquals(305, stats.minTenthsC());
+		assertEquals(305, stats.maxTenthsC());
+		assertTrue(stats.hasData());
+	}
+
+	@Test
+	public void hotterReading_widensTheMaximum() {
+		final TemperatureStats seeded = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 305, 80, DISCHARGING);
+		final TemperatureStats stats = BatteryTemperatureTracker.fold(seeded, 421, 78, DISCHARGING);
+
+		assertEquals(305, stats.minTenthsC());
+		assertEquals(421, stats.maxTenthsC());
+	}
+
+	@Test
+	public void colderReading_widensTheMinimum() {
+		final TemperatureStats seeded = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 305, 80, DISCHARGING);
+		final TemperatureStats stats = BatteryTemperatureTracker.fold(seeded, 188, 78, DISCHARGING);
+
+		assertEquals(188, stats.minTenthsC());
+		assertEquals(305, stats.maxTenthsC());
+	}
+
+	@Test
+	public void readingInsideTheRange_changesNothing() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 200, 80, DISCHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 400, 79, DISCHARGING);
+
+		// An equal state back, so record()'s !equals check skips the write — the save-on-change rule
+		// the trackers share. (Record value equality, not identity: only rejected readings return the
+		// same instance.)
+		assertEquals(stats, BatteryTemperatureTracker.fold(stats, 300, 78, DISCHARGING));
+	}
+
+	// --- the plausibility gate -----------------------------------------------
+
+	@Test
+	public void zeroReading_isRejectedAsNotReported() {
+		// SystemService defaults EXTRA_TEMPERATURE to 0, so 0 means "this device didn't report one".
+		assertSame(NOTHING_RECORDED, BatteryTemperatureTracker.fold(NOTHING_RECORDED, 0, 80, DISCHARGING));
+	}
+
+	@Test
+	public void readingBelowThePlausibleBand_isRejected() {
+		final int tooCold = BatteryTemperatureTracker.MIN_PLAUSIBLE_TENTHS_C - 1;
+		assertSame(NOTHING_RECORDED, BatteryTemperatureTracker.fold(NOTHING_RECORDED, tooCold, 80, DISCHARGING));
+	}
+
+	@Test
+	public void readingAboveThePlausibleBand_isRejected() {
+		final int tooHot = BatteryTemperatureTracker.MAX_PLAUSIBLE_TENTHS_C + 1;
+		assertSame(NOTHING_RECORDED, BatteryTemperatureTracker.fold(NOTHING_RECORDED, tooHot, 80, DISCHARGING));
+	}
+
+	@Test
+	public void implausibleReading_leavesAnExistingRangeUntouched() {
+		final TemperatureStats seeded = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 305, 80, DISCHARGING);
+
+		assertSame(seeded, BatteryTemperatureTracker.fold(seeded, 0, 79, DISCHARGING));
+	}
+
+	// --- the end-of-charge reset ---------------------------------------------
+
+	@Test
+	public void chargeCompleting_startsAFreshRangeAtThatReading() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 200, 60, CHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 450, 90, CHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 330, 100, FULL);
+
+		assertEquals(330, stats.minTenthsC());
+		assertEquals(330, stats.maxTenthsC());
+		assertTrue(stats.fullSeen());
+	}
+
+	@Test
+	public void stayingAtFull_doesNotKeepResettingTheRange() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 330, 100, FULL);
+		// Still plugged in at full: these must widen the new range, not wipe it on every tick.
+		stats = BatteryTemperatureTracker.fold(stats, 360, 100, FULL);
+		stats = BatteryTemperatureTracker.fold(stats, 310, 100, FULL);
+
+		assertEquals(310, stats.minTenthsC());
+		assertEquals(360, stats.maxTenthsC());
+	}
+
+	@Test
+	public void leavingFull_reArmsTheResetForTheNextCharge() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 330, 100, FULL);
+		stats = BatteryTemperatureTracker.fold(stats, 420, 70, DISCHARGING);
+		assertFalse(stats.fullSeen());
+
+		stats = BatteryTemperatureTracker.fold(stats, 350, 100, FULL);
+		assertEquals(350, stats.minTenthsC());
+		assertEquals(350, stats.maxTenthsC());
+	}
+
+	@Test
+	public void plugInAndUnplugAlone_doNotResetTheRange() {
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 250, 40, DISCHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 430, 55, CHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 300, 70, DISCHARGING);
+
+		// The charge never completed, so the range still spans the whole stretch.
+		assertEquals(250, stats.minTenthsC());
+		assertEquals(430, stats.maxTenthsC());
+	}
+
+	@Test
+	public void fullLevelWithoutFullStatus_countsAsComplete() {
+		// Some OEMs report 100% a tick before the status catches up.
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 250, 90, CHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 400, 100, CHARGING);
+
+		assertEquals(400, stats.minTenthsC());
+		assertEquals(400, stats.maxTenthsC());
+	}
+
+	@Test
+	public void fullStatusBelowFullLevel_countsAsComplete() {
+		// A device with a charge cap reports FULL well short of 100%.
+		TemperatureStats stats = BatteryTemperatureTracker.fold(NOTHING_RECORDED, 250, 70, CHARGING);
+		stats = BatteryTemperatureTracker.fold(stats, 400, 80, FULL);
+
+		assertEquals(400, stats.minTenthsC());
+		assertEquals(400, stats.maxTenthsC());
+	}
+
+	@Test
+	public void isChargeComplete_isFalseWhileStillCharging() {
+		assertFalse(BatteryTemperatureTracker.isChargeComplete(99, CHARGING));
+	}
+
+	// --- the display view ----------------------------------------------------
+
+	@Test
+	public void summarize_isNullBeforeAnythingIsRecorded() {
+		assertNull(BatteryTemperatureTracker.summarize(NOTHING_RECORDED));
+	}
+
+	@Test
+	public void summarize_exposesTheRecordedRange() {
+		final TemperatureStats stats = new TemperatureStats(188, 421, true, false);
+		final TemperatureRange range = BatteryTemperatureTracker.summarize(stats);
+
+		assertEquals(new TemperatureRange(188, 421), range);
+	}
+}


### PR DESCRIPTION
Closes #260

## The problem

The battery temperature is read on every broadcast but was never retained, so after the fact there was no way to tell whether the battery brushed the alert threshold for a minute or spent the afternoon there — and no sense of what a normal temperature looks like on your own device.

## The change

A new **Temperature Range** card in Battery Insights showing the coldest and hottest reading, in the user's display unit (reuses `TemperatureUtils.format`, so °C/°F and the Western-digit convention are already handled).

### The window

The range accumulates continuously and resets **only when a charge completes**. Plugging in, unplugging and the clock do nothing.

- "Charge complete" is `BATTERY_STATUS_FULL` **or** a level of 100. The status alone misses devices whose charge cap stops them short of 100 %; the level alone misses OEMs that report full a tick early.
- The reset is edge-triggered through a `fullSeen` flag, so it fires once per completed charge. Same fire-once-then-re-arm shape as the full-battery alert's `fullNotified`.
- Re-arming needs the battery to drop **out of the full band** (`NotificationService.FULL_PERCENTAGE`, 95 %), not merely to stop reading full. A phone left on the charger drifts 100 → 99 (status `CHARGING`) and tops back up over and over, so a bare "no longer full" would re-arm on every one of those dips and the range would span the last few minutes by morning instead of the night. The same band also holds the flag on charge-capped devices, which rest at FULL well below 100 % and would otherwise re-arm on their own resting level.
- The end-of-charge bookkeeping is decided **before** the reading is judged. Gating it behind a usable reading would freeze the flag forever on a device that never reports a temperature.

### The tracker

`BatteryTemperatureTracker` holds a running min/max plus that flag in the backup-excluded `battery_transient` prefs (another device's range says nothing about this one). Fed the whole `BatteryDO` from `BatteryLevelReceiver.onReceive` next to `BatteryHealthTracker.recordBatteryState`, so no new polling. Pure `fold`/`summarize` helpers, mirroring `BatteryCapacityTracker`.

Two details worth flagging:

- **Only a reading of exactly `0` is rejected.** `SystemService` reads `EXTRA_TEMPERATURE` with a default of 0, so on a device that doesn't report a temperature every tick would look like a freezing battery. Nothing else is second-guessed — "how hot did it actually get?" is the whole question this card answers, so an alarmingly high reading is the last thing it should quietly discard.
- **No sample count.** It would change on every tick and defeat the save-on-change rule the other trackers follow; `hasData` flips once and after that only a genuinely wider range writes.

## Other files

- `ui/widget/MinMaxRangeView` + `layout/view_min_max_range.xml` + two `attrs.xml` entries — the two-column min/max mini-table, now shared by this card and the measured-capacity card instead of being drawn inline twice. An `<include>` can't carry it: both instances live in one layout, so their child ids would collide and `findViewById` would resolve both cards to whichever came first. The compound view scopes the lookup to its own subtree and hands each card one `setRange` call in place of two `TextView` fields.
- `values/strings.xml` + `values-ar/strings.xml` — the duplicate min/max captions folded into one pair (`range_min_label` / `range_max_label`), plus two new strings for the card, kept in parity across both locales.
- `CONTEXT.md` — a **Temperature range** glossary entry, since `CLAUDE.md` makes the glossary binding for UI and code wording. The card's basis line uses that wording verbatim.

## Tests

`BatteryTemperatureTrackerTest` covers the running range, the "no reading" gate (`0` alone, and that it leaves an existing range untouched while still moving the reset flag), and the reset: a completed charge starts a fresh range; staying at full does not keep resetting; the overnight 100 → 99 → 100 top-up cycle does not reset again; re-arming waits for the drop out of the full band; a charge-capped device resting at FULL does not re-arm on its own level; plug-in/unplug alone do not reset; full-level-without-full-status and full-status-below-full-level both count; a completed charge that carried no reading clears the range for the next one.

## Manual verification

Not run — no device available in this environment. Worth checking on hardware:

1. The card reads "—" on a fresh install, then real min/max once a broadcast lands.
2. Switching the unit preference to Fahrenheit — both values should follow.
3. The card in Arabic (RTL) for wrapping, and the reworded basis line.
4. Charging to full collapses the range to that moment and it widens again; leaving the phone on the charger overnight leaves one range spanning the night, not the last few minutes.
5. The measured-capacity card's min/max still renders as before, now that both cards share one view.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8Rjarp53XHQEaZYX4SwTD)_
