### PR TITLE
fix: dismiss the full-battery alert when the charger comes out

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -61,6 +61,9 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 *   <li>the temperature flag — a hot spell doesn't end at unplug; cooling below the threshold
 	 *       (the hysteresis in {@link #decideTemperature}) is its only re-arm.</li>
 	 * </ul>
+	 * This is the prompt path, driven by the unplug transition. It is not the only one:
+	 * {@link #decideLevelAlert} re-arms (and dismisses a stale full alert) from the plugged state on
+	 * any later broadcast, so a transition missed while the process was dead still resolves.
 	 *
 	 * @param context The application context
 	 */
@@ -85,6 +88,10 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		final int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
 		final boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING;
 		final boolean isFull = status == BatteryManager.BATTERY_STATUS_FULL;
+		// The cable, not the status, is what bounds the full-battery alert: plenty of devices keep
+		// reporting BATTERY_STATUS_FULL while sitting at 100% with the charger already out. See
+		// decideLevelAlert.
+		final boolean isPlugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0) > 0;
 
 		// Build the reading from the delivered intent; with a non-null intent this never returns null.
 		final BatteryDO batteryDO = SystemService.getBatteryInfo(context, intent);
@@ -112,12 +119,17 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_every_tick), false));
 
 		final LevelAlertState previous = loadLevelState(sharedPref);
