### PR TITLE
fix: make the "alert is showing" flag survive a process kill

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -74,10 +74,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	public static void onChargerDisconnected(Context context) {
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 		final LevelAlertState state = loadLevelState(prefs);
-		final LevelAlertState reset = reArmForNewDischarge(state);
-		if (!reset.equals(state)) {
-			saveLevelState(prefs, reset);
-		}
+		saveLevelStateIfChanged(prefs, state, reArmForNewDischarge(state));
 	}
 
 	/**
@@ -170,11 +167,9 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		final LevelAlertState previous = loadLevelState(sharedPref);
 		final LevelAlertDecision decision = decideLevelAlert(previous, percentage, power, config);
 
-		// Persist only on change: most broadcasts (voltage/temperature deltas) re-decide an identical
-		// state, and rewriting it would churn SharedPreferences on every tick.
-		if (!decision.newState().equals(previous)) {
-			saveLevelState(sharedPref, decision.newState());
-		}
+		// Persisted before the notification is posted, so a kill in between can only leave the
+		// recoverable "flag says shown, nothing is" state — never the reverse (#268).
+		saveLevelStateIfChanged(sharedPref, previous, decision.newState());
 		if (decision.clearFullAlert()) {
 			NotificationService.clearLevelAlert(context);
 		}
@@ -395,12 +390,57 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	}
 
 	static void saveLevelState(SharedPreferences prefs, LevelAlertState state) {
-		prefs.edit()
-		     .putInt(PREF_PREV_LEVEL, state.prevLevel())
-		     .putInt(PREF_PREV_TYPE, AlertType.persistedId(state.prevType()))
-		     .putBoolean(PREF_FULL_NOTIFIED, state.fullNotified())
-		     .putBoolean(PREF_FULL_ALERT_SHOWN, state.fullAlertShown())
-		     .apply();
+		levelStateEditor(prefs, state).apply();
+	}
+
+	/**
+	 * Persists synchronously, for the write that records a full alert reaching the screen (#268).
+	 * <p>
+	 * {@code apply()} returns before the write lands, so a process killed between it and the notification
+	 * loses {@code fullAlertShown} while the notification, living in system_server, survives. The
+	 * state-driven dismissal in {@link #decideLevelAlert} keys on exactly that flag, so it would then read
+	 * "nothing on screen" and leave the alert up for good.
+	 *
+	 * @param prefs the shared preferences
+	 * @param state the episode state to persist
+	 */
+	@SuppressLint("ApplySharedPref") // Durability is the point — see above; only on the alert transition
+	private static void saveLevelStateDurably(SharedPreferences prefs, LevelAlertState state) {
+		levelStateEditor(prefs, state).commit();
+	}
+
+	private static SharedPreferences.Editor levelStateEditor(SharedPreferences prefs, LevelAlertState state) {
+		return prefs.edit()
+		            .putInt(PREF_PREV_LEVEL, state.prevLevel())
+		            .putInt(PREF_PREV_TYPE, AlertType.persistedId(state.prevType()))
+		            .putBoolean(PREF_FULL_NOTIFIED, state.fullNotified())
+		            .putBoolean(PREF_FULL_ALERT_SHOWN, state.fullAlertShown());
+	}
+
+	/**
+	 * Persist the episode state only when it differs from what was loaded — most broadcasts
+	 * (voltage/temperature deltas) re-decide an identical state, and rewriting it would churn
+	 * SharedPreferences on every tick.
+	 * <p>
+	 * The transition that puts a full alert on screen goes through {@link #saveLevelStateDurably};
+	 * everything else, the re-arm included, stays asynchronous. Losing a re-arm write is self-healing —
+	 * the next tick re-decides it — so only the one unrecoverable write pays for the disk wait.
+	 *
+	 * @param prefs    the shared preferences
+	 * @param previous the state loaded at the start of this tick
+	 * @param state    the state to persist
+	 */
+	static void saveLevelStateIfChanged(SharedPreferences prefs,
+	                                    LevelAlertState previous,
+	                                    LevelAlertState state) {
+		if (state.equals(previous)) {
+			return;
+		}
+		if (!previous.fullAlertShown() && state.fullAlertShown()) {
+			saveLevelStateDurably(prefs, state);
+		} else {
+			saveLevelState(prefs, state);
+		}
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -1,5 +1,6 @@
 package com.almothafar.simplebatterynotifier.receiver;
 
+import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -209,7 +210,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		final TemperatureDecision decision = decideTemperature(previouslyAlerted, enabled, rawTenthsC, thresholdCelsius);
 
 		if (decision.alerted() != previouslyAlerted) {
-			sharedPref.edit().putBoolean(PREF_TEMPERATURE_ALERTED, decision.alerted()).apply();
+			persistTemperatureAlerted(sharedPref, decision.alerted());
 		}
 		if (decision.shouldNotify()) {
 			NotificationService.sendTemperatureNotification(context, rawTenthsC);
@@ -217,6 +218,33 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 			// The spell just ended: cooled past the hysteresis, or the alert switched off while one was
 			// showing. Dismiss the stale warning (#259) — staying inside the band holds, so it can't flap.
 			NotificationService.clearTemperatureAlert(context);
+		}
+	}
+
+	/**
+	 * Persist the hot-spell flag, synchronously when it is being turned <em>on</em> (#268).
+	 * <p>
+	 * The flag is written before the notification is posted so that a process killed in between leaves
+	 * the recoverable state — a flag claiming an alert that isn't showing, which the next cool tick
+	 * resolves with a no-op cancel. {@code apply()} does not actually give that ordering: it returns
+	 * before the write reaches disk, so a hard kill can lose the flag while the notification, living in
+	 * system_server, survives. The alert is then stranded with nothing left to dismiss it. Turning the
+	 * flag <em>off</em> keeps {@code apply()} — losing that write is self-healing, because the next tick
+	 * re-decides the same transition and repeats the cancel.
+	 * <p>
+	 * Only a hot-spell transition reaches here (the caller compares against the stored value), so this
+	 * is roughly two synchronous writes per spell, never one per broadcast.
+	 *
+	 * @param sharedPref The shared preferences
+	 * @param alerted    the flag value to store; {@code true} means an alert is now on screen
+	 */
+	@SuppressLint("ApplySharedPref") // Durability is the point — see above; the write is per-spell, not per-tick
+	static void persistTemperatureAlerted(SharedPreferences sharedPref, boolean alerted) {
+		final SharedPreferences.Editor edit = sharedPref.edit().putBoolean(PREF_TEMPERATURE_ALERTED, alerted);
+		if (alerted) {
+			edit.commit();
+		} else {
+			edit.apply();
 		}
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTracker.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTracker.java
@@ -1,5 +1,6 @@
 package com.almothafar.simplebatterynotifier.service;
 
+import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 
 /**
@@ -159,6 +160,28 @@ final class SustainedConditionTracker {
         }
 
         void save(SharedPreferences prefs, Streak state) {
+            editorFor(prefs, state).apply();
+        }
+
+        /**
+         * Persists synchronously, for the one write that records an alert the user can now see (#268).
+         * <p>
+         * The streak is written before the notification is posted so a process killed in between leaves
+         * the recoverable state: a streak claiming an alert that isn't showing, which the next tick
+         * resolves with a no-op cancel. {@code apply()} does not actually give that ordering — it returns
+         * before the write reaches disk, so a hard kill can lose the streak while the notification, living
+         * in system_server, survives. The alert is then stranded with no {@code alerted} flag left to
+         * dismiss it.
+         *
+         * @param prefs the shared preferences
+         * @param state the state to persist
+         */
+        @SuppressLint("ApplySharedPref") // Durability is the point — see above; only on the alert transition
+        void saveDurably(SharedPreferences prefs, Streak state) {
+            editorFor(prefs, state).commit();
+        }
+
+        private SharedPreferences.Editor editorFor(SharedPreferences prefs, Streak state) {
             final SharedPreferences.Editor editor = prefs.edit()
                     .putLong(keyStart, state.start())
                     .putBoolean(keyAlerted, state.alerted())
@@ -166,18 +189,29 @@ final class SustainedConditionTracker {
             if (keyLastReminder != null) {
                 editor.putLong(keyLastReminder, state.lastReminder());
             }
-            editor.apply();
+            return editor;
         }
 
         /**
          * Persists the new state only when it differs from what's stored — the common healthy-tick case
          * re-decides the same state on every broadcast, and rewriting it would churn SharedPreferences.
+         * <p>
+         * The transition that turns {@code alerted} on goes through {@link #saveDurably}; everything else,
+         * the re-arm included, stays asynchronous. {@code lastSeen} moves on every tick of an active
+         * episode, so keying the durable write on the transition rather than on {@code alerted} being true
+         * is what keeps it to one synchronous write per episode.
          *
          * @param prefs the shared preferences
          * @param state the state to persist
          */
         void saveIfChanged(SharedPreferences prefs, Streak state) {
-            if (!load(prefs).equals(state)) {
+            final Streak stored = load(prefs);
+            if (stored.equals(state)) {
+                return;
+            }
+            if (!stored.alerted() && state.alerted()) {
+                saveDurably(prefs, state);
+            } else {
                 save(prefs, state);
             }
         }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
@@ -1,5 +1,7 @@
 package com.almothafar.simplebatterynotifier.receiver;
 
+import android.content.SharedPreferences;
+
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.ChargeState;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertConfig;
 import com.almothafar.simplebatterynotifier.receiver.BatteryLevelReceiver.LevelAlertDecision;
@@ -14,6 +16,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link BatteryLevelReceiver}'s pure decision cores (#164), in the
@@ -354,5 +361,36 @@ public class BatteryLevelReceiverDecisionTest {
 		final TemperatureDecision d = BatteryLevelReceiver.decideTemperature(true, false, 470, THRESHOLD_C);
 		assertFalse(d.shouldNotify());
 		assertFalse(d.alerted());
+	}
+
+	// --- durability of the "alert is showing" flag (#268) -------------------------------------------
+	// A real SharedPreferences can't tell commit() from apply() — both read back — so these assert on
+	// the editor itself. That is the whole behaviour under test: the flag must reach disk before the
+	// notification posts, or a process kill strands an alert nothing can dismiss.
+
+	@Test
+	public void temperatureFlag_whenTheAlertFires_isWrittenSynchronously() {
+		final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class, RETURNS_SELF);
+		final SharedPreferences prefs = mock(SharedPreferences.class);
+		when(prefs.edit()).thenReturn(editor);
+
+		BatteryLevelReceiver.persistTemperatureAlerted(prefs, true);
+
+		verify(editor).commit();
+		verify(editor, never()).apply();
+	}
+
+	@Test
+	public void temperatureFlag_whenTheSpellEnds_staysAsynchronous() {
+		final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class, RETURNS_SELF);
+		final SharedPreferences prefs = mock(SharedPreferences.class);
+		when(prefs.edit()).thenReturn(editor);
+
+		// Losing the re-arm write is harmless — the next cool tick re-decides it — so it must not pay
+		// for a synchronous disk write.
+		BatteryLevelReceiver.persistTemperatureAlerted(prefs, false);
+
+		verify(editor).apply();
+		verify(editor, never()).commit();
 	}
 }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
@@ -381,6 +381,48 @@ public class BatteryLevelReceiverDecisionTest {
 	}
 
 	@Test
+	public void levelState_whenTheFullAlertReachesTheScreen_isWrittenSynchronously() {
+		final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class, RETURNS_SELF);
+		final SharedPreferences prefs = mock(SharedPreferences.class);
+		when(prefs.edit()).thenReturn(editor);
+
+		// The dismissal in decideLevelAlert keys on fullAlertShown, so losing this write leaves the
+		// "Battery fully charged" notification up with nothing able to take it down.
+		BatteryLevelReceiver.saveLevelStateIfChanged(prefs,
+				new LevelAlertState(100, null, false, false),
+				new LevelAlertState(100, null, true, true));
+
+		verify(editor).commit();
+		verify(editor, never()).apply();
+	}
+
+	@Test
+	public void levelState_whenTheEpisodeReArms_staysAsynchronous() {
+		final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class, RETURNS_SELF);
+		final SharedPreferences prefs = mock(SharedPreferences.class);
+		when(prefs.edit()).thenReturn(editor);
+
+		BatteryLevelReceiver.saveLevelStateIfChanged(prefs,
+				new LevelAlertState(100, null, true, true),
+				new LevelAlertState(100, null, false, false));
+
+		verify(editor).apply();
+		verify(editor, never()).commit();
+	}
+
+	@Test
+	public void levelState_unchanged_isNotWrittenAtAll() {
+		// The churn guard: ACTION_BATTERY_CHANGED fires every few seconds and re-decides an identical
+		// state, so the common tick must not touch the preferences file at all.
+		final SharedPreferences prefs = mock(SharedPreferences.class);
+		final LevelAlertState same = new LevelAlertState(100, null, true, true);
+
+		BatteryLevelReceiver.saveLevelStateIfChanged(prefs, same, same);
+
+		verify(prefs, never()).edit();
+	}
+
+	@Test
 	public void temperatureFlag_whenTheSpellEnds_staysAsynchronous() {
 		final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class, RETURNS_SELF);
 		final SharedPreferences prefs = mock(SharedPreferences.class);

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTrackerTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/SustainedConditionTrackerTest.java
@@ -20,6 +20,11 @@ import org.robolectric.annotation.Config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the shared sustained-condition engine {@link SustainedConditionTracker} (issue #163):
@@ -145,6 +150,63 @@ public class SustainedConditionTrackerTest {
 			store.clear(prefs);
 
 			assertEquals(CLEARED, store.load(prefs));
+		}
+
+		@Test
+		public void alertTransition_isWrittenSynchronously() {
+			// A real SharedPreferences can't tell commit() from apply() — both read back — so this asserts
+			// on the editor. The streak must reach disk before the notification posts (#268), or a process
+			// kill loses `alerted` while the notification survives, stranding an alert nothing dismisses.
+			final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class, RETURNS_SELF);
+			final SharedPreferences mockPrefs = mock(SharedPreferences.class);
+			when(mockPrefs.edit()).thenReturn(editor);
+			// Unstubbed getters return 0/false, so the stored streak is CLEARED — not alerted.
+
+			store().saveIfChanged(mockPrefs, new Streak(111, true, 222, 333));
+
+			verify(editor).commit();
+			verify(editor, never()).apply();
+		}
+
+		@Test
+		public void tickWithinAnActiveEpisode_staysAsynchronous() {
+			// The guard that keeps this cheap: lastSeen moves on every broadcast of a live episode, so if
+			// the durable write keyed on `alerted` being true rather than on the transition, every tick
+			// would block on disk. Only the transition may be synchronous.
+			final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class, RETURNS_SELF);
+			final SharedPreferences mockPrefs = mock(SharedPreferences.class);
+			when(mockPrefs.edit()).thenReturn(editor);
+			when(mockPrefs.getBoolean(KEY_ALERTED, false)).thenReturn(true);
+			when(mockPrefs.getLong(KEY_START, 0)).thenReturn(111L);
+			when(mockPrefs.getLong(KEY_LAST_SEEN, 0)).thenReturn(222L);
+			when(mockPrefs.getLong(KEY_LAST_REMINDER, 0)).thenReturn(333L);
+
+			store().saveIfChanged(mockPrefs, new Streak(111, true, 999, 333));
+
+			verify(editor).apply();
+			verify(editor, never()).commit();
+		}
+
+		@Test
+		public void reArm_staysAsynchronous() {
+			final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class, RETURNS_SELF);
+			final SharedPreferences mockPrefs = mock(SharedPreferences.class);
+			when(mockPrefs.edit()).thenReturn(editor);
+			when(mockPrefs.getBoolean(KEY_ALERTED, false)).thenReturn(true);
+			when(mockPrefs.getLong(KEY_START, 0)).thenReturn(111L);
+			when(mockPrefs.getLong(KEY_LAST_SEEN, 0)).thenReturn(222L);
+			when(mockPrefs.getLong(KEY_LAST_REMINDER, 0)).thenReturn(333L);
+
+			// Losing the re-arm write is self-healing: the next tick re-decides it and repeats a no-op
+			// cancel, so it must not pay for a synchronous disk write.
+			store().saveIfChanged(mockPrefs, CLEARED);
+
+			verify(editor).apply();
+			verify(editor, never()).commit();
+		}
+
+		private static StreakStore store() {
+			return new StreakStore(KEY_START, KEY_ALERTED, KEY_LAST_SEEN, KEY_LAST_REMINDER);
 		}
 
 		@Test


