### PR TITLE
refactor: put Appearance at the top of Notification behaviour

### DIFF
--- a/app/src/main/res/xml/pref_behaviour.xml
+++ b/app/src/main/res/xml/pref_behaviour.xml
@@ -1,8 +1,40 @@
 <!-- The "Notification behaviour" screen (#112): HOW alerts sound and appear, and WHEN they are
      allowed. These options apply to all alerts; the per-event settings (toggles, thresholds,
-     sounds) live on the "Alerts" screen (pref_alerts.xml). -->
+     sounds) live on the "Alerts" screen (pref_alerts.xml).
+
+     Appearance leads (#265): its two settings are the ones users change and then verify right
+     away, while sound and quiet hours are set once and forgotten. Below the four-row Quiet Hours
+     block it fell off-screen on shorter devices. -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        android:title="@string/pref_cat_title_appearance"
+        app:iconSpaceReserved="false">
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/_pref_key_notifications_sticky"
+            android:summaryOff="@string/notification_is_not_sticky"
+            android:summaryOn="@string/notification_is_sticky"
+            android:switchTextOff="@string/off"
+            android:switchTextOn="@string/on"
+            android:title="@string/sticky_notification"
+            app:iconSpaceReserved="false" />
+
+        <!-- How the charge-connected announcement surfaces (toast / notification / none).
+             Moved here from the Alerts screen: "style" reads as appearance, so this is where
+             users look for it (#112 follow-up, maintainer decision). -->
+        <ListPreference
+            android:defaultValue="@string/_pref_value_charge_notification_style_toast"
+            android:entries="@array/charge_notification_style_entries"
+            android:entryValues="@array/charge_notification_style_values"
+            android:key="@string/_pref_key_charge_notification_style"
+            android:title="@string/charge_notification_style_title"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
 
     <PreferenceCategory
         android:title="@string/pref_cat_title_sound_vibration"
@@ -70,34 +102,6 @@
             android:switchTextOff="@string/off"
             android:switchTextOn="@string/on"
             android:title="@string/critical_ignore_quiet_hours"
-            app:iconSpaceReserved="false" />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:title="@string/pref_cat_title_appearance"
-        app:iconSpaceReserved="false">
-
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="@string/_pref_key_notifications_sticky"
-            android:summaryOff="@string/notification_is_not_sticky"
-            android:summaryOn="@string/notification_is_sticky"
-            android:switchTextOff="@string/off"
-            android:switchTextOn="@string/on"
-            android:title="@string/sticky_notification"
-            app:iconSpaceReserved="false" />
-
-        <!-- How the charge-connected announcement surfaces (toast / notification / none).
-             Moved here from the Alerts screen: "style" reads as appearance, so this is where
-             users look for it (#112 follow-up, maintainer decision). -->
-        <ListPreference
-            android:defaultValue="@string/_pref_value_charge_notification_style_toast"
-            android:entries="@array/charge_notification_style_entries"
-            android:entryValues="@array/charge_notification_style_values"
-            android:key="@string/_pref_key_charge_notification_style"
-            android:title="@string/charge_notification_style_title"
-            app:useSimpleSummaryProvider="true"
             app:iconSpaceReserved="false" />
 
     </PreferenceCategory>


### PR DESCRIPTION
Closes #265.

Reorders the categories on the **Notification behaviour** screen to:

1. **Appearance** — Sticky notification, Charge notification style
2. **Sound & Vibration** — Mute alerts in silent mode, Vibrate
3. **Quiet Hours** — Quiet hours switch, Alerts allowed from / until, Critical alerts ignore quiet hours

Appearance holds the two settings a user is most likely to change and then verify immediately, but it sat below the four-row Quiet Hours block and landed off-screen on shorter devices. Sound and quiet-hours settings are set once and forgotten.

### Scope

Pure XML reordering in `app/src/main/res/xml/pref_behaviour.xml` — no preference keys, defaults, or logic change, so there is no migration and no behaviour change. Each `<PreferenceCategory>` moved as an intact block; the only other edit is three added lines in the file's header comment recording why Appearance leads.

The three `android:dependency` links inside Quiet Hours are untouched, and the master switch still precedes its dependents within the category. That ordering matters — AndroidX resolves dependencies during hierarchy attachment and throws if the target isn't yet in the hierarchy — but since the category moved as a unit, resolution is unaffected.

### Verification

- A sorted-line diff of old vs. new confirms every preference and attribute line is byte-identical; the only textual additions are the header-comment lines.
- Parsed the result to confirm well-formedness and that all three dependency links still resolve to `_pref_key_notifications_time_range`.
- All 36 `@string`/`@array` references resolve, and all 21 user-facing strings already exist in `values-ar/strings.xml`, so the `MissingTranslation` gate is satisfied. No new strings were needed.

Gradle was not run — the session container has no Android SDK, so the build fails at plugin/SDK resolution independently of this change. CI is the first real compile.

### Not done

The issue's rejected alternative — gating Quiet Hours on the **Mute alerts in silent mode** switch — was deliberately not implemented. The reasoning in the issue checks out against `QuietHours.java`: the two are independent gates with opposite defaults, and such a dependency would grey out Quiet Hours on every fresh install.

---
_Generated by [Claude Code](https://claude.ai/code/session_019v3wYx8mirn6mNPYZ9PNyc)_