### PR TITLE
fix: close the whole charge session when the unplug broadcast is missed

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -50,6 +50,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	private static final String PREF_PREV_LEVEL = "_level_alert_prev_level";
 	private static final String PREF_PREV_TYPE = "_level_alert_prev_type";
 	private static final String PREF_FULL_NOTIFIED = "_level_alert_full_notified";
+	private static final String PREF_FULL_ALERT_SHOWN = "_level_alert_full_shown";
 	private static final String PREF_TEMPERATURE_ALERTED = "_temperature_alert_sent";
 
 	/**
@@ -63,22 +64,37 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 *       (the hysteresis in {@link #decideTemperature}) is its only re-arm.</li>
 	 * </ul>
 	 * This is the prompt path, driven by the unplug transition. It is not the only one:
-	 * {@link #decideLevelAlert} re-arms (and dismisses a stale full alert) from the plugged state on
-	 * any later broadcast, so a transition missed while the process was dead still resolves.
+	 * {@link #decideLevelAlert} applies the very same {@link #reArmForNewDischarge} reset — and
+	 * dismisses a stale full alert — as soon as a broadcast reports the charger out, so a transition
+	 * missed while the process was dead resolves identically rather than only half-resolving.
 	 *
 	 * @param context The application context
 	 */
-	public static void onChargerDisconnected(final Context context) {
+	public static void onChargerDisconnected(Context context) {
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 		final LevelAlertState state = loadLevelState(prefs);
-		final LevelAlertState reset = new LevelAlertState(state.prevLevel(), null, false);
+		final LevelAlertState reset = reArmForNewDischarge(state);
 		if (!reset.equals(state)) {
 			saveLevelState(prefs, reset);
 		}
 	}
 
+	/**
+	 * The charge-session reset both unplug paths share: re-arm the full-battery alert and the
+	 * critical/warning de-dupe, and forget any full alert that was on screen. Keeping this in one
+	 * place is what makes the transition path ({@link #onChargerDisconnected}) and the state-driven
+	 * fallback in {@link #decideLevelAlert} provably equivalent.
+	 *
+	 * @param state the episode state to reset
+	 *
+	 * @return the state a fresh discharge session starts from
+	 */
+	private static LevelAlertState reArmForNewDischarge(LevelAlertState state) {
+		return new LevelAlertState(state.prevLevel(), null, false, false);
+	}
+
 	@Override
-	public void onReceive(final Context context, final Intent intent) {
+	public void onReceive(Context context, Intent intent) {
 		// The receiver is registered for ACTION_BATTERY_CHANGED (see PowerConnectionService), so the
 		// delivered intent already carries the battery state — no need to re-query the sticky
 		// broadcast (#159). The action check guards against unexpected/spoofed intents.
@@ -87,12 +103,13 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		}
 
 		final int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
-		final boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING;
-		final boolean isFull = status == BatteryManager.BATTERY_STATUS_FULL;
 		// The cable, not the status, is what bounds the full-battery alert: plenty of devices keep
 		// reporting BATTERY_STATUS_FULL while sitting at 100% with the charger already out. See
 		// decideLevelAlert.
-		final boolean isPlugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0) > 0;
+		final ChargeState power = new ChargeState(
+				status == BatteryManager.BATTERY_STATUS_CHARGING,
+				status == BatteryManager.BATTERY_STATUS_FULL,
+				intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0) > 0);
 
 		// Build the reading from the delivered intent; with a non-null intent this never returns null.
 		final BatteryDO batteryDO = SystemService.getBatteryInfo(context, intent);
@@ -117,30 +134,8 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		BatteryTemperatureTracker.record(context, batteryDO);
 
 		final SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
-		final LevelAlertConfig config = new LevelAlertConfig(
-				AppPrefs.criticalLevel(context),
-				AppPrefs.warningLevel(context),
-				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_warning_level), true),
-				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_full_level), true),
-				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_every_tick), false));
 
-		final LevelAlertState previous = loadLevelState(sharedPref);
-		final LevelAlertDecision decision = decideLevelAlert(previous, percentage, isCharging, isFull, isPlugged, config);
-
-		// Persist only on change: most broadcasts (voltage/temperature deltas) re-decide an identical
-		// state, and rewriting it would churn SharedPreferences on every tick.
-		if (!decision.newState().equals(previous)) {
-			saveLevelState(sharedPref, decision.newState());
-		}
-		// Dismiss before sending, never after: level alerts share one notification ID, so a new alert
-		// decided on this same broadcast replaces the stale full one and must not then be cancelled.
-		if (decision.clearFullAlert()) {
-			NotificationService.clearLevelAlert(context);
-		}
-		if (nonNull(decision.notifyType())) {
-			NotificationService.sendNotification(context, decision.notifyType());
-		}
-
+		handleLevelAlerts(context, sharedPref, percentage, power);
 		handleTemperature(context, batteryDO, sharedPref);
 
 		// #109: warn when the (smoothed #108) drain rate stays abnormally high for a sustained time.