-		final LevelAlertDecision decision = decideLevelAlert(previous, percentage, isCharging, isFull, config);
+		final LevelAlertDecision decision = decideLevelAlert(previous, percentage, isCharging, isFull, isPlugged, config);
 
 		// Persist only on change: most broadcasts (voltage/temperature deltas) re-decide an identical
 		// state, and rewriting it would churn SharedPreferences on every tick.
 		if (!decision.newState().equals(previous)) {
 			saveLevelState(sharedPref, decision.newState());
+		}
+		// Dismiss before sending, never after: level alerts share one notification ID, so a new alert
+		// decided on this same broadcast replaces the stale full one and must not then be cancelled.
+		if (decision.clearFullAlert()) {
+			NotificationService.clearLevelAlert(context);
 		}
 		if (nonNull(decision.notifyType())) {
 			NotificationService.sendNotification(context, decision.notifyType());
@@ -170,23 +182,42 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * dependencies (#164). A changed level while discharging is judged against the thresholds; an
 	 * unchanged level or a charging/full state runs the full-battery logic instead — the same split
 	 * the receiver has always used, now explicit.
+	 * <p>
+	 * The full-battery alert is bounded by the <em>charger</em>, not by the status: a battery sitting
+	 * at 100% keeps reporting {@code BATTERY_STATUS_FULL} on many devices long after the cable is out.
+	 * Unplugged, therefore, the alert can neither fire (it would re-post itself the instant the unplug
+	 * dismissal cleared it, reading as a notification that refuses to go away) nor stay shown — "you
+	 * can unplug now" is answered once the charger is out, so a displayed one is dismissed here. That
+	 * dismissal is deliberately state-driven rather than left to the unplug broadcast alone: when the
+	 * process is killed mid-charge (doze, OEM task killers) nobody sees that transition, and the alert
+	 * would otherwise linger — un-swipeable, when the user has the sticky-notification preference on.
 	 *
 	 * @param state      current persisted episode state
 	 * @param percentage current battery percentage (whole, via the single rounding policy #158)
 	 * @param charging   whether the battery status is {@code BATTERY_STATUS_CHARGING}
 	 * @param full       whether the battery status is {@code BATTERY_STATUS_FULL}
+	 * @param plugged    whether a charger is connected ({@code EXTRA_PLUGGED} is non-zero)
 	 * @param config     the user's alert thresholds and toggles
 	 *
-	 * @return which alert to send now ({@code null} for none) and the new state to persist
+	 * @return which alert to send now ({@code null} for none), whether to dismiss a stale full alert,
+	 * and the new state to persist
 	 */
 	static LevelAlertDecision decideLevelAlert(final LevelAlertState state, final int percentage,
 	                                           final boolean charging, final boolean full,
-	                                           final LevelAlertConfig config) {
-		final boolean levelChanged = state.prevLevel() != percentage;
-		if (levelChanged && !charging) {
-			return decideDischarging(state, percentage, config);
-		}
-		return decideChargingOrFull(state, percentage, full, config);
+	                                           final boolean plugged, final LevelAlertConfig config) {
+		// Off the charger a shown full alert is stale, and the episode re-arms for the next charge —
+		// the same re-arm PowerConnectionReceiver applies on the unplug broadcast it did see.
+		final boolean staleFullAlert = !plugged && state.fullNotified();
+		final LevelAlertState current = staleFullAlert
+		                                ? new LevelAlertState(state.prevLevel(), state.prevType(), false)
+		                                : state;
+
+		final boolean levelChanged = current.prevLevel() != percentage;
+		final LevelAlertDecision decision = levelChanged && !charging
+		                                    ? decideDischarging(current, percentage, config)
+		                                    : decideChargingOrFull(current, percentage, full && plugged, config);
+
+		return new LevelAlertDecision(decision.notifyType(), decision.newState(), staleFullAlert);
 	}
 
 	/**
@@ -210,26 +241,32 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 			}
 			prevType = AlertType.WARNING;
 		}
-		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, prevType, state.fullNotified()));
+		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, prevType, state.fullNotified()), false);
 	}
 
 	/**
 	 * The charging-or-unchanged side: the full alert fires once per charge session, re-armed once
 	 * the level has genuinely dropped out of the full band while staying above the warning band.
+	 *
+	 * @param state         current persisted episode state
+	 * @param percentage    current battery percentage
+	 * @param fullOnCharger charge complete <em>and</em> still on the charger — the status alone is not
+	 *                      enough, see {@link #decideLevelAlert}
+	 * @param config        the user's alert thresholds and toggles
 	 */
 	private static LevelAlertDecision decideChargingOrFull(final LevelAlertState state, final int percentage,
-	                                                       final boolean full, final LevelAlertConfig config) {
+	                                                       final boolean fullOnCharger, final LevelAlertConfig config) {
 		boolean fullNotified = state.fullNotified();
 		AlertType notifyType = null;
 
-		if (!fullNotified && full && config.fullNotifyEnabled()) {
+		if (!fullNotified && fullOnCharger && config.fullNotifyEnabled()) {
 			notifyType = AlertType.FULL;
 			fullNotified = true;
 		}
 		if (percentage <= NotificationService.FULL_PERCENTAGE && percentage > config.warningLevel()) {
 			fullNotified = false;
 		}
-		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, state.prevType(), fullNotified));
+		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, state.prevType(), fullNotified), false);
 	}
 
 	/**
@@ -304,12 +341,15 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	}
 
 	/**
-	 * Result of {@link #decideLevelAlert}: which alert to send now, and the state to persist.
+	 * Result of {@link #decideLevelAlert}: which alert to send now, whether a stale full alert is
+	 * still on screen, and the state to persist.
 	 *
-	 * @param notifyType the alert to send, or {@code null} for none
-	 * @param newState   the state to persist
+	 * @param notifyType     the alert to send, or {@code null} for none
+	 * @param newState       the state to persist
+	 * @param clearFullAlert whether a full-battery alert shown from a finished charge session must be
+	 *                       dismissed (the charger is out)
 	 */