### PR DESCRIPTION
Closes #268. Follow-up to #261, from reviewing the residual risk it left behind. Rebased onto #269.

## The hole

Every self-dismissing alert writes a persisted "I have shown this" flag and then posts the notification. The order is deliberate: a process killed in between leaves the *recoverable* state — a flag claiming an alert that isn't showing, which the next tick resolves with a no-op cancel.

`apply()` does not actually give that ordering. It returns before the write reaches disk, so a hard kill (OEM task killer, force stop, low-memory kill) can lose the flag while the notification, which lives in system_server, survives. The app wakes up reading `false`, re-decides `false`, sees no transition, and never dismisses. That is the #259 symptom again, reached by a route no later tick can recover from.

## The fix

Write the flag synchronously **only when it is being turned on**. The asymmetry is the whole design, and it is what keeps this cheap:

- Losing "I alerted" (`true`) strands a visible notification — unrecoverable, so it must be durable.
- Losing "I re-armed" (`false`) is self-healing — the next tick re-decides the same transition and repeats a no-op cancel.

Three sites, four alerts:

- `BatteryLevelReceiver.persistTemperatureAlerted` — the high-temperature alert. The caller already only writes on a hot-spell transition.
- `BatteryLevelReceiver.saveLevelStateIfChanged` → `saveLevelStateDurably` — the full-battery alert's `fullAlertShown`.
- `SustainedConditionTracker.StreakStore.saveDurably`, reached from `saveIfChanged` — shared by `FastDrainDetector` (#109) and `SlowChargeDetector` (#123), so one change covers both.

Every one of them keys the durable write on the **transition**, never on the flag being true. That distinction is load-bearing. `Streak.lastSeen` moves on every tick of a live episode, so the flag-is-true version would block on disk every broadcast — and `ACTION_BATTERY_CHANGED` fires every few seconds, which is why all three sites already guard their writes behind a change check, as `BatteryRateTracker.persist` spells out. `tickWithinAnActiveEpisode_staysAsynchronous` and `levelState_unchanged_isNotWrittenAtAll` are the regression tests for exactly that mistake.

Android Lint's `ApplySharedPref` is suppressed at each site with the reason written down, in the style of #256.

## What changed after #269 merged

This PR originally left the level path alone, on the grounds that stranding a full alert took *two* failures: the lost write **and** a missed unplug broadcast, since `PowerConnectionReceiver` cancels `NOTIFICATION_ID` whatever the flag says.

#269 undercut that. Its new `fullAlertShown` is a third flag of exactly this kind, and its state-driven dismissal keys on that flag alone — and the whole reason #269 exists is that the unplug broadcast *does* get missed when the process is dead, which is the same condition that loses an `apply()` write. Two failures with a shared cause is not two independent failures, so the level path is now covered here rather than deferred.

The durability choice went where the comparison already happens. Both call sites (`onChargerDisconnected` and `handleLevelAlerts`) repeated the same load-compare-save guard; that is now one `saveLevelStateIfChanged`, mirroring `StreakStore.saveIfChanged`. `saveLevelState` keeps its signature, since `BatteryLevelReceiverTest` uses it to seed episode state.

## Tests

Eight cases. A real `SharedPreferences` cannot tell `commit()` from `apply()` — both read back — so they assert against a mocked editor, which is the actual behaviour under test.

- `temperatureFlag_whenTheAlertFires_isWrittenSynchronously` / `..._whenTheSpellEnds_staysAsynchronous`
- `levelState_whenTheFullAlertReachesTheScreen_isWrittenSynchronously` / `..._whenTheEpisodeReArms_staysAsynchronous` / `levelState_unchanged_isNotWrittenAtAll`
- `alertTransition_isWrittenSynchronously`, `tickWithinAnActiveEpisode_staysAsynchronous`, `reArm_staysAsynchronous`

Verified they are real regression guards, not just green: reverting all three `commit()` calls to `apply()` fails exactly the three "synchronously" tests and leaves the others passing.

`testDebugUnitTest` (551 tests), `lintDebug` and `assembleDebug` all pass locally.

## Manual verification

Not run — this needs a process kill in a millisecond-wide window, which isn't reproducible by hand. The behaviour it protects is covered by the #259 and #267 steps.