@@ -149,6 +144,42 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		// #123: warn when charging power stays abnormally low for a sustained time (frayed cable, dirty
 		// port, or dying charger). Independent of the drain rate — it reads the estimated charge wattage.
 		SlowChargeDetector.evaluate(context, batteryDO);
+	}
+
+	/**
+	 * Decide and dispatch this broadcast's critical/warning/full level alert.
+	 * <p>
+	 * Dismissal runs <b>before</b> dispatch: the level alerts share one notification ID, so an alert
+	 * decided on this same broadcast must replace the stale full one rather than be cancelled after
+	 * it. {@code BatteryLevelReceiverTest} pins that order.
+	 *
+	 * @param context    The application context
+	 * @param sharedPref The shared preferences
+	 * @param percentage Current battery percentage
+	 * @param power      What this broadcast says about charging, fullness and the cable
+	 */
+	private void handleLevelAlerts(Context context, SharedPreferences sharedPref, int percentage, ChargeState power) {
+		final LevelAlertConfig config = new LevelAlertConfig(
+				AppPrefs.criticalLevel(context),
+				AppPrefs.warningLevel(context),
+				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_warning_level), true),
+				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_full_level), true),
+				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_every_tick), false));
+
+		final LevelAlertState previous = loadLevelState(sharedPref);
+		final LevelAlertDecision decision = decideLevelAlert(previous, percentage, power, config);
+
+		// Persist only on change: most broadcasts (voltage/temperature deltas) re-decide an identical
+		// state, and rewriting it would churn SharedPreferences on every tick.
+		if (!decision.newState().equals(previous)) {
+			saveLevelState(sharedPref, decision.newState());
+		}
+		if (decision.clearFullAlert()) {
+			NotificationService.clearLevelAlert(context);
+		}
+		if (nonNull(decision.notifyType())) {
+			NotificationService.sendNotification(context, decision.notifyType());
+		}
 	}
 
 	/**
@@ -200,44 +231,48 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * Unplugged, therefore, the alert can neither fire (it would re-post itself the instant the unplug
 	 * dismissal cleared it, reading as a notification that refuses to go away) nor stay shown — "you
 	 * can unplug now" is answered once the charger is out, so a displayed one is dismissed here. That
-	 * dismissal is deliberately state-driven rather than left to the unplug broadcast alone: when the
-	 * process is killed mid-charge (doze, OEM task killers) nobody sees that transition, and the alert
-	 * would otherwise linger — un-swipeable, when the user has the sticky-notification preference on.
+	 * dismissal is deliberately driven by {@code EXTRA_PLUGGED} rather than left to the unplug
+	 * broadcast alone: when the process is killed mid-charge (doze, OEM task killers) nobody sees that
+	 * transition, and the alert would otherwise linger — un-swipeable, when the user has the
+	 * sticky-notification preference on.
+	 * <p>
+	 * Closing the episode is one-shot and applies {@link #reArmForNewDischarge}, so the fallback ends
+	 * in exactly the state the seen transition would have produced. Dismissal keys off
+	 * {@code fullAlertShown} rather than {@code fullNotified}: the latter re-arms mid-charge inside the
+	 * {@code (warning, FULL_PERCENTAGE]} band while the notification is still on screen, and it stays
+	 * set after a critical alert has repainted the shared ID — reading it would both strand stale full
+	 * alerts and cancel live critical ones.
 	 *
 	 * @param state      current persisted episode state
 	 * @param percentage current battery percentage (whole, via the single rounding policy #158)
-	 * @param charging   whether the battery status is {@code BATTERY_STATUS_CHARGING}
-	 * @param full       whether the battery status is {@code BATTERY_STATUS_FULL}
-	 * @param plugged    whether a charger is connected ({@code EXTRA_PLUGGED} is non-zero)
+	 * @param power      what this broadcast says about charging, fullness and the cable
 	 * @param config     the user's alert thresholds and toggles
 	 *
 	 * @return which alert to send now ({@code null} for none), whether to dismiss a stale full alert,
 	 * and the new state to persist
 	 */