-	record LevelAlertDecision(AlertType notifyType, LevelAlertState newState) {
+	record LevelAlertDecision(AlertType notifyType, LevelAlertState newState, boolean clearFullAlert) {
 	}
 
 	/**

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
@@ -17,9 +17,9 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link BatteryLevelReceiver}'s pure decision cores (#164), in the
  * {@code FastDrainDetectorTest} style: the critical/warning de-dupe, the red-alert override, the
- * full-once-per-charge episode with its re-arm band, and the temperature hysteresis. Because the
- * state is now a value passed in and returned, every test doubles as a process-restart test: the
- * decision depends only on what was persisted, not on in-memory history.
+ * full-once-per-charge episode with its re-arm band and its unplug dismissal, and the temperature
+ * hysteresis. Because the state is now a value passed in and returned, every test doubles as a
+ * process-restart test: the decision depends only on what was persisted, not on in-memory history.
  */
 public class BatteryLevelReceiverDecisionTest {
 
@@ -28,24 +28,30 @@ public class BatteryLevelReceiverDecisionTest {
 	private static final int THRESHOLD_C = 45;
 
 	private static final LevelAlertConfig DEFAULTS = new LevelAlertConfig(CRITICAL, WARNING, true, true, false);
-	private static final LevelAlertState FRESH = new LevelAlertState(0, null, false);
 
 	private static final boolean DISCHARGING = false;
+	// A completed charge reports BATTERY_STATUS_FULL rather than CHARGING, so the full cases are
+	// "not charging" without being a discharge.
+	private static final boolean NOT_CHARGING = false;
+	private static final boolean CHARGING = true;
 	private static final boolean NOT_FULL = false;
+	private static final boolean FULL = true;
+	private static final boolean PLUGGED = true;
+	private static final boolean UNPLUGGED = false;
 
 	// --- discharging: critical/warning thresholds and de-dupe -----------------------------------
 
 	@Test
 	public void discharging_belowCritical_firesCriticalOnce() {
 		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(16, null, false), 15, DISCHARGING, NOT_FULL, DEFAULTS);
+				new LevelAlertState(16, null, false), 15, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, first.notifyType());
 		assertEquals(new LevelAlertState(15, AlertType.CRITICAL, false), first.newState());
 
 		// Next tick, still below critical: the persisted prevType suppresses the duplicate.
 		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
-				first.newState(), 14, DISCHARGING, NOT_FULL, DEFAULTS);
+				first.newState(), 14, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 		assertNull(second.notifyType());
 		assertEquals(14, second.newState().prevLevel());
 	}
@@ -53,19 +59,19 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void discharging_inWarningBand_firesWarningOnce() {
 		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(41, null, false), 38, DISCHARGING, NOT_FULL, DEFAULTS);
+				new LevelAlertState(41, null, false), 38, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 
 		assertEquals(AlertType.WARNING, first.notifyType());
 
 		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
-				first.newState(), 35, DISCHARGING, NOT_FULL, DEFAULTS);
+				first.newState(), 35, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 		assertNull(second.notifyType());
 	}
 
 	@Test
 	public void discharging_aboveWarning_noAlert() {
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(81, null, false), 80, DISCHARGING, NOT_FULL, DEFAULTS);
+				new LevelAlertState(81, null, false), 80, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 
 		assertNull(d.notifyType());
 		assertEquals(80, d.newState().prevLevel());
@@ -75,7 +81,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void discharging_warningDisabled_staysSilentInWarningBand() {
 		final LevelAlertConfig noWarning = new LevelAlertConfig(CRITICAL, WARNING, false, true, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(41, null, false), 38, DISCHARGING, NOT_FULL, noWarning);
+				new LevelAlertState(41, null, false), 38, DISCHARGING, NOT_FULL, UNPLUGGED, noWarning);
 
 		assertNull(d.notifyType());
 	}
@@ -84,7 +90,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void discharging_warningThenCritical_escalates() {
 		final LevelAlertState afterWarning = new LevelAlertState(35, AlertType.WARNING, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				afterWarning, 20, DISCHARGING, NOT_FULL, DEFAULTS);
+				afterWarning, 20, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
@@ -94,7 +100,7 @@ public class BatteryLevelReceiverDecisionTest {
 		final LevelAlertConfig everyTick = new LevelAlertConfig(CRITICAL, WARNING, true, true, true);
 		final LevelAlertState alreadyCritical = new LevelAlertState(15, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				alreadyCritical, 14, DISCHARGING, NOT_FULL, everyTick);
+				alreadyCritical, 14, DISCHARGING, NOT_FULL, UNPLUGGED, everyTick);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
@@ -104,7 +110,7 @@ public class BatteryLevelReceiverDecisionTest {
 		// Already alerted critical this episode, but at/below the red-alert level it must re-fire.
 		final LevelAlertState alreadyCritical = new LevelAlertState(5, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				alreadyCritical, NotificationService.RED_ALERT_LEVEL, DISCHARGING, NOT_FULL, DEFAULTS);
+				alreadyCritical, NotificationService.RED_ALERT_LEVEL, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
@@ -114,7 +120,7 @@ public class BatteryLevelReceiverDecisionTest {
 		// Same level as last tick routes to the charging-or-full branch (the receiver's historical
 		// split), so a repeated broadcast at the same percentage can't duplicate a level alert.
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(15, AlertType.CRITICAL, false), 15, DISCHARGING, NOT_FULL, DEFAULTS);
+				new LevelAlertState(15, AlertType.CRITICAL, false), 15, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 
 		assertNull(d.notifyType());
 	}
@@ -124,12 +130,14 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void charging_full_firesOnceThenHolds() {
 		final LevelAlertState atHundred = new LevelAlertState(100, null, false);
-		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(atHundred, 100, false, true, DEFAULTS);
+		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
+				atHundred, 100, NOT_CHARGING, FULL, PLUGGED, DEFAULTS);
 
 		assertEquals(AlertType.FULL, first.notifyType());
 		assertTrue(first.newState().fullNotified());
 
-		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(first.newState(), 100, false, true, DEFAULTS);
+		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
+				first.newState(), 100, NOT_CHARGING, FULL, PLUGGED, DEFAULTS);
 		assertNull(second.notifyType());
 	}
 
@@ -137,7 +145,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void charging_fullDisabled_staysSilent() {
 		final LevelAlertConfig noFull = new LevelAlertConfig(CRITICAL, WARNING, true, false, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(100, null, false), 100, false, true, noFull);
+				new LevelAlertState(100, null, false), 100, NOT_CHARGING, FULL, PLUGGED, noFull);
 
 		assertNull(d.notifyType());
 		assertFalse(d.newState().fullNotified());
@@ -147,7 +155,8 @@ public class BatteryLevelReceiverDecisionTest {
 	public void charging_levelLeavesFullBand_reArmsFullAlert() {
 		// Notified at full, then the level drops to 90 (≤ FULL_PERCENTAGE, above warning): re-armed.
 		final LevelAlertState notified = new LevelAlertState(100, null, true);
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(notified, 90, true, NOT_FULL, DEFAULTS);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				notified, 90, CHARGING, NOT_FULL, PLUGGED, DEFAULTS);
 
 		assertNull(d.notifyType());
 		assertFalse(d.newState().fullNotified());
@@ -157,9 +166,81 @@ public class BatteryLevelReceiverDecisionTest {
 	public void charging_belowWarningBand_doesNotReArmFullAlert() {
 		// The re-arm band is (warning, FULL_PERCENTAGE]: charging low keeps the flag as-is.
 		final LevelAlertState notified = new LevelAlertState(100, null, true);
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(notified, 30, true, NOT_FULL, DEFAULTS);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				notified, 30, CHARGING, NOT_FULL, PLUGGED, DEFAULTS);
 
 		assertTrue(d.newState().fullNotified());
+	}
+
+	// --- unplugged: the full alert is bounded by the charger, not by the status --------------------
+
+	@Test
+	public void unplugged_stillReportingFull_neverFires() {
+		// The status stays BATTERY_STATUS_FULL at 100% on plenty of devices with the cable already out.
+		// Firing here is what made the alert look like it refused to go away: the unplug handler cleared
+		// it and the very next broadcast posted it straight back.
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				new LevelAlertState(100, null, false), 100, NOT_CHARGING, FULL, UNPLUGGED, DEFAULTS);
+
+		assertNull(d.notifyType());
+		assertFalse(d.newState().fullNotified());
+		assertFalse(d.clearFullAlert());
+	}
+
+	@Test
+	public void unplugged_withFullAlertShown_dismissesItOnce() {
+		// Missed unplug broadcast (process killed mid-charge): the shown alert is dismissed from the
+		// plugged state instead, then the episode is re-armed so nothing dismisses twice.
+		final LevelAlertState notified = new LevelAlertState(100, null, true);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				notified, 100, NOT_CHARGING, FULL, UNPLUGGED, DEFAULTS);
+
+		assertTrue(d.clearFullAlert());
+		assertNull(d.notifyType());
+		assertFalse(d.newState().fullNotified());
+
+		final LevelAlertDecision next = BatteryLevelReceiver.decideLevelAlert(
+				d.newState(), 99, DISCHARGING, FULL, UNPLUGGED, DEFAULTS);
+		assertFalse(next.clearFullAlert());
+		assertNull(next.notifyType());
+	}
+
+	@Test
+	public void unplugged_levelAlreadyDropping_stillDismissesTheFullAlert() {
+		// The discharge branch (changed level) must clear it too — otherwise a restart that first sees
+		// 99% leaves the alert up until the next charge session.
+		final LevelAlertState notified = new LevelAlertState(100, null, true);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				notified, 98, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+
+		assertTrue(d.clearFullAlert());
+		assertFalse(d.newState().fullNotified());
+	}
+
+	@Test
+	public void unplugged_dischargedToCritical_stillAlertsWhileDismissingTheStaleFull() {
+		// Both at once: the receiver dismisses first and posts after, so the critical alert survives
+		// (they share one notification ID).
+		final LevelAlertState notified = new LevelAlertState(21, null, true);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				notified, 19, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+
+		assertTrue(d.clearFullAlert());
+		assertEquals(AlertType.CRITICAL, d.notifyType());
+	}
+
+	@Test
+	public void replugged_afterUnplugAtFull_firesAgain() {
+		// The unplug re-arm is what lets a charger connected at 100% alert again, so it must survive
+		// the dismissal path above.
+		final LevelAlertState notified = new LevelAlertState(100, null, true);
+		final LevelAlertDecision unplugged = BatteryLevelReceiver.decideLevelAlert(
+				notified, 100, NOT_CHARGING, FULL, UNPLUGGED, DEFAULTS);
+		final LevelAlertDecision replugged = BatteryLevelReceiver.decideLevelAlert(
+				unplugged.newState(), 100, NOT_CHARGING, FULL, PLUGGED, DEFAULTS);
+
+		assertEquals(AlertType.FULL, replugged.notifyType());
+		assertFalse(replugged.clearFullAlert());
 	}
 
 	// --- charger-disconnect reset semantics (via the pure state) ---------------------------------