-	static LevelAlertDecision decideLevelAlert(final LevelAlertState state, final int percentage,
-	                                           final boolean charging, final boolean full,
-	                                           final boolean plugged, final LevelAlertConfig config) {
-		// Off the charger a shown full alert is stale, and the episode re-arms for the next charge —
-		// the same re-arm PowerConnectionReceiver applies on the unplug broadcast it did see.
-		final boolean staleFullAlert = !plugged && state.fullNotified();
-		final LevelAlertState current = staleFullAlert
-		                                ? new LevelAlertState(state.prevLevel(), state.prevType(), false)
-		                                : state;
+	static LevelAlertDecision decideLevelAlert(LevelAlertState state, int percentage,
+	                                           ChargeState power, LevelAlertConfig config) {
+		// Off the charger the charge session is over: re-arm exactly as the unplug transition does, and
+		// dismiss the full alert if one is still occupying the shared level-alert notification.
+		final boolean chargeSessionOver = !power.plugged() && (state.fullNotified() || state.fullAlertShown());
+		final boolean dismissFullAlert = !power.plugged() && state.fullAlertShown();
+		final LevelAlertState episode = chargeSessionOver ? reArmForNewDischarge(state) : state;
 
-		final boolean levelChanged = current.prevLevel() != percentage;
-		final LevelAlertDecision decision = levelChanged && !charging
-		                                    ? decideDischarging(current, percentage, config)
-		                                    : decideChargingOrFull(current, percentage, full && plugged, config);
+		final boolean levelChanged = episode.prevLevel() != percentage;
+		final LevelAlertDecision decision = levelChanged && !power.charging()
+		                                    ? decideDischarging(episode, percentage, config)
+		                                    : decideChargingOrFull(episode, percentage, power.fullOnCharger(), config);
 
-		return new LevelAlertDecision(decision.notifyType(), decision.newState(), staleFullAlert);
+		return decision.withClearFullAlert(dismissFullAlert);
 	}
 
 	/**
 	 * The discharging side: critical first, then warning, de-duplicated via {@code prevType} —
 	 * except at/below the red-alert floor, where the critical alert always re-fires.
 	 */
-	private static LevelAlertDecision decideDischarging(final LevelAlertState state, final int percentage,
-	                                                    final LevelAlertConfig config) {
+	private static LevelAlertDecision decideDischarging(LevelAlertState state, int percentage,
+	                                                    LevelAlertConfig config) {
 		// Force the critical alert through the de-dupe at the red-alert floor: about to die trumps "already told you".
 		AlertType prevType = percentage <= NotificationService.RED_ALERT_LEVEL ? null : state.prevType();
 		AlertType notifyType = null;
@@ -253,7 +288,11 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 			}
 			prevType = AlertType.WARNING;
 		}
-		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, prevType, state.fullNotified()), false);
+		// A critical/warning alert repaints the shared level-alert ID, so whatever full alert was on
+		// screen is gone — and must not be "dismissed" later, which would cancel this one instead.
+		final boolean fullAlertShown = state.fullAlertShown() && isNull(notifyType);
+		return new LevelAlertDecision(notifyType,
+				new LevelAlertState(percentage, prevType, state.fullNotified(), fullAlertShown));
 	}
 
 	/**
@@ -266,19 +305,25 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 *                      enough, see {@link #decideLevelAlert}
 	 * @param config        the user's alert thresholds and toggles
 	 */
-	private static LevelAlertDecision decideChargingOrFull(final LevelAlertState state, final int percentage,
-	                                                       final boolean fullOnCharger, final LevelAlertConfig config) {
+	private static LevelAlertDecision decideChargingOrFull(LevelAlertState state, int percentage,
+	                                                       boolean fullOnCharger, LevelAlertConfig config) {
 		boolean fullNotified = state.fullNotified();
+		boolean fullAlertShown = state.fullAlertShown();
 		AlertType notifyType = null;
 
 		if (!fullNotified && fullOnCharger && config.fullNotifyEnabled()) {
 			notifyType = AlertType.FULL;
 			fullNotified = true;
+			fullAlertShown = true;
 		}
+		// Only the once-per-charge flag re-arms here. Whether the alert is still on screen is a
+		// separate fact: the battery drifting down to FULL_PERCENTAGE doesn't take the notification
+		// away, and conflating the two left stale full alerts undismissable after a missed unplug.
 		if (percentage <= NotificationService.FULL_PERCENTAGE && percentage > config.warningLevel()) {
 			fullNotified = false;
 		}
-		return new LevelAlertDecision(notifyType, new LevelAlertState(percentage, state.prevType(), fullNotified), false);
+		return new LevelAlertDecision(notifyType,
+				new LevelAlertState(percentage, state.prevType(), fullNotified, fullAlertShown));
 	}
 
 	/**
@@ -313,18 +358,20 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		return new TemperatureDecision(false, alreadyAlerted);
 	}
 
-	static LevelAlertState loadLevelState(final SharedPreferences prefs) {
+	static LevelAlertState loadLevelState(SharedPreferences prefs) {
 		return new LevelAlertState(
 				prefs.getInt(PREF_PREV_LEVEL, 0),
 				AlertType.fromPersistedId(prefs.getInt(PREF_PREV_TYPE, 0)),
-				prefs.getBoolean(PREF_FULL_NOTIFIED, false));
+				prefs.getBoolean(PREF_FULL_NOTIFIED, false),
+				prefs.getBoolean(PREF_FULL_ALERT_SHOWN, false));
 	}
 
-	static void saveLevelState(final SharedPreferences prefs, final LevelAlertState state) {
+	static void saveLevelState(SharedPreferences prefs, LevelAlertState state) {
 		prefs.edit()
 		     .putInt(PREF_PREV_LEVEL, state.prevLevel())
 		     .putInt(PREF_PREV_TYPE, AlertType.persistedId(state.prevType()))
 		     .putBoolean(PREF_FULL_NOTIFIED, state.fullNotified())
+		     .putBoolean(PREF_FULL_ALERT_SHOWN, state.fullAlertShown())
 		     .apply();
 	}
 
@@ -333,11 +380,40 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * (see {@link AlertType#persistedId}), so state written by older int-typed versions reads back
 	 * unchanged.
 	 *
-	 * @param prevLevel    the percentage seen on the previous broadcast (gates the discharge branch)
-	 * @param prevType     the last level alert sent while discharging ({@code null} when none)
-	 * @param fullNotified whether the full-battery alert has fired this charge session
+	 * @param prevLevel      the percentage seen on the previous broadcast (gates the discharge branch)
+	 * @param prevType       the last level alert sent while discharging ({@code null} when none)
+	 * @param fullNotified   whether the full-battery alert has fired this charge session — the
+	 *                       once-per-charge de-dupe, re-armed by the {@code (warning,
+	 *                       FULL_PERCENTAGE]} band
+	 * @param fullAlertShown whether a full alert currently occupies the shared level-alert
+	 *                       notification. Distinct from {@code fullNotified}: the band re-arms that
+	 *                       one while the notification is still up, and a critical/warning alert
+	 *                       repaints the ID without ending the charge session
 	 */
-	record LevelAlertState(int prevLevel, AlertType prevType, boolean fullNotified) {
+	record LevelAlertState(int prevLevel, AlertType prevType, boolean fullNotified, boolean fullAlertShown) {
+	}
+
+	/**
+	 * What one {@code ACTION_BATTERY_CHANGED} broadcast says about the charge side. These three
+	 * always travel together and are all read from the same intent, so they are one value rather
+	 * than three adjacent booleans at every call site.
+	 *
+	 * @param charging whether the battery status is {@code BATTERY_STATUS_CHARGING}
+	 * @param full     whether the battery status is {@code BATTERY_STATUS_FULL}
+	 * @param plugged  whether a charger is connected ({@code EXTRA_PLUGGED} is non-zero)
+	 */
+	record ChargeState(boolean charging, boolean full, boolean plugged) {
+
+		/**
+		 * Charge complete <em>and</em> still on the charger — what actually bounds the full-battery
+		 * alert. The status alone is not enough: many devices keep reporting
+		 * {@code BATTERY_STATUS_FULL} at 100% with the cable already out.
+		 *
+		 * @return true when the full-battery alert may fire
+		 */
+		boolean fullOnCharger() {
+			return full && plugged;
+		}
 	}
 
 	/**
@@ -364,6 +440,29 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 *                       dismissed (the charger is out)
 	 */
 	record LevelAlertDecision(AlertType notifyType, LevelAlertState newState, boolean clearFullAlert) {
+
+		/**
+		 * A decision from one of the branch helpers, which see a single broadcast's level and cannot
+		 * know whether a finished charge session left an alert on screen — only
+		 * {@link #decideLevelAlert} decides that.
+		 *
+		 * @param notifyType the alert to send, or {@code null} for none
+		 * @param newState   the state to persist
+		 */
+		LevelAlertDecision(AlertType notifyType, LevelAlertState newState) {
+			this(notifyType, newState, false);
+		}
+
+		/**
+		 * This decision with the dismissal the caller determined.
+		 *
+		 * @param clear whether a stale full alert must be dismissed
+		 *
+		 * @return the same decision carrying {@code clear}
+		 */
+		LevelAlertDecision withClearFullAlert(boolean clear) {
+			return new LevelAlertDecision(notifyType, newState, clear);
+		}
 	}
 
 	/**

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
@@ -1,5 +1,6 @@
 package com.almothafar.simplebatterynotifier.receiver;
 
+import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.ChargeState;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertConfig;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertDecision;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertState;
@@ -29,29 +30,35 @@ public class BatteryLevelReceiverDecisionTest {
 
 	private static final LevelAlertConfig DEFAULTS = new LevelAlertConfig(CRITICAL, WARNING, true, true, false);
 
-	private static final boolean DISCHARGING = false;
-	// A completed charge reports BATTERY_STATUS_FULL rather than CHARGING, so the full cases are
-	// "not charging" without being a discharge.
-	private static final boolean NOT_CHARGING = false;
-	private static final boolean CHARGING = true;
-	private static final boolean NOT_FULL = false;
-	private static final boolean FULL = true;
-	private static final boolean PLUGGED = true;
-	private static final boolean UNPLUGGED = false;
+	// The charge side of a broadcast. A completed charge reports BATTERY_STATUS_FULL rather than
+	// CHARGING, so the full cases are "not charging" without being a discharge.
+	private static final ChargeState DISCHARGING = new ChargeState(false, false, false);
+	private static final ChargeState UNPLUGGED_STILL_FULL = new ChargeState(false, true, false);
+	private static final ChargeState CHARGING = new ChargeState(true, false, true);
+	private static final ChargeState FULL_ON_CHARGER = new ChargeState(false, true, true);
+
+	// Episode state shorthands: nothing alerted yet, and "the full alert fired and is on screen".
+	private static LevelAlertState fresh(int prevLevel, AlertType prevType) {
+		return new LevelAlertState(prevLevel, prevType, false, false);
+	}
+
+	private static LevelAlertState fullAlertShowing(int prevLevel) {
+		return new LevelAlertState(prevLevel, null, true, true);
+	}
 
 	// --- discharging: critical/warning thresholds and de-dupe -----------------------------------
 
 	@Test
 	public void discharging_belowCritical_firesCriticalOnce() {
 		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(16, null, false), 15, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fresh(16, null), 15, DISCHARGING, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, first.notifyType());
-		assertEquals(new LevelAlertState(15, AlertType.CRITICAL, false), first.newState());
+		assertEquals(fresh(15, AlertType.CRITICAL), first.newState());
 
 		// Next tick, still below critical: the persisted prevType suppresses the duplicate.
 		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
-				first.newState(), 14, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				first.newState(), 14, DISCHARGING, DEFAULTS);
 		assertNull(second.notifyType());
 		assertEquals(14, second.newState().prevLevel());
 	}
@@ -59,19 +66,19 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void discharging_inWarningBand_firesWarningOnce() {
 		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(41, null, false), 38, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fresh(41, null), 38, DISCHARGING, DEFAULTS);
 
 		assertEquals(AlertType.WARNING, first.notifyType());
 
 		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
-				first.newState(), 35, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				first.newState(), 35, DISCHARGING, DEFAULTS);
 		assertNull(second.notifyType());
 	}
 
 	@Test
 	public void discharging_aboveWarning_noAlert() {
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(81, null, false), 80, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fresh(81, null), 80, DISCHARGING, DEFAULTS);
 
 		assertNull(d.notifyType());
 		assertEquals(80, d.newState().prevLevel());
@@ -81,16 +88,15 @@ public class BatteryLevelReceiverDecisionTest {
 	public void discharging_warningDisabled_staysSilentInWarningBand() {
 		final LevelAlertConfig noWarning = new LevelAlertConfig(CRITICAL, WARNING, false, true, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(41, null, false), 38, DISCHARGING, NOT_FULL, UNPLUGGED, noWarning);
+				fresh(41, null), 38, DISCHARGING, noWarning);
 
 		assertNull(d.notifyType());
 	}
 
 	@Test
 	public void discharging_warningThenCritical_escalates() {
-		final LevelAlertState afterWarning = new LevelAlertState(35, AlertType.WARNING, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				afterWarning, 20, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fresh(35, AlertType.WARNING), 20, DISCHARGING, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
@@ -98,46 +104,44 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void discharging_alertEveryTick_repeatsCritical() {
 		final LevelAlertConfig everyTick = new LevelAlertConfig(CRITICAL, WARNING, true, true, true);
-		final LevelAlertState alreadyCritical = new LevelAlertState(15, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				alreadyCritical, 14, DISCHARGING, NOT_FULL, UNPLUGGED, everyTick);
+				fresh(15, AlertType.CRITICAL), 14, DISCHARGING, everyTick);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
 
 	@Test
-	public void discharging_atRedAlertFloor_overridesDeDupe() {
+	public void discharging_atRedAlertLevel_reFiresCriticalDespiteDeDupe() {
 		// Already alerted critical this episode, but at/below the red-alert level it must re-fire.
-		final LevelAlertState alreadyCritical = new LevelAlertState(5, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				alreadyCritical, NotificationService.RED_ALERT_LEVEL, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fresh(5, AlertType.CRITICAL), NotificationService.RED_ALERT_LEVEL, DISCHARGING, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
 
 	@Test
-	public void discharging_unchangedLevel_doesNotAlert() {
+	public void unchangedLevel_skipsTheDischargeBranch() {
 		// Same level as last tick routes to the charging-or-full branch (the receiver's historical
 		// split), so a repeated broadcast at the same percentage can't duplicate a level alert.
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(15, AlertType.CRITICAL, false), 15, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fresh(15, AlertType.CRITICAL), 15, DISCHARGING, DEFAULTS);
 
 		assertNull(d.notifyType());
 	}
 
-	// --- charging / full: once per charge session ------------------------------------------------
+	// --- full-battery alert: once per charge session, re-armed on the way down -------------------
 
 	@Test
 	public void charging_full_firesOnceThenHolds() {
-		final LevelAlertState atHundred = new LevelAlertState(100, null, false);
 		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
-				atHundred, 100, NOT_CHARGING, FULL, PLUGGED, DEFAULTS);
+				fresh(100, null), 100, FULL_ON_CHARGER, DEFAULTS);
 
 		assertEquals(AlertType.FULL, first.notifyType());
 		assertTrue(first.newState().fullNotified());
+		assertTrue(first.newState().fullAlertShown());
 
 		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
-				first.newState(), 100, NOT_CHARGING, FULL, PLUGGED, DEFAULTS);
+				first.newState(), 100, FULL_ON_CHARGER, DEFAULTS);
 		assertNull(second.notifyType());
 	}
 
@@ -145,18 +149,18 @@ public class BatteryLevelReceiverDecisionTest {
 	public void charging_fullDisabled_staysSilent() {
 		final LevelAlertConfig noFull = new LevelAlertConfig(CRITICAL, WARNING, true, false, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(100, null, false), 100, NOT_CHARGING, FULL, PLUGGED, noFull);
+				fresh(100, null), 100, FULL_ON_CHARGER, noFull);
 
 		assertNull(d.notifyType());
 		assertFalse(d.newState().fullNotified());
+		assertFalse(d.newState().fullAlertShown());
 	}
 
 	@Test
 	public void charging_levelLeavesFullBand_reArmsFullAlert() {
 		// Notified at full, then the level drops to 90 (≤ FULL_PERCENTAGE, above warning): re-armed.
-		final LevelAlertState notified = new LevelAlertState(100, null, true);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				notified, 90, CHARGING, NOT_FULL, PLUGGED, DEFAULTS);
+				fullAlertShowing(90), 90, CHARGING, DEFAULTS);
 
 		assertNull(d.notifyType());
 		assertFalse(d.newState().fullNotified());
@@ -165,11 +169,27 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void charging_belowWarningBand_doesNotReArmFullAlert() {
 		// The re-arm band is (warning, FULL_PERCENTAGE]: charging low keeps the flag as-is.
-		final LevelAlertState notified = new LevelAlertState(100, null, true);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				notified, 30, CHARGING, NOT_FULL, PLUGGED, DEFAULTS);
+				fullAlertShowing(30), 30, CHARGING, DEFAULTS);
 
 		assertTrue(d.newState().fullNotified());
+	}
+
+	@Test
+	public void charging_reArmBand_doesNotForgetTheAlertIsStillOnScreen() {
+		// The band re-arms the once-per-charge flag, but the notification is still up — conflating the
+		// two is what left a stale full alert undismissable after a missed unplug.
+		final LevelAlertDecision reArmed = BatteryLevelReceiver.decideLevelAlert(
+				fullAlertShowing(95), 95, CHARGING, DEFAULTS);
+
+		assertFalse(reArmed.newState().fullNotified());
+		assertTrue(reArmed.newState().fullAlertShown());
+
+		// Unplugged in that window, the alert is still dismissed.
+		final LevelAlertDecision unplugged = BatteryLevelReceiver.decideLevelAlert(
+				reArmed.newState(), 95, DISCHARGING, DEFAULTS);
+		assertTrue(unplugged.clearFullAlert());
+		assertFalse(unplugged.newState().fullAlertShown());
 	}
 
 	// --- unplugged: the full alert is bounded by the charger, not by the status --------------------
@@ -180,7 +200,7 @@ public class BatteryLevelReceiverDecisionTest {
 		// Firing here is what made the alert look like it refused to go away: the unplug handler cleared
 		// it and the very next broadcast posted it straight back.
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				new LevelAlertState(100, null, false), 100, NOT_CHARGING, FULL, UNPLUGGED, DEFAULTS);
+				fresh(100, null), 100, UNPLUGGED_STILL_FULL, DEFAULTS);
 
 		assertNull(d.notifyType());
 		assertFalse(d.newState().fullNotified());
@@ -189,18 +209,18 @@ public class BatteryLevelReceiverDecisionTest {
 
 	@Test
 	public void unplugged_withFullAlertShown_dismissesItOnce() {
-		// Missed unplug broadcast (process killed mid-charge): the shown alert is dismissed from the
-		// plugged state instead, then the episode is re-armed so nothing dismisses twice.
-		final LevelAlertState notified = new LevelAlertState(100, null, true);
+		// Missed unplug broadcast (process killed mid-charge): the shown alert is dismissed from
+		// EXTRA_PLUGGED instead, then the session is re-armed so nothing dismisses twice.
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				notified, 100, NOT_CHARGING, FULL, UNPLUGGED, DEFAULTS);
+				fullAlertShowing(100), 100, UNPLUGGED_STILL_FULL, DEFAULTS);
 
 		assertTrue(d.clearFullAlert());
 		assertNull(d.notifyType());
 		assertFalse(d.newState().fullNotified());
+		assertFalse(d.newState().fullAlertShown());
 
 		final LevelAlertDecision next = BatteryLevelReceiver.decideLevelAlert(
-				d.newState(), 99, DISCHARGING, FULL, UNPLUGGED, DEFAULTS);
+				d.newState(), 99, UNPLUGGED_STILL_FULL, DEFAULTS);
 		assertFalse(next.clearFullAlert());
 		assertNull(next.notifyType());
 	}
@@ -209,9 +229,8 @@ public class BatteryLevelReceiverDecisionTest {
 	public void unplugged_levelAlreadyDropping_stillDismissesTheFullAlert() {
 		// The discharge branch (changed level) must clear it too — otherwise a restart that first sees
 		// 99% leaves the alert up until the next charge session.
-		final LevelAlertState notified = new LevelAlertState(100, null, true);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				notified, 98, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fullAlertShowing(100), 98, DISCHARGING, DEFAULTS);
 
 		assertTrue(d.clearFullAlert());
 		assertFalse(d.newState().fullNotified());
@@ -220,24 +239,66 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void unplugged_dischargedToCritical_stillAlertsWhileDismissingTheStaleFull() {
 		// Both at once: the receiver dismisses first and posts after, so the critical alert survives
-		// (they share one notification ID).
-		final LevelAlertState notified = new LevelAlertState(21, null, true);
+		// (they share one notification ID). BatteryLevelReceiverTest pins that ordering.
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				notified, 19, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fullAlertShowing(21), 19, DISCHARGING, DEFAULTS);
 
 		assertTrue(d.clearFullAlert());
 		assertEquals(AlertType.CRITICAL, d.notifyType());
 	}
 
 	@Test
+	public void unplugged_missedTransition_reArmsTheLevelDeDupeToo() {
+		// The state-driven fallback must land in exactly the state onChargerDisconnected produces.
+		// Re-arming only the full flag left prevType armed, silencing the next session's critical alert.
+		final LevelAlertState afterFullCharge = new LevelAlertState(100, AlertType.CRITICAL, true, true);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				afterFullCharge, 100, UNPLUGGED_STILL_FULL, DEFAULTS);
+
+		assertNull(d.newState().prevType());
+		assertEquals(new LevelAlertState(100, null, false, false), d.newState());
+	}
+
+	@Test
+	public void unplugged_missedTransition_criticalStillAlertsWithWarningsOff() {
+		// The user-visible consequence of the re-arm above: with warning alerts disabled nothing else
+		// resets prevType on the way down, so a half re-arm stayed silent all the way to RED_ALERT_LEVEL.
+		final LevelAlertConfig noWarning = new LevelAlertConfig(CRITICAL, WARNING, false, true, false);
+		final LevelAlertState afterFullCharge = new LevelAlertState(100, AlertType.CRITICAL, true, true);
+
+		LevelAlertState state = BatteryLevelReceiver.decideLevelAlert(
+				afterFullCharge, 100, UNPLUGGED_STILL_FULL, noWarning).newState();
+
+		AlertType fired = null;
+		for (int percentage = 99; percentage >= CRITICAL; percentage--) {
+			final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(state, percentage, DISCHARGING, noWarning);
+			state = d.newState();
+			if (fired == null) {
+				fired = d.notifyType();
+			}
+		}
+		assertEquals(AlertType.CRITICAL, fired);
+	}
+
+	@Test
+	public void unplugged_afterACriticalAlert_doesNotCancelIt() {
+		// fullNotified survives a critical alert repainting the shared ID, so dismissal must key off
+		// "is a full alert on screen" — otherwise the unplug silently cancels the live critical one.
+		final LevelAlertState criticalOnScreen = new LevelAlertState(19, AlertType.CRITICAL, true, false);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				criticalOnScreen, 18, DISCHARGING, DEFAULTS);
+
+		assertFalse(d.clearFullAlert());
+	}
+
+	@Test
 	public void replugged_afterUnplugAtFull_firesAgain() {
 		// The unplug re-arm is what lets a charger connected at 100% alert again, so it must survive
 		// the dismissal path above.
-		final LevelAlertState notified = new LevelAlertState(100, null, true);
 		final LevelAlertDecision unplugged = BatteryLevelReceiver.decideLevelAlert(
-				notified, 100, NOT_CHARGING, FULL, UNPLUGGED, DEFAULTS);
+				fullAlertShowing(100), 100, UNPLUGGED_STILL_FULL, DEFAULTS);
 		final LevelAlertDecision replugged = BatteryLevelReceiver.decideLevelAlert(
-				unplugged.newState(), 100, NOT_CHARGING, FULL, PLUGGED, DEFAULTS);
+				unplugged.newState(), 100, FULL_ON_CHARGER, DEFAULTS);
 
 		assertEquals(AlertType.FULL, replugged.notifyType());
 		assertFalse(replugged.clearFullAlert());
@@ -249,9 +310,8 @@ public class BatteryLevelReceiverDecisionTest {
 	public void restartMidEpisode_persistedStateSuppressesDuplicates() {
 		// Process death loses nothing: the decision on the persisted state after a "restart" is the
 		// same as it would have been in-process — no duplicate critical while still below threshold.
-		final LevelAlertState persisted = new LevelAlertState(15, AlertType.CRITICAL, false);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				persisted, 13, DISCHARGING, NOT_FULL, UNPLUGGED, DEFAULTS);
+				fresh(15, AlertType.CRITICAL), 13, DISCHARGING, DEFAULTS);
 
 		assertNull(d.notifyType());
 	}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
@@ -16,6 +16,7 @@ import com.almothafar.simplebatterynotifier.service.SystemService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -23,6 +24,7 @@ import org.robolectric.annotation.Config;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -114,7 +116,7 @@ public class BatteryLevelReceiverTest {
 	@Test
 	public void full_whileCharging_sendsFullAlertOnce() {
 		// Simulate the battery already sitting at 100% (unchanged) so the charging/full branch runs
-		saveLevelState(new LevelAlertState(100, null, false));
+		saveLevelState(new LevelAlertState(100, null, false, false));
 		publishBattery(BatteryManager.BATTERY_STATUS_FULL, 100, 100, BatteryManager.BATTERY_PLUGGED_AC);
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
@@ -126,7 +128,7 @@ public class BatteryLevelReceiverTest {
 
 	@Test
 	public void unplug_reArmsFullAlert_forNextChargeSession() {
-		saveLevelState(new LevelAlertState(100, null, false));
+		saveLevelState(new LevelAlertState(100, null, false, false));
 		publishBattery(BatteryManager.BATTERY_STATUS_FULL, 100, 100, BatteryManager.BATTERY_PLUGGED_AC);
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
@@ -136,6 +138,23 @@ public class BatteryLevelReceiverTest {
 			receive();
 
 			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL)), times(2));
+		}
+	}
+
+	@Test
+	public void unplugAtFull_dismissesTheStaleAlertBeforePostingTheCriticalOne() {
+		// The level alerts share one notification ID, so the dismissal has to run first: cancelling
+		// after sending would wipe the critical alert this same broadcast just decided. Only the
+		// receiver can pin this — the decision record carries no ordering.
+		saveLevelState(new LevelAlertState(21, null, true, true));
+		publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 15, 100, 0);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+
+			final InOrder ordered = inOrder(NotificationService.class);
+			ordered.verify(ns, () -> NotificationService.clearLevelAlert(any(Context.class)));
+			ordered.verify(ns, () -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL)));
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #266 (merged). That PR bounded the full-battery alert by the charger rather than the status, which fixed the alert that kept re-posting itself after unplug. The fallback it added for an unplug missed while the process was dead only did half the job, and this closes the rest.

Closes #267.

## The re-arm was only half a re-arm

`onChargerDisconnected` resets both flags — `new LevelAlertState(prevLevel, null, false)`, clearing `prevType` — while the new state-driven path kept `prevType`. The comment claimed the two matched; they didn't.

Both now call one `reArmForNewDischarge` helper, so equivalence is structural instead of asserted.

It mattered: drain to 15% (CRITICAL fires, `prevType=CRITICAL` persists) → plug in → FULL at 100% → process killed → unplug unseen. `PowerConnectionService` seeds `setCurrentState(plugged)` at startup, so `handleChargerDisconnected` never runs retroactively. With warning alerts **on** the warning band overwrites `prevType` on the way down and it self-heals; with them **off**, nothing did, and the whole next discharge session stayed silent at the critical threshold down to `RED_ALERT_LEVEL` (4%).

## "On screen" is now a separate fact from "already fired"

The dismissal keyed off `fullNotified`, which means "FULL fired this charge session". The two diverge both ways:

- The `(warning, FULL_PERCENTAGE]` band re-arms `fullNotified` while the notification is still up. A battery sitting at 100% drifts to 95% on the charger, the band fires, and an unplug in that window with the process dead left the "Battery fully charged" notification stranded — exactly the symptom #266 was opened for.
- `fullNotified` survives a critical alert repainting the shared `NOTIFICATION_ID`, so dismissing on it could cancel a live critical warning instead of a stale full one.

`fullAlertShown` now tracks the notification slot directly: set when FULL is sent, cleared when another level alert repaints the ID or when it is dismissed, and deliberately untouched by the re-arm band. It defaults to `false`, so existing installs simply read it as "nothing on screen".

## The ordering claim is now actually tested

#266 described dismiss-before-send as pinned by a test, but the test asserted fields on the returned record and a record carries no ordering. `unplugAtFull_dismissesTheStaleAlertBeforePostingTheCriticalOne` moves that to `BatteryLevelReceiverTest`, with a Mockito `InOrder` against the already-mocked `NotificationService`.

## Standards cleanups in the same code

- The three booleans read from one intent (`charging`, `full`, `plugged`) become a `ChargeState` record with `fullOnCharger()`. The test file's `DISCHARGING` / `NOT_CHARGING` — two names for the same `false` in the same slot — go away with them.
- The level-alert block leaves `onReceive` for a `handleLevelAlerts` helper mirroring the existing `handleTemperature`: 68 lines down to 47, back under the ~50 limit.
- The branch helpers stop hardcoding a decision component only the caller can set; `LevelAlertDecision` gains a two-arg constructor and `withClearFullAlert`.
- Parameters of every touched method drop their `final`, per `CODE_REVIEW_GUIDELINES.md` §Variables and `.claude/guidelines.md` §Immutability. Untouched methods keep theirs — the docs call for incremental migration, not a sweep.
- `current` → `episode`; "from the plugged state" reworded, since it read as "while plugged in", the opposite of what it does.

## Tests

The decision suite goes 21 → 26 cases: the re-arm parity (asserting the fallback lands in exactly the transition's state), the warnings-off silence it caused, the band re-arm not forgetting the alert is on screen, and the critical alert not being cancelled. Plus the receiver-level ordering test above.

`testDebugUnitTest` (543 tests) and `lintDebug` both pass.

Unchanged and still pinned by their own tests: once-per-charge behaviour, the `(warning, FULL_PERCENTAGE]` re-arm band, and re-firing when a charger is connected at an already-full battery.

---
_Generated by [Claude Code](https://claude.com/claude-code)_