@@ -170,7 +251,7 @@ public class BatteryLevelReceiverDecisionTest {
 		// same as it would have been in-process — no duplicate critical while still below threshold.
 		final LevelAlertState persisted = new LevelAlertState(15, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				persisted, 13, DISCHARGING, NOT_FULL, DEFAULTS);
+				persisted, 13, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
 
 		assertNull(d.notifyType());
 	}


### PR DESCRIPTION
The "Battery fully charged" notification stayed on screen after unplugging.

## The bug

`decideChargingOrFull` treated `BATTERY_STATUS_FULL` as the whole trigger, never asking whether a charger was actually connected. Plenty of devices keep reporting that status while sitting at 100% with the cable already out, so on unplug:

1. `PowerConnectionReceiver.handleChargerDisconnected` cancels the notification and clears `fullNotified` to re-arm the next charge session.
2. The very next `ACTION_BATTERY_CHANGED` — still reporting `FULL`, now against a freshly cleared flag — posts the alert straight back.

The alert is cleared and immediately re-posted, which reads as a notification that refuses to go away. With the sticky-notification preference on it carries `FLAG_NO_CLEAR`, so it can't be swiped either.

A second path reached the same symptom: when the process is killed mid-charge (doze, OEM task killers) nobody sees the unplug broadcast, so nothing ever clears the alert.

## The fix

The full alert is now bounded by the **charger**, not by the status.

- `BatteryLevelReceiver` reads `EXTRA_PLUGGED` and passes it into the decision core; the alert fires only on `full && plugged`, so off the charger it cannot re-post itself.
- A shown full alert is dismissed from the *plugged state* rather than from the unplug transition alone, so a transition missed while the process was dead still resolves on the next broadcast instead of stranding the notification until the following charge. The same step re-arms the episode, matching what `PowerConnectionReceiver` already does on the transition it does see.
- Dismissal runs **before** dispatch in `onReceive`: level alerts share one notification ID, so an alert decided on the same broadcast (a critical one, on a battery unplugged at full that then drained) must replace the stale notification rather than be cancelled after it.

Unchanged: the once-per-charge behaviour, the `(warning, FULL_PERCENTAGE]` re-arm band, and re-firing when a charger is connected at an already-full battery — each pinned by a test.

## Tests

Five new cases in `BatteryLevelReceiverDecisionTest` covering the regression itself (unplugged while still reporting `FULL`), the dismissal of a stale alert on both the charging-or-full and the discharge branch, the critical-alert-survives-the-dismissal ordering, and the re-plug case. `testDebugUnitTest` and `lintDebug` both pass.

Also drops an unused constant (`FRESH`) in the test file.

---
_Generated by [Claude Code](https://claude.ai/code/session_016VvXe4CxGMYwGSC3UgUDru)_