### PR TITLE
feat: repeat the full-battery alert until the charger comes out

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,10 @@ done" means for the temperature range. At 100% it means a genuinely complete cha
 waits for one.
 _Avoid_: charge limit, charge cap (that is the OEM hardware feature), threshold.
 
+**Unplug reminder**:
+The opt-in repeat of the full-battery alert, re-posted every N minutes for as long as the battery stays on the charger at or above the charge target (default off, gap 15 min, range 5–60). It repeats the one alert rather than adding a second one, and the charger coming out is the only thing that ends it.
+_Avoid_: nag, snooze, recurring alert, repeat notification.
+
 **Temperature range**:
 The lowest and highest battery temperature seen since the battery last finished charging, in the
 user's display unit. Accumulated from the readings the monitoring service observes; finishing a

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiver.java
@@ -52,6 +52,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	private static final String PREF_PREV_TYPE = "_level_alert_prev_type";
 	private static final String PREF_FULL_NOTIFIED = "_level_alert_full_notified";
 	private static final String PREF_FULL_ALERT_SHOWN = "_level_alert_full_shown";
+	private static final String PREF_FULL_ALERT_AT = "_level_alert_full_at";
 	private static final String PREF_TEMPERATURE_ALERTED = "_temperature_alert_sent";
 
 	/**
@@ -164,10 +165,13 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 				AppPrefs.chargeTarget(context),
 				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_warning_level), true),
 				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_for_full_level), true),
-				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_every_tick), false));
+				sharedPref.getBoolean(context.getString(R.string._pref_key_notify_every_tick), false),
+				AppPrefs.unplugReminderEnabled(context),
+				AppPrefs.unplugReminderGapMs(context));
 
 		final LevelAlertState previous = loadLevelState(sharedPref);
-		final LevelAlertDecision decision = decideLevelAlert(previous, percentage, power, config);
+		// The unplug reminder (#264) is the only time-dependent part of this decision; every other branch ignores the clock.
+		final LevelAlertDecision decision = decideLevelAlert(previous, percentage, power, config, System.currentTimeMillis());
 
 		// Persisted before the notification is posted, so a kill in between can only leave the
 		// recoverable "flag says shown, nothing is" state — never the reverse (#268).
@@ -176,7 +180,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 			NotificationService.clearLevelAlert(context);
 		}
 		if (nonNull(decision.notifyType())) {
-			NotificationService.sendNotification(context, decision.notifyType(), percentage);
+			NotificationService.sendNotification(context, decision.notifyType(), percentage, decision.reminder());
 		}
 	}
 
@@ -270,11 +274,17 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * @param percentage current battery percentage (whole, via the single rounding policy #158)
 	 * @param power      what this broadcast says about charging, fullness and the cable
 	 * @param config     the user's alert thresholds and toggles
+	 * @param nowMillis  current time in millis, for the unplug reminder's gap (#264)
 	 *
-	 * @return which alert to send now ({@code null} for none), whether to dismiss a stale full alert,
-	 * and the new state to persist
+	 * @return which alert to send now ({@code null} for none), whether it is a reminder rather than the
+	 * charge session's first alert, whether to dismiss a stale full alert, and the new state to persist
 	 */
-	static LevelAlertDecision decideLevelAlert(LevelAlertState state, int percentage, ChargeState power, LevelAlertConfig config) {
+	static LevelAlertDecision decideLevelAlert(
+			LevelAlertState state,
+			int percentage,
+			ChargeState power,
+			LevelAlertConfig config,
+			long nowMillis) {
 		// Off the charger the charge session is over: re-arm exactly as the unplug transition does, and
 		// dismiss the full alert if one is still occupying the shared level-alert notification.
 		final boolean chargeSessionOver = !power.plugged() && (state.fullNotified() || state.fullAlertShown());
@@ -284,7 +294,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		final boolean levelChanged = episode.prevLevel() != percentage;
 		final LevelAlertDecision decision = levelChanged && !power.charging()
 		                                    ? decideDischarging(episode, percentage, config)
-		                                    : decideChargingOrFull(episode, percentage, power, config);
+		                                    : decideChargingOrFull(episode, percentage, power, config, nowMillis);
 
 		return decision.withClearFullAlert(dismissFullAlert);
 	}
@@ -313,7 +323,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		// screen is gone — and must not be "dismissed" later, which would cancel this one instead.
 		final boolean fullAlertShown = state.fullAlertShown() && isNull(notifyType);
 		return new LevelAlertDecision(notifyType,
-				new LevelAlertState(percentage, prevType, state.fullNotified(), fullAlertShown));
+				new LevelAlertState(percentage, prevType, state.fullNotified(), fullAlertShown, state.fullAlertAt()));
 	}
 
 	/**
@@ -326,26 +336,49 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * <p>
 	 * The re-arm band moves with the target ({@link AppPrefs#reArmLevel}) rather than sitting at a fixed 95%. A fixed point below the target would re-arm on
 	 * the very tick the alert fired and then fire again on every percent up to 100 — seven notifications for one charge at a target of 90.
+	 * <p>
+	 * On top of that once-per-charge alert sits the opt-in unplug reminder (#264): while the charge stays done and the cable stays in, the same alert is
+	 * re-posted every {@code unplugReminderGapMs}. It is a rate-limited repeat <em>of</em> the once-per-charge episode, not a replacement for it — the
+	 * {@code fullNotified} guard is what bounds the repeat to one charge session, and the gap is measured from the last post rather than from the first, so the
+	 * reminders are evenly spaced however long the cable stays in.
 	 *
 	 * @param state      current persisted episode state
 	 * @param percentage current battery percentage
 	 * @param power      what this broadcast says about charging, fullness and the cable — the status
 	 *                   alone is not enough, see {@link #decideLevelAlert}
 	 * @param config     the user's alert thresholds and toggles
+	 * @param nowMillis  current time in millis, for the unplug reminder's gap
 	 */
-	private static LevelAlertDecision decideChargingOrFull(LevelAlertState state, int percentage, ChargeState power, LevelAlertConfig config) {
+	private static LevelAlertDecision decideChargingOrFull(
+			LevelAlertState state,
+			int percentage,
+			ChargeState power,
+			LevelAlertConfig config,
+			long nowMillis) {
 		// One reading of "the charge you asked for is done", used by both the fire condition and the re-arm below. They are exact opposites, and evaluating the
 		// predicate twice invites them to drift apart — which is the bug the re-arm comment describes.
 		final boolean chargeDone = power.reachedChargeTarget(percentage, config.chargeTarget());
 
 		boolean fullNotified = state.fullNotified();
 		boolean fullAlertShown = state.fullAlertShown();
+		long fullAlertAt = state.fullAlertAt();
 		AlertType notifyType = null;
+		boolean reminder = false;
 
-		if (!fullNotified && config.fullNotifyEnabled() && chargeDone) {
-			notifyType = AlertType.FULL;
+		if (config.fullNotifyEnabled() && chargeDone) {
+			if (!fullNotified) {
+				notifyType = AlertType.FULL;
+			} else if (dueForUnplugReminder(state, config, nowMillis)) {
+				notifyType = AlertType.FULL;
+				reminder = true;
+			}
+		}
+		// One place records "a full alert just went out", so the first alert and its reminders can't drift on what that means: the episode is open, the shared
+		// notification ID now holds a full alert, and the next reminder is timed from here.
+		if (nonNull(notifyType)) {
 			fullNotified = true;
 			fullAlertShown = true;
+			fullAlertAt = nowMillis;
 		}
 		// Only the once-per-charge flag re-arms here. Whether the alert is still on screen is a separate fact: the battery drifting down out of the band
 		// doesn't take the notification away, and conflating the two left stale full alerts undismissable after a missed unplug.
@@ -357,9 +390,34 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		// guards the identical hazard the same way.
 		if (!chargeDone && percentage <= AppPrefs.reArmLevel(config.chargeTarget()) && percentage > config.warningLevel()) {
 			fullNotified = false;
+			// The reminder clock belongs to the episode that flag opens, so it re-arms with it rather than being left to age into an instant reminder the
+			// moment the next charge reaches the target.
+			fullAlertAt = 0;
 		}
 		return new LevelAlertDecision(notifyType,
-				new LevelAlertState(percentage, state.prevType(), fullNotified, fullAlertShown));
+				new LevelAlertState(percentage, state.prevType(), fullNotified, fullAlertShown, fullAlertAt)).withReminder(reminder);
+	}
+
+	/**
+	 * Whether the unplug reminder is switched on and its gap has elapsed since the last full alert (#264).
+	 * <p>
+	 * The gap is a <em>minimum</em>: reminders ride the {@code ACTION_BATTERY_CHANGED} broadcasts rather than an alarm of their own — the same no-timer design
+	 * as the fast-drain reminder — so a phone that goes quiet on the charger reminds late rather than on the dot.
+	 * <p>
+	 * A missing timestamp ({@code 0}) never reminds. That is the state an install upgrading mid-charge is in — the flag saying an alert already fired, with no
+	 * record of when — and treating an absent time as "long ago" would greet exactly those users with a reminder the instant they updated. The next charge
+	 * records a real timestamp and reminds normally.
+	 *
+	 * @param state     current persisted episode state
+	 * @param config    the user's alert thresholds and toggles
+	 * @param nowMillis current time in millis
+	 *
+	 * @return true when a reminder is due now
+	 */
+	private static boolean dueForUnplugReminder(LevelAlertState state, LevelAlertConfig config, long nowMillis) {
+		return config.unplugReminderEnabled()
+				&& state.fullAlertAt() != 0
+				&& nowMillis - state.fullAlertAt() >= config.unplugReminderGapMs();
 	}
 
 	/**
@@ -398,7 +456,8 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 				prefs.getInt(PREF_PREV_LEVEL, 0),
 				AlertType.fromPersistedId(prefs.getInt(PREF_PREV_TYPE, 0)),
 				prefs.getBoolean(PREF_FULL_NOTIFIED, false),
-				prefs.getBoolean(PREF_FULL_ALERT_SHOWN, false));
+				prefs.getBoolean(PREF_FULL_ALERT_SHOWN, false),
+				prefs.getLong(PREF_FULL_ALERT_AT, 0));
 	}
 
 	static void saveLevelState(SharedPreferences prefs, LevelAlertState state) {
@@ -426,7 +485,8 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		            .putInt(PREF_PREV_LEVEL, state.prevLevel())
 		            .putInt(PREF_PREV_TYPE, AlertType.persistedId(state.prevType()))
 		            .putBoolean(PREF_FULL_NOTIFIED, state.fullNotified())
-		            .putBoolean(PREF_FULL_ALERT_SHOWN, state.fullAlertShown());
+		            .putBoolean(PREF_FULL_ALERT_SHOWN, state.fullAlertShown())
+		            .putLong(PREF_FULL_ALERT_AT, state.fullAlertAt());
 	}
 
 	/**
@@ -435,8 +495,8 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * SharedPreferences on every tick.
 	 * <p>
 	 * The transition that puts a full alert on screen goes through {@link #saveLevelStateDurably};
-	 * everything else, the re-arm included, stays asynchronous. Losing a re-arm write is self-healing —
-	 * the next tick re-decides it — so only the one unrecoverable write pays for the disk wait.
+	 * everything else, the re-arm and the unplug reminder's timestamp included, stays asynchronous. Losing one of those writes is self-healing — the next tick
+	 * re-decides the re-arm, and a lost reminder timestamp costs at most one extra reminder — so only the one unrecoverable write pays for the disk wait.
 	 *
 	 * @param prefs    the shared preferences
 	 * @param previous the state loaded at the start of this tick
@@ -466,8 +526,27 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 *                       notification. Distinct from {@code fullNotified}: the band re-arms that
 	 *                       one while the notification is still up, and a critical/warning alert
 	 *                       repaints the ID without ending the charge session
+	 * @param fullAlertAt    when the full alert was last posted, in millis ({@code 0} = never this episode). The unplug reminder (#264) measures its gap from
+	 *                       here; it re-arms with {@code fullNotified}, whose episode it belongs to
 	 */
-	record LevelAlertState(int prevLevel, AlertType prevType, boolean fullNotified, boolean fullAlertShown) {
+	record LevelAlertState(
+			int prevLevel,
+			AlertType prevType,
+			boolean fullNotified,
+			boolean fullAlertShown,
+			long fullAlertAt) {
+
+		/**
+		 * Episode state with no full alert on the clock — every state in which {@code fullNotified} is false, and the state a pre-#264 install reads back.
+		 *
+		 * @param prevLevel      the percentage seen on the previous broadcast
+		 * @param prevType       the last level alert sent while discharging ({@code null} when none)
+		 * @param fullNotified   whether the full-battery alert has fired this charge session
+		 * @param fullAlertShown whether a full alert currently occupies the shared level-alert notification
+		 */
+		LevelAlertState(int prevLevel, AlertType prevType, boolean fullNotified, boolean fullAlertShown) {
+			this(prevLevel, prevType, fullNotified, fullAlertShown, 0);
+		}
 	}
 
 	/**
@@ -530,12 +609,15 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * The user's alert thresholds and toggles (reduces parameter count, like
 	 * {@code NotificationConfig}).
 	 *
-	 * @param criticalLevel     critical alert threshold in percent
-	 * @param warningLevel      warning alert threshold in percent
-	 * @param chargeTarget      the level the full-battery alert fires at while charging (#263)
-	 * @param warningEnabled    whether the warning alert is enabled
-	 * @param fullNotifyEnabled whether the full-battery alert is enabled
-	 * @param alertEveryTick    whether the critical alert repeats on every level tick
+	 * @param criticalLevel          critical alert threshold in percent
+	 * @param warningLevel           warning alert threshold in percent
+	 * @param chargeTarget           the level the full-battery alert fires at while charging (#263)
+	 * @param warningEnabled         whether the warning alert is enabled
+	 * @param fullNotifyEnabled      whether the full-battery alert is enabled
+	 * @param alertEveryTick         whether the critical alert repeats on every level tick — the <b>critical</b> alert only; the full alert's repeat is the
+	 *                               separate, opt-in {@code unplugReminderEnabled} below
+	 * @param unplugReminderEnabled  whether the full-battery alert repeats until the charger comes out (#264)
+	 * @param unplugReminderGapMs    minimum gap between those reminders, in millis
 	 */
 	record LevelAlertConfig(
 			int criticalLevel,
@@ -543,7 +625,9 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 			int chargeTarget,
 			boolean warningEnabled,
 			boolean fullNotifyEnabled,
-			boolean alertEveryTick) {
+			boolean alertEveryTick,
+			boolean unplugReminderEnabled,
+			long unplugReminderGapMs) {
 	}
 
 	/**
@@ -554,8 +638,11 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 	 * @param newState       the state to persist
 	 * @param clearFullAlert whether a full-battery alert shown from a finished charge session must be
 	 *                       dismissed (the charger is out)
+	 * @param reminder       whether {@code notifyType} is an unplug reminder re-posting an alert this charge session already sent (#264), rather than that
+	 *                       session's first alert. The dispatcher needs the distinction: a re-post that keeps {@code setOnlyAlertOnce} slips into the shade in
+	 *                       silence, and a reminder nobody notices is the miss the feature exists to prevent
 	 */
-	record LevelAlertDecision(AlertType notifyType, LevelAlertState newState, boolean clearFullAlert) {
+	record LevelAlertDecision(AlertType notifyType, LevelAlertState newState, boolean clearFullAlert, boolean reminder) {
 
 		/**
 		 * A decision from one of the branch helpers, which see a single broadcast's level and cannot
@@ -566,7 +653,7 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		 * @param newState   the state to persist
 		 */
 		LevelAlertDecision(AlertType notifyType, LevelAlertState newState) {
-			this(notifyType, newState, false);
+			this(notifyType, newState, false, false);
 		}
 
 		/**
@@ -577,7 +664,20 @@ public class BatteryLevelReceiver extends BroadcastReceiver {
 		 * @return the same decision carrying {@code clear}
 		 */
 		LevelAlertDecision withClearFullAlert(boolean clear) {
-			return new LevelAlertDecision(notifyType, newState, clear);
+			return new LevelAlertDecision(notifyType, newState, clear, reminder);
+		}
+
+		/**
+		 * This decision marked as an unplug reminder rather than the charge session's first alert (#264). A separate wither for the same reason as
+		 * {@link #withClearFullAlert}: it keeps the branch helpers off the four-argument constructor, where two adjacent booleans are one transposition away
+		 * from silently swapping "dismiss this" with "re-alert for this".
+		 *
+		 * @param repeat whether this dispatch repeats an alert already sent this charge session
+		 *
+		 * @return the same decision carrying {@code repeat}
+		 */
+		LevelAlertDecision withReminder(boolean repeat) {
+			return new LevelAlertDecision(notifyType, newState, clearFullAlert, repeat);
 		}
 	}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
@@ -168,22 +168,6 @@ public final class FastDrainDetector {
 	                                int defaultMinutes,
 	                                int minMinutes,
 	                                int maxMinutes) {
-		return clampMinutesToMs(prefs.getInt(context.getString(keyRes), defaultMinutes), minMinutes, maxMinutes);
-	}
-
-	/**
-	 * Clamps a stored minutes preference to its slider range and converts to millis. Mirrors
-	 * {@link AppPrefs#clampDrainLimit}: the slider constrains UI input, but a corrupt or
-	 * out-of-range stored value (e.g. 0 sustained minutes) would otherwise defeat the sustained-window
-	 * requirement and fire on a momentary spike. Pure so it is unit-testable.
-	 *
-	 * @param storedMinutes the raw persisted value in minutes
-	 * @param minMinutes    the slider's minimum
-	 * @param maxMinutes    the slider's maximum
-	 *
-	 * @return the clamped duration in milliseconds
-	 */
-	static long clampMinutesToMs(int storedMinutes, int minMinutes, int maxMinutes) {
-		return Math.max(minMinutes, Math.min(maxMinutes, storedMinutes)) * MS_PER_MINUTE;
+		return AppPrefs.clampMinutesToMs(prefs.getInt(context.getString(keyRes), defaultMinutes), minMinutes, maxMinutes);
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -91,8 +91,11 @@ public final class NotificationService {
 	 * @param levelPercent The battery level this alert fired at. The full-battery alert's copy depends
 	 * on it (#263): a charge that completed below the user's charge target must not claim the target was reached. The critical/warning alerts word themselves
 	 * from their configured thresholds and ignore it.
+	 * @param reminder     Whether this post repeats an alert the user has already been sent — today only the unplug reminder (#264). It re-posts the same
+	 * notification ID, and a re-post is silent unless it is allowed to alert again, so this is what decides whether the user is actually reminded or the shade
+	 * quietly updates behind their back.
 	 */
-	public static void sendNotification(Context context, AlertType type, int levelPercent) {
+	public static void sendNotification(Context context, AlertType type, int levelPercent, boolean reminder) {
 		if (isNull(type)) {
 			Log.w(TAG, "No alert type given, notification not sent");
 			return;
@@ -109,8 +112,9 @@ public final class NotificationService {
 
 		final String channelId = NotificationChannels.channelFor(context, config.alertsAllowed, config.channelId);
 		final NotificationCompat.Builder builder = alertBuilder(context, channelId, config.toAlertSpec(NOTIFICATION_ID));
-		if (!type.alertsEveryTime()) {
-			// Non-critical alerts update quietly when re-posted; only critical alerts alert every time.
+		if (!type.alertsEveryTime() && !reminder) {
+			// Non-critical alerts update quietly when re-posted; only critical alerts alert every time — and a
+			// reminder, which exists precisely to be noticed again (#264).
 			builder.setOnlyAlertOnce(true);
 		}
 

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/util/AppPrefs.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/util/AppPrefs.java
@@ -27,9 +27,9 @@ import com.almothafar.simplebatterynotifier.model.LevelThresholds;
  *       default in three spots (channel creation, the level-alert config and the manual override path),
  *       which meant the alert channels and the silent-mode buzz could drift apart.</li>
  * </ul>
- * The one restatement that remains is the XML-declared slider default in {@code pref_alerts.xml}, which
- * the framework instantiates from XML and so cannot share a constant with — a comment ties the two, and
- * {@code AppPrefsTest} asserts they stay equal. Remaining settings migrate incrementally.
+ * The one restatement that remains is each slider's XML-declared default in {@code pref_alerts.xml}, which the framework instantiates from XML and so cannot
+ * share a constant with — a comment ties each pair, and {@code AppPrefsTest} asserts they stay equal. Remaining settings migrate incrementally; new ones (the
+ * charge target #263, the unplug reminder #264) are born here.
  */
 public final class AppPrefs {
 
@@ -63,6 +63,18 @@ public final class AppPrefs {
 	 */
 	public static final int CHARGE_TARGET_REARM_MARGIN = 5;
 
+	/**
+	 * Default for the "remind me until I unplug" preference (#264) — <b>off</b>. The full-battery alert fires once per charge; the repeat is deliberately
+	 * opt-in, because a notification that keeps coming back is a nag for everyone who did not ask for it.
+	 */
+	public static final boolean DEFAULT_UNPLUG_REMINDER = false;
+	/** Default gap between unplug reminders, in minutes — mirrors the slider's {@code android:defaultValue} in pref_alerts.xml. */
+	public static final int DEFAULT_UNPLUG_REMINDER_MINUTES = 15;
+	/** Shortest accepted unplug-reminder gap; mirrors the slider's {@code app:min} in pref_alerts.xml. */
+	public static final int MIN_UNPLUG_REMINDER_MINUTES = 5;
+	/** Longest accepted unplug-reminder gap; mirrors the slider's {@code android:max} in pref_alerts.xml. */
+	public static final int MAX_UNPLUG_REMINDER_MINUTES = 60;
+
 	/** Default "high drain" limit in %/h. */
 	public static final int DEFAULT_DRAIN_LIMIT_PPH = 20;
 	/** Lowest accepted drain limit in %/h; mirrors the slider's {@code app:min} in pref_alerts.xml. */
@@ -72,6 +84,8 @@ public final class AppPrefs {
 
 	/** Default for the "Vibrate" preference — mirrors the switch's {@code android:defaultValue} in pref_behaviour.xml. */
 	public static final boolean DEFAULT_VIBRATE = true;
+
+	private static final long MS_PER_MINUTE = 60_000L;
 
 	private AppPrefs() {
 		// Utility class
@@ -175,6 +189,51 @@ public final class AppPrefs {
 	 */
 	public static int reArmLevel(int chargeTarget) {
 		return chargeTarget - CHARGE_TARGET_REARM_MARGIN;
+	}
+
+	/**
+	 * Whether the unplug reminder is on (#264): the opt-in repeat of the full-battery alert for as long as the battery stays on the charger at or above the
+	 * charge target. Defaults to {@link #DEFAULT_UNPLUG_REMINDER} — the alert is once per charge unless the user asks otherwise.
+	 *
+	 * @param context Application context
+	 *
+	 * @return true when the full-battery alert repeats until the charger comes out
+	 */
+	public static boolean unplugReminderEnabled(Context context) {
+		return prefs(context).getBoolean(context.getString(R.string._pref_key_notify_unplug_reminder), DEFAULT_UNPLUG_REMINDER);
+	}
+
+	/**
+	 * The minimum gap between unplug reminders, in milliseconds (#264). Reads {@link #DEFAULT_UNPLUG_REMINDER_MINUTES} when unset and always clamps, so a
+	 * corrupt preference can't turn the reminder into a notification on every broadcast.
+	 * <p>
+	 * A <em>minimum</em>, not a period: the reminder rides the battery broadcasts rather than a timer of its own (no alarm, no wakelock — the same design as
+	 * the fast-drain reminder), so a device that goes quiet on the charger reminds late rather than on the dot.
+	 *
+	 * @param context Application context
+	 *
+	 * @return the configured reminder gap in milliseconds
+	 */
+	public static long unplugReminderGapMs(Context context) {
+		return clampMinutesToMs(
+				prefs(context).getInt(context.getString(R.string._pref_key_unplug_reminder_minutes), DEFAULT_UNPLUG_REMINDER_MINUTES),
+				MIN_UNPLUG_REMINDER_MINUTES,
+				MAX_UNPLUG_REMINDER_MINUTES);
+	}
+
+	/**
+	 * Clamps a stored minutes preference to its slider range and converts it to milliseconds. The sliders constrain UI input, but a corrupt or out-of-range
+	 * stored value (a 0-minute gap, say) would otherwise defeat the very interval it configures. Shared by every timing preference — the fast-drain window and
+	 * reminder (#109) and the unplug reminder (#264) — so "the slider range is also the enforced range" is stated once. Pure so it is unit-testable.
+	 *
+	 * @param storedMinutes the raw persisted value in minutes
+	 * @param minMinutes    the slider's minimum
+	 * @param maxMinutes    the slider's maximum
+	 *
+	 * @return the clamped duration in milliseconds
+	 */
+	public static long clampMinutesToMs(int storedMinutes, int minMinutes, int maxMinutes) {
+		return Math.max(minMinutes, Math.min(maxMinutes, storedMinutes)) * MS_PER_MINUTE;
 	}
 
 	/**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -119,6 +119,10 @@
     <string name="charge_target">هدف الشحن</string>
     <string name="charge_target_summary">تنبيه عند %1$s — شارف على الاكتمال، أفضل لعمر البطارية</string>
     <string name="charge_target_summary_full">تنبيه عند %1$s — شحن كامل</string>
+    <string name="notify_unplug_reminder">ذكّرني حتى أفصل الشاحن</string>
+    <string name="notify_unplug_reminder_summary_on">يتكرر التنبيه ما دام الشاحن موصولًا</string>
+    <string name="notify_unplug_reminder_summary_off">يصل التنبيه مرة واحدة لكل شحنة</string>
+    <string name="unplug_reminder_minutes">التذكير كل (دقائق)</string>
     <string name="notify_every_tick">التنبيه للمستوى الحرج كل (\u20661%\u2069)</string>
     <string name="notify_every_tick_summary_on">التنبيه كل درجة (\u20661%\u2069) للمستوى الحرج مفعل</string>
     <string name="notify_every_tick_summary_off">التنبيه كل درجة (\u20661%\u2069) للمستوى الحرج معطل</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,12 @@
          Western in every locale (#96), and it brings its own '%' sign. -->
     <string name="charge_target_summary">Alert at %1$s — almost full, better for battery life</string>
     <string name="charge_target_summary_full">Alert at %1$s — a full charge</string>
+    <!-- #264: the opt-in repeat of the full-battery alert. Named for what the user wants out of it — the phone off the charger — rather than for the
+         notification being re-posted. -->
+    <string name="notify_unplug_reminder">Remind me until I unplug</string>
+    <string name="notify_unplug_reminder_summary_on">The alert repeats while the charger stays in</string>
+    <string name="notify_unplug_reminder_summary_off">The alert arrives once per charge</string>
+    <string name="unplug_reminder_minutes">Remind every (minutes)</string>
     <string name="notify_every_tick">Notify for critical every (1%)</string>
     <string name="notify_every_tick_summary_on">Notify every tick (1%) for critical level enabled</string>
     <string name="notify_every_tick_summary_off">Notify every tick (1%) for critical level disabled</string>
@@ -418,6 +424,9 @@
     <string name="_pref_key_critical_ignore_quiet_hours" translatable="false">key_critical_ignore_quiet_hours</string>
     <!-- #263: the level the full-battery alert fires at while charging -->
     <string name="_pref_key_charge_target" translatable="false">key_charge_target</string>
+    <!-- #264: repeat the full-battery alert until the charger comes out, and how far apart the repeats are -->
+    <string name="_pref_key_notify_unplug_reminder" translatable="false">key_notify_unplug_reminder</string>
+    <string name="_pref_key_unplug_reminder_minutes" translatable="false">key_unplug_reminder_minutes</string>
     <string name="_pref_key_notify_high_temperature" translatable="false">key_notify_high_temperature</string>
     <string name="_pref_key_high_temperature_threshold" translatable="false">key_high_temperature_threshold</string>
     <!-- #108/#109: append the rate to the ongoing notification, and the shared "high drain" limit (%/h) -->

--- a/app/src/main/res/xml/pref_alerts.xml
+++ b/app/src/main/res/xml/pref_alerts.xml
@@ -114,6 +114,38 @@
             app:adjustable="true"
             app:iconSpaceReserved="false" />
 
+        <!-- #264: the opt-in repeat. Off by default — the alert is once per charge unless the user asks to be
+             nagged, because a notification that keeps coming back is a nag for everyone who didn't.
+
+             Gated by the alert switch above, unlike the charge target: there is nothing to repeat when the
+             alert itself is off, and this preference governs nothing else. The interval in turn depends on
+             this switch, so the whole reminder collapses with it. -->
+        <SwitchPreference
+            android:defaultValue="false"
+            android:dependency="@string/_pref_key_notify_for_full_level"
+            android:key="@string/_pref_key_notify_unplug_reminder"
+            android:summaryOff="@string/notify_unplug_reminder_summary_off"
+            android:summaryOn="@string/notify_unplug_reminder_summary_on"
+            android:switchTextOff="@string/off"
+            android:switchTextOn="@string/on"
+            android:title="@string/notify_unplug_reminder"
+            app:iconSpaceReserved="false" />
+
+        <!-- defaultValue/min/max must match AppPrefs.DEFAULT/MIN/MAX_UNPLUG_REMINDER_MINUTES, which clamp the
+             stored value when it is read. app:min for the same reason as the sliders above — androidx
+             SeekBarPreference reads `min` from its own namespace and ignores android:min entirely. -->
+        <SeekBarPreference
+            android:defaultValue="15"
+            android:dependency="@string/_pref_key_notify_unplug_reminder"
+            android:key="@string/_pref_key_unplug_reminder_minutes"
+            app:min="5"
+            android:max="60"
+            android:title="@string/unplug_reminder_minutes"
+            style="@style/PreferenceSeekBar"
+            app:showSeekBarValue="true"
+            app:adjustable="true"
+            app:iconSpaceReserved="false" />
+
         <com.almothafar.simplebatterynotifier.ui.preference.RingtonePreference
             android:defaultValue="content://settings/system/notification_sound"
             android:dependency="@string/_pref_key_notify_for_full_level"

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
@@ -36,14 +36,17 @@ public class BatteryLevelReceiverDecisionTest {
 	private static final int WARNING = 40;
 	private static final int THRESHOLD_C = 45;
 	private static final int TARGET_90 = 90;
+	// The unplug reminder's clock (#264). NOW is an arbitrary fixed instant — nothing but the reminder reads it.
+	private static final long NOW = 1_000_000L;
+	private static final long REMINDER_GAP_MS = 15 * 60_000L;
 
 	// Every pre-#263 case runs at the maximum charge target, where the alert waits for a genuinely complete charge — so this suite doubles as the proof that
 	// setting the slider to 100% restores the pre-#263 behaviour exactly. It is deliberately NOT the shipped default: an install that never touches the slider
 	// gets DEFAULT_CHARGE_TARGET (90) and is meant to start alerting there, which is the whole point of #263. The target-driven cases below cover that path.
 	private static final LevelAlertConfig DEFAULTS =
-			new LevelAlertConfig(CRITICAL, WARNING, AppPrefs.MAX_CHARGE_TARGET, true, true, false);
+			config(AppPrefs.MAX_CHARGE_TARGET, true, true, false);
 	private static final LevelAlertConfig TARGET_AT_90 =
-			new LevelAlertConfig(CRITICAL, WARNING, TARGET_90, true, true, false);
+			config(TARGET_90, true, true, false);
 
 	// The charge side of a broadcast. A completed charge reports BATTERY_STATUS_FULL rather than
 	// CHARGING, so the full cases are "not charging" without being a discharge.
@@ -64,18 +67,46 @@ public class BatteryLevelReceiverDecisionTest {
 		return new LevelAlertState(prevLevel, null, true, true);
 	}
 
+	/** The same, mid-charge with the reminder clock already running — the state a charge session is in between reminders (#264). */
+	private static LevelAlertState fullAlertShowing(int prevLevel, long alertAt) {
+		return new LevelAlertState(prevLevel, null, true, true, alertAt);
+	}
+
+	/**
+	 * A config with the unplug reminder off, which is the shipped default and the premise of every case that isn't about the reminder. The two thresholds are
+	 * fixed for the whole suite, so only what a case actually varies is named at the call site.
+	 */
+	private static LevelAlertConfig config(int chargeTarget, boolean warningEnabled, boolean fullNotifyEnabled, boolean alertEveryTick) {
+		return new LevelAlertConfig(CRITICAL, WARNING, chargeTarget, warningEnabled, fullNotifyEnabled, alertEveryTick, false, REMINDER_GAP_MS);
+	}
+
+	/**
+	 * A config with the unplug reminder on (#264), at the given charge target. Everything else matches {@link #config}.
+	 */
+	private static LevelAlertConfig remindingAt(int chargeTarget) {
+		return new LevelAlertConfig(CRITICAL, WARNING, chargeTarget, true, true, false, true, REMINDER_GAP_MS);
+	}
+
+	/**
+	 * The decision at a fixed instant. Only the unplug reminder (#264) reads the clock, so every other case can hold it still and the reminder cases pass their
+	 * own {@code now} to the five-argument core directly.
+	 */
+	private static LevelAlertDecision decide(LevelAlertState state, int percentage, ChargeState power, LevelAlertConfig config) {
+		return BatteryLevelReceiver.decideLevelAlert(state, percentage, power, config, NOW);
+	}
+
 	// --- discharging: critical/warning thresholds and de-dupe -----------------------------------
 
 	@Test
 	public void discharging_belowCritical_firesCriticalOnce() {
-		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision first = decide(
 				fresh(16, null), 15, DISCHARGING, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, first.notifyType());
 		assertEquals(fresh(15, AlertType.CRITICAL), first.newState());
 
 		// Next tick, still below critical: the persisted prevType suppresses the duplicate.
-		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision second = decide(
 				first.newState(), 14, DISCHARGING, DEFAULTS);
 		assertNull(second.notifyType());
 		assertEquals(14, second.newState().prevLevel());
@@ -83,19 +114,19 @@ public class BatteryLevelReceiverDecisionTest {
 
 	@Test
 	public void discharging_inWarningBand_firesWarningOnce() {
-		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision first = decide(
 				fresh(41, null), 38, DISCHARGING, DEFAULTS);
 
 		assertEquals(AlertType.WARNING, first.notifyType());
 
-		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision second = decide(
 				first.newState(), 35, DISCHARGING, DEFAULTS);
 		assertNull(second.notifyType());
 	}
 
 	@Test
 	public void discharging_aboveWarning_noAlert() {
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(81, null), 80, DISCHARGING, DEFAULTS);
 
 		assertNull(d.notifyType());
@@ -104,8 +135,8 @@ public class BatteryLevelReceiverDecisionTest {
 
 	@Test
 	public void discharging_warningDisabled_staysSilentInWarningBand() {
-		final LevelAlertConfig noWarning = new LevelAlertConfig(CRITICAL, WARNING, AppPrefs.MAX_CHARGE_TARGET, false, true, false);
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertConfig noWarning = config(AppPrefs.MAX_CHARGE_TARGET, false, true, false);
+		final LevelAlertDecision d = decide(
 				fresh(41, null), 38, DISCHARGING, noWarning);
 
 		assertNull(d.notifyType());
@@ -113,7 +144,7 @@ public class BatteryLevelReceiverDecisionTest {
 
 	@Test
 	public void discharging_warningThenCritical_escalates() {
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(35, AlertType.WARNING), 20, DISCHARGING, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
@@ -121,8 +152,8 @@ public class BatteryLevelReceiverDecisionTest {
 
 	@Test
 	public void discharging_alertEveryTick_repeatsCritical() {
-		final LevelAlertConfig everyTick = new LevelAlertConfig(CRITICAL, WARNING, AppPrefs.MAX_CHARGE_TARGET, true, true, true);
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertConfig everyTick = config(AppPrefs.MAX_CHARGE_TARGET, true, true, true);
+		final LevelAlertDecision d = decide(
 				fresh(15, AlertType.CRITICAL), 14, DISCHARGING, everyTick);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
@@ -131,7 +162,7 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void discharging_atRedAlertLevel_reFiresCriticalDespiteDeDupe() {
 		// Already alerted critical this episode, but at/below the red-alert level it must re-fire.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(5, AlertType.CRITICAL), NotificationService.RED_ALERT_LEVEL, DISCHARGING, DEFAULTS);
 
 		assertEquals(AlertType.CRITICAL, d.notifyType());
@@ -141,7 +172,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void unchangedLevel_skipsTheDischargeBranch() {
 		// Same level as last tick routes to the charging-or-full branch (the receiver's historical
 		// split), so a repeated broadcast at the same percentage can't duplicate a level alert.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(15, AlertType.CRITICAL), 15, DISCHARGING, DEFAULTS);
 
 		assertNull(d.notifyType());
@@ -151,22 +182,22 @@ public class BatteryLevelReceiverDecisionTest {
 
 	@Test
 	public void charging_full_firesOnceThenHolds() {
-		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision first = decide(
 				fresh(100, null), 100, FULL_ON_CHARGER, DEFAULTS);
 
 		assertEquals(AlertType.FULL, first.notifyType());
 		assertTrue(first.newState().fullNotified());
 		assertTrue(first.newState().fullAlertShown());
 
-		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision second = decide(
 				first.newState(), 100, FULL_ON_CHARGER, DEFAULTS);
 		assertNull(second.notifyType());
 	}
 
 	@Test
 	public void charging_fullDisabled_staysSilent() {
-		final LevelAlertConfig noFull = new LevelAlertConfig(CRITICAL, WARNING, AppPrefs.MAX_CHARGE_TARGET, true, false, false);
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertConfig noFull = config(AppPrefs.MAX_CHARGE_TARGET, true, false, false);
+		final LevelAlertDecision d = decide(
 				fresh(100, null), 100, FULL_ON_CHARGER, noFull);
 
 		assertNull(d.notifyType());
@@ -177,7 +208,7 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void charging_levelLeavesFullBand_reArmsFullAlert() {
 		// Notified at full, then the level drops to 90 (≤ the 95 re-arm level of a 100 target, above warning): re-armed.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fullAlertShowing(90), 90, CHARGING, DEFAULTS);
 
 		assertNull(d.notifyType());
@@ -187,7 +218,7 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void charging_belowWarningBand_doesNotReArmFullAlert() {
 		// The re-arm band is (warning, target − margin]: charging low keeps the flag as-is.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fullAlertShowing(30), 30, CHARGING, DEFAULTS);
 
 		assertTrue(d.newState().fullNotified());
@@ -197,14 +228,14 @@ public class BatteryLevelReceiverDecisionTest {
 	public void charging_reArmBand_doesNotForgetTheAlertIsStillOnScreen() {
 		// The band re-arms the once-per-charge flag, but the notification is still up — conflating the
 		// two is what left a stale full alert undismissable after a missed unplug.
-		final LevelAlertDecision reArmed = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision reArmed = decide(
 				fullAlertShowing(95), 95, CHARGING, DEFAULTS);
 
 		assertFalse(reArmed.newState().fullNotified());
 		assertTrue(reArmed.newState().fullAlertShown());
 
 		// Unplugged in that window, the alert is still dismissed.
-		final LevelAlertDecision unplugged = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision unplugged = decide(
 				reArmed.newState(), 95, DISCHARGING, DEFAULTS);
 		assertTrue(unplugged.clearFullAlert());
 		assertFalse(unplugged.newState().fullAlertShown());
@@ -215,7 +246,7 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void charging_reachesTheTarget_firesBeforeAFullCharge() {
 		// The point of the feature: at a target of 90 the alert arrives while the battery is still climbing, not once it has already sat at 100%.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(89, null), TARGET_90, CHARGING, TARGET_AT_90);
 
 		assertEquals(AlertType.FULL, d.notifyType());
@@ -225,7 +256,7 @@ public class BatteryLevelReceiverDecisionTest {
 
 	@Test
 	public void charging_belowTheTarget_staysSilent() {
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(88, null), 89, CHARGING, TARGET_AT_90);
 
 		assertNull(d.notifyType());
@@ -240,7 +271,7 @@ public class BatteryLevelReceiverDecisionTest {
 		int fired = 0;
 
 		for (int percentage = TARGET_90; percentage <= 100; percentage++) {
-			final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(state, percentage, CHARGING, TARGET_AT_90);
+			final LevelAlertDecision d = decide(state, percentage, CHARGING, TARGET_AT_90);
 			state = d.newState();
 			if (d.notifyType() == AlertType.FULL) {
 				fired++;
@@ -249,18 +280,18 @@ public class BatteryLevelReceiverDecisionTest {
 		assertEquals(1, fired);
 
 		// And the completed charge doesn't add a second one on top.
-		assertNull(BatteryLevelReceiver.decideLevelAlert(state, 100, FULL_ON_CHARGER, TARGET_AT_90).notifyType());
+		assertNull(decide(state, 100, FULL_ON_CHARGER, TARGET_AT_90).notifyType());
 	}
 
 	@Test
 	public void discharging_pastTheTarget_neverFires() {
 		// decideChargingOrFull is also reached with the level unchanged while discharging, so the trigger has to be gated on charging: sitting at 90% on the
 		// way DOWN is not a finished charge.
-		final LevelAlertDecision changed = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision changed = decide(
 				fresh(91, null), TARGET_90, DISCHARGING, TARGET_AT_90);
 		assertNull(changed.notifyType());
 
-		final LevelAlertDecision unchanged = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision unchanged = decide(
 				fresh(TARGET_90, null), TARGET_90, DISCHARGING, TARGET_AT_90);
 		assertNull(unchanged.notifyType());
 		assertFalse(unchanged.newState().fullNotified());
@@ -270,7 +301,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void pluggedAndHoldingAtACap_firesOnTheTarget() {
 		// A device parked at its own charge cap reports NOT_CHARGING, not FULL: cable in, nothing flowing, no completed-charge status ever coming. Requiring
 		// CHARGING left the whole feature silently dead there — on exactly the phones whose owners went looking for a charge target.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(95, null), 95, PLUGGED_NOT_CHARGING, TARGET_AT_90);
 
 		assertEquals(AlertType.FULL, d.notifyType());
@@ -285,7 +316,7 @@ public class BatteryLevelReceiverDecisionTest {
 		int fired = 0;
 
 		for (int tick = 0; tick < 5; tick++) {
-			final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(state, 95, PLUGGED_NOT_CHARGING, TARGET_AT_90);
+			final LevelAlertDecision d = decide(state, 95, PLUGGED_NOT_CHARGING, TARGET_AT_90);
 			state = d.newState();
 			if (d.notifyType() == AlertType.FULL) {
 				fired++;
@@ -299,7 +330,7 @@ public class BatteryLevelReceiverDecisionTest {
 		// The cable alone is not enough: a phone drawing more than the charger supplies reports DISCHARGING with the cable in. The battery is going down, so no
 		// charge is finishing.
 		final ChargeState pluggedButDraining = new ChargeState(false, false, false, true);
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(95, null), 95, pluggedButDraining, TARGET_AT_90);
 
 		assertNull(d.notifyType());
@@ -310,11 +341,11 @@ public class BatteryLevelReceiverDecisionTest {
 	public void pluggedInAboveTheTarget_firesTheAlert() {
 		// Connecting a charger at 95% with a target of 90 has nothing left to reach, so the alert has to come from the level already being there. It rides on
 		// the unplug re-arm, which is why removing that would break this quietly.
-		final LevelAlertDecision unplugged = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision unplugged = decide(
 				fullAlertShowing(95), 95, DISCHARGING, TARGET_AT_90);
 		assertFalse(unplugged.newState().fullNotified());
 
-		final LevelAlertDecision replugged = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision replugged = decide(
 				unplugged.newState(), 95, CHARGING, TARGET_AT_90);
 		assertEquals(AlertType.FULL, replugged.notifyType());
 	}
@@ -323,11 +354,11 @@ public class BatteryLevelReceiverDecisionTest {
 	public void charging_droppingBelowTheReArmLevel_armsTheNextAlert() {
 		// A top-up without unplugging: the level has to fall a margin below the target before the alert can fire again, so the flag holds at 86 and clears at
 		// 85.
-		final LevelAlertDecision inBand = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision inBand = decide(
 				fullAlertShowing(86), 86, CHARGING, TARGET_AT_90);
 		assertTrue(inBand.newState().fullNotified());
 
-		final LevelAlertDecision dropped = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision dropped = decide(
 				fullAlertShowing(85), 85, CHARGING, TARGET_AT_90);
 		assertFalse(dropped.newState().fullNotified());
 	}
@@ -336,11 +367,11 @@ public class BatteryLevelReceiverDecisionTest {
 	public void maximumTarget_waitsForACompletedCharge() {
 		// 100% is the opt-out: reaching the level is not enough, the battery must report the charge finished — bit for bit what the app did before the target
 		// existed.
-		final LevelAlertDecision atLevel = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision atLevel = decide(
 				fresh(99, null), 100, CHARGING, DEFAULTS);
 		assertNull(atLevel.notifyType());
 
-		final LevelAlertDecision complete = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision complete = decide(
 				atLevel.newState(), 100, FULL_ON_CHARGER, DEFAULTS);
 		assertEquals(AlertType.FULL, complete.notifyType());
 	}
@@ -348,7 +379,7 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void belowTheTarget_aCompletedChargeStillFires() {
 		// A charge-capped device reports FULL well short of the target. That is still a finished charge.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(80, null), 80, FULL_ON_CHARGER, TARGET_AT_90);
 
 		assertEquals(AlertType.FULL, d.notifyType());
@@ -366,13 +397,151 @@ public class BatteryLevelReceiverDecisionTest {
 		int fired = 0;
 
 		for (int tick = 0; tick < 5; tick++) {
-			final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(state, 80, FULL_ON_CHARGER, TARGET_AT_90);
+			final LevelAlertDecision d = decide(state, 80, FULL_ON_CHARGER, TARGET_AT_90);
 			state = d.newState();
 			if (d.notifyType() == AlertType.FULL) {
 				fired++;
 			}
 		}
 		assertEquals(1, fired);
+	}
+
+	// --- the unplug reminder: the opt-in repeat on top of the once-per-charge alert (#264) --------
+
+	@Test
+	public void unplugReminder_offByDefault_leavesTheAlertAtOncePerCharge() {
+		// The shipped default. Hours past any plausible gap, a battery sitting on the charger at the target still gets exactly the one alert.
+		final LevelAlertDecision fired = decide(fresh(89, null), 90, CHARGING, TARGET_AT_90);
+		assertEquals(AlertType.FULL, fired.notifyType());
+
+		final LevelAlertDecision later = BatteryLevelReceiver.decideLevelAlert(
+				fired.newState(), 90, CHARGING, TARGET_AT_90, NOW + 6 * REMINDER_GAP_MS);
+		assertNull(later.notifyType());
+	}
+
+	@Test
+	public void firstAlertOfTheCharge_isNotAReminder_andStartsTheClock() {
+		// The distinction the dispatcher acts on: the first alert of a charge session posts normally, and it is what the reminder gap is then measured from.
+		final LevelAlertDecision d = decide(fresh(89, null), 90, CHARGING, remindingAt(TARGET_90));
+
+		assertEquals(AlertType.FULL, d.notifyType());
+		assertFalse(d.reminder());
+		assertEquals(NOW, d.newState().fullAlertAt());
+	}
+
+	@Test
+	public void unplugReminder_rePostsTheAlertOnceTheGapElapses() {
+		final LevelAlertDecision fired = decide(fresh(89, null), 90, CHARGING, remindingAt(TARGET_90));
+
+		final LevelAlertDecision reminded = BatteryLevelReceiver.decideLevelAlert(
+				fired.newState(), 91, CHARGING, remindingAt(TARGET_90), NOW + REMINDER_GAP_MS);
+
+		assertEquals(AlertType.FULL, reminded.notifyType());
+		assertTrue(reminded.reminder());
+		// Still one episode, not a re-armed one — the repeat rides on the once-per-charge flag rather than replacing it.
+		assertTrue(reminded.newState().fullNotified());
+		assertTrue(reminded.newState().fullAlertShown());
+	}
+
+	@Test
+	public void unplugReminder_staysQuietUntilTheGapHasFullyElapsed() {
+		final LevelAlertDecision fired = decide(fresh(89, null), 90, CHARGING, remindingAt(TARGET_90));
+
+		final LevelAlertDecision early = BatteryLevelReceiver.decideLevelAlert(
+				fired.newState(), 90, CHARGING, remindingAt(TARGET_90), NOW + REMINDER_GAP_MS - 1);
+
+		assertNull(early.notifyType());
+		// The clock is left alone by a tick that didn't remind, so the next one is still due on the original schedule.
+		assertEquals(NOW, early.newState().fullAlertAt());
+	}
+
+	@Test
+	public void unplugReminder_spacesRepeatsFromTheLastPost() {
+		// Measured from the last post, not the first: otherwise every broadcast after the first gap is "overdue" and the reminder becomes a per-tick alarm.
+		final LevelAlertDecision fired = decide(fresh(89, null), 90, CHARGING, remindingAt(TARGET_90));
+		final LevelAlertDecision first = BatteryLevelReceiver.decideLevelAlert(
+				fired.newState(), 90, CHARGING, remindingAt(TARGET_90), NOW + REMINDER_GAP_MS);
+		assertTrue(first.reminder());
+
+		final LevelAlertDecision tooSoon = BatteryLevelReceiver.decideLevelAlert(
+				first.newState(), 90, CHARGING, remindingAt(TARGET_90), NOW + REMINDER_GAP_MS + 1);
+		assertNull(tooSoon.notifyType());
+
+		final LevelAlertDecision second = BatteryLevelReceiver.decideLevelAlert(
+				first.newState(), 90, CHARGING, remindingAt(TARGET_90), NOW + 2 * REMINDER_GAP_MS);
+		assertTrue(second.reminder());
+	}
+
+	@Test
+	public void unplugReminder_keepsGoingAtAnOemChargeCap() {
+		// The device holding at its own cap reports NOT_CHARGING with the cable in and never reports FULL — the case a "still charging" reading of the feature
+		// would go silent on, and the one whose owners asked for the reminder.
+		final LevelAlertDecision fired = decide(fullAlertShowing(88, NOW), 88, PLUGGED_NOT_CHARGING, remindingAt(85));
+
+		assertNull(fired.notifyType()); // not yet due
+
+		final LevelAlertDecision reminded = BatteryLevelReceiver.decideLevelAlert(
+				fired.newState(), 88, PLUGGED_NOT_CHARGING, remindingAt(85), NOW + REMINDER_GAP_MS);
+		assertTrue(reminded.reminder());
+	}
+
+	@Test
+	public void unplugReminder_stopsWhenTheChargerComesOut() {
+		// "Until I unplug" is the whole promise: off the cable the episode is over, the shown alert is dismissed, and no reminder rides along behind it.
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				fullAlertShowing(90, NOW), 90, DISCHARGING, remindingAt(TARGET_90), NOW + 10 * REMINDER_GAP_MS);
+
+		assertNull(d.notifyType());
+		assertTrue(d.clearFullAlert());
+		assertFalse(d.newState().fullNotified());
+		assertEquals(0, d.newState().fullAlertAt());
+	}
+
+	@Test
+	public void unplugReminder_stopsOnceTheLevelFallsBackBelowTheTarget() {
+		// A phone drawing more than the cable supplies slides back out of "the charge you asked for is done", so there is nothing left to be reminded about.
+		// The repeated level is what reaches the full-battery branch here, the same path chargeTarget_whileDischarging_neverAlerts uses.
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				fullAlertShowing(84, NOW), 84, PLUGGED_NOT_CHARGING, remindingAt(TARGET_90), NOW + 10 * REMINDER_GAP_MS);
+
+		assertNull(d.notifyType());
+		// Re-armed by the band, and the reminder clock re-arms with it rather than being left to fire the instant the next charge reaches the target.
+		assertFalse(d.newState().fullNotified());
+		assertEquals(0, d.newState().fullAlertAt());
+	}
+
+	@Test
+	public void unplugReminder_withNoRecordedAlertTime_neverFires() {
+		// What an install upgrading mid-charge reads back: the flag says an alert already fired, with no record of when. Treating that absent time as "long
+		// ago" would greet exactly those users with a reminder the instant they updated.
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				fullAlertShowing(90), 90, CHARGING, remindingAt(TARGET_90), NOW + 100 * REMINDER_GAP_MS);
+
+		assertNull(d.notifyType());
+	}
+
+	@Test
+	public void unplugReminder_neverOutlivesTheChargeSessionItStarted() {
+		// Unplug, then plug back in above the target: that is a new session, so its first alert is a first alert — not a reminder inherited from the last one.
+		final LevelAlertDecision unplugged = BatteryLevelReceiver.decideLevelAlert(
+				fullAlertShowing(95, NOW), 95, DISCHARGING, remindingAt(TARGET_90), NOW + REMINDER_GAP_MS);
+		assertFalse(unplugged.newState().fullNotified());
+
+		final LevelAlertDecision replugged = BatteryLevelReceiver.decideLevelAlert(
+				unplugged.newState(), 95, CHARGING, remindingAt(TARGET_90), NOW + 2 * REMINDER_GAP_MS);
+		assertEquals(AlertType.FULL, replugged.notifyType());
+		assertFalse(replugged.reminder());
+	}
+
+	@Test
+	public void unplugReminder_withTheFullAlertSwitchedOff_saysNothing() {
+		// The reminder repeats the full-battery alert; with that alert off there is nothing to repeat, whatever this switch says.
+		final LevelAlertConfig noFullButReminding =
+				new LevelAlertConfig(CRITICAL, WARNING, TARGET_90, true, false, false, true, REMINDER_GAP_MS);
+		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+				fullAlertShowing(90, NOW), 90, CHARGING, noFullButReminding, NOW + 10 * REMINDER_GAP_MS);
+
+		assertNull(d.notifyType());
 	}
 
 	// --- unplugged: the full alert is bounded by the charger, not by the status --------------------
@@ -382,7 +551,7 @@ public class BatteryLevelReceiverDecisionTest {
 		// The status stays BATTERY_STATUS_FULL at 100% on plenty of devices with the cable already out.
 		// Firing here is what made the alert look like it refused to go away: the unplug handler cleared
 		// it and the very next broadcast posted it straight back.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(100, null), 100, UNPLUGGED_STILL_FULL, DEFAULTS);
 
 		assertNull(d.notifyType());
@@ -394,7 +563,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void unplugged_withFullAlertShown_dismissesItOnce() {
 		// Missed unplug broadcast (process killed mid-charge): the shown alert is dismissed from
 		// EXTRA_PLUGGED instead, then the session is re-armed so nothing dismisses twice.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fullAlertShowing(100), 100, UNPLUGGED_STILL_FULL, DEFAULTS);
 
 		assertTrue(d.clearFullAlert());
@@ -402,7 +571,7 @@ public class BatteryLevelReceiverDecisionTest {
 		assertFalse(d.newState().fullNotified());
 		assertFalse(d.newState().fullAlertShown());
 
-		final LevelAlertDecision next = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision next = decide(
 				d.newState(), 99, UNPLUGGED_STILL_FULL, DEFAULTS);
 		assertFalse(next.clearFullAlert());
 		assertNull(next.notifyType());
@@ -412,7 +581,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void unplugged_levelAlreadyDropping_stillDismissesTheFullAlert() {
 		// The discharge branch (changed level) must clear it too — otherwise a restart that first sees
 		// 99% leaves the alert up until the next charge session.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fullAlertShowing(100), 98, DISCHARGING, DEFAULTS);
 
 		assertTrue(d.clearFullAlert());
@@ -423,7 +592,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void unplugged_dischargedToCritical_stillAlertsWhileDismissingTheStaleFull() {
 		// Both at once: the receiver dismisses first and posts after, so the critical alert survives
 		// (they share one notification ID). BatteryLevelReceiverTest pins that ordering.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fullAlertShowing(21), 19, DISCHARGING, DEFAULTS);
 
 		assertTrue(d.clearFullAlert());
@@ -435,7 +604,7 @@ public class BatteryLevelReceiverDecisionTest {
 		// The state-driven fallback must land in exactly the state onChargerDisconnected produces.
 		// Re-arming only the full flag left prevType armed, silencing the next session's critical alert.
 		final LevelAlertState afterFullCharge = new LevelAlertState(100, AlertType.CRITICAL, true, true);
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				afterFullCharge, 100, UNPLUGGED_STILL_FULL, DEFAULTS);
 
 		assertNull(d.newState().prevType());
@@ -446,15 +615,15 @@ public class BatteryLevelReceiverDecisionTest {
 	public void unplugged_missedTransition_criticalStillAlertsWithWarningsOff() {
 		// The user-visible consequence of the re-arm above: with warning alerts disabled nothing else
 		// resets prevType on the way down, so a half re-arm stayed silent all the way to RED_ALERT_LEVEL.
-		final LevelAlertConfig noWarning = new LevelAlertConfig(CRITICAL, WARNING, AppPrefs.MAX_CHARGE_TARGET, false, true, false);
+		final LevelAlertConfig noWarning = config(AppPrefs.MAX_CHARGE_TARGET, false, true, false);
 		final LevelAlertState afterFullCharge = new LevelAlertState(100, AlertType.CRITICAL, true, true);
 
-		LevelAlertState state = BatteryLevelReceiver.decideLevelAlert(
+		LevelAlertState state = decide(
 				afterFullCharge, 100, UNPLUGGED_STILL_FULL, noWarning).newState();
 
 		AlertType fired = null;
 		for (int percentage = 99; percentage >= CRITICAL; percentage--) {
-			final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(state, percentage, DISCHARGING, noWarning);
+			final LevelAlertDecision d = decide(state, percentage, DISCHARGING, noWarning);
 			state = d.newState();
 			if (fired == null) {
 				fired = d.notifyType();
@@ -468,7 +637,7 @@ public class BatteryLevelReceiverDecisionTest {
 		// fullNotified survives a critical alert repainting the shared ID, so dismissal must key off
 		// "is a full alert on screen" — otherwise the unplug silently cancels the live critical one.
 		final LevelAlertState criticalOnScreen = new LevelAlertState(19, AlertType.CRITICAL, true, false);
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				criticalOnScreen, 18, DISCHARGING, DEFAULTS);
 
 		assertFalse(d.clearFullAlert());
@@ -478,9 +647,9 @@ public class BatteryLevelReceiverDecisionTest {
 	public void replugged_afterUnplugAtFull_firesAgain() {
 		// The unplug re-arm is what lets a charger connected at 100% alert again, so it must survive
 		// the dismissal path above.
-		final LevelAlertDecision unplugged = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision unplugged = decide(
 				fullAlertShowing(100), 100, UNPLUGGED_STILL_FULL, DEFAULTS);
-		final LevelAlertDecision replugged = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision replugged = decide(
 				unplugged.newState(), 100, FULL_ON_CHARGER, DEFAULTS);
 
 		assertEquals(AlertType.FULL, replugged.notifyType());
@@ -493,7 +662,7 @@ public class BatteryLevelReceiverDecisionTest {
 	public void restartMidEpisode_persistedStateSuppressesDuplicates() {
 		// Process death loses nothing: the decision on the persisted state after a "restart" is the
 		// same as it would have been in-process — no duplicate critical while still below threshold.
-		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
+		final LevelAlertDecision d = decide(
 				fresh(15, AlertType.CRITICAL), 13, DISCHARGING, DEFAULTS);
 
 		assertNull(d.notifyType());

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverTest.java
@@ -22,6 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -61,7 +62,7 @@ public class BatteryLevelReceiverTest {
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL), anyInt()));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL), anyInt(), anyBoolean()));
 		}
 	}
 
@@ -71,7 +72,7 @@ public class BatteryLevelReceiverTest {
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING), anyInt()));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING), anyInt(), anyBoolean()));
 		}
 	}
 
@@ -81,8 +82,8 @@ public class BatteryLevelReceiverTest {
 
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING), anyInt()), never());
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL), anyInt()), never());
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING), anyInt(), anyBoolean()), never());
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL), anyInt(), anyBoolean()), never());
 		}
 	}
 
@@ -95,7 +96,7 @@ public class BatteryLevelReceiverTest {
 			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 35, 100, 0);
 			receive();
 
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING), anyInt()), times(1));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.WARNING), anyInt(), anyBoolean()), times(1));
 		}
 	}
 
@@ -109,7 +110,7 @@ public class BatteryLevelReceiverTest {
 			publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 14, 100, 0);
 			receive();
 
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL), anyInt()), times(2));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL), anyInt(), anyBoolean()), times(2));
 		}
 	}
 
@@ -122,7 +123,7 @@ public class BatteryLevelReceiverTest {
 		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
 			receive();
 			receive(); // second identical tick must not re-send
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt()), times(1));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt(), anyBoolean()), times(1));
 		}
 	}
 
@@ -137,7 +138,7 @@ public class BatteryLevelReceiverTest {
 			BatteryLevelReceiver.onChargerDisconnected(context);
 			receive();
 
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt()), times(2));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt(), anyBoolean()), times(2));
 		}
 	}
 
@@ -157,8 +158,8 @@ public class BatteryLevelReceiverTest {
 			receive();
 
 			// Once, and carrying the level it actually fired at — that level is what keeps the copy honest.
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), eq(85)), times(1));
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt()), times(1));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), eq(85), anyBoolean()), times(1));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt(), anyBoolean()), times(1));
 		}
 	}
 
@@ -174,7 +175,7 @@ public class BatteryLevelReceiverTest {
 			receive();
 			receive(); // it sits there for hours; only the first tick may alert
 
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), eq(88)), times(1));
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), eq(88), anyBoolean()), times(1));
 		}
 	}
 
@@ -189,7 +190,51 @@ public class BatteryLevelReceiverTest {
 			receive();
 			receive();
 
-			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt()), never());
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt(), anyBoolean()), never());
+		}
+	}
+
+	@Test
+	public void unplugReminder_offByDefault_leavesTheAlertAtOncePerCharge() {
+		// The default the feature ships with (#264). The stored state is mid-charge with the alert long since posted — an install that never touches the switch
+		// must still hear nothing more until the cable comes out.
+		saveLevelState(new LevelAlertState(90, null, true, true, 1));
+		publishBattery(BatteryManager.BATTERY_STATUS_CHARGING, 90, 100, BatteryManager.BATTERY_PLUGGED_AC);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt(), anyBoolean()), never());
+		}
+	}
+
+	@Test
+	public void unplugReminder_switchedOn_rePostsTheAlertAsAReminder() {
+		// End-to-end for #264: the switch is read from the preference the settings screen writes, and a due reminder re-posts the full alert flagged as a
+		// repeat — which is what stops the dispatcher silencing it with setOnlyAlertOnce.
+		//
+		// The stored alert time is 1 ms after the epoch, i.e. any real gap has elapsed by now; that keeps the assertion off the wall clock.
+		setUnplugReminderEnabled(true);
+		saveLevelState(new LevelAlertState(90, null, true, true, 1));
+		publishBattery(BatteryManager.BATTERY_STATUS_CHARGING, 90, 100, BatteryManager.BATTERY_PLUGGED_AC);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), eq(90), eq(true)));
+		}
+	}
+
+	@Test
+	public void unplugReminder_switchedOn_stopsAtUnplug() {
+		// The promise the feature is named for. Same due reminder, cable out: the alert is taken down instead of repeated.
+		setUnplugReminderEnabled(true);
+		saveLevelState(new LevelAlertState(90, null, true, true, 1));
+		publishBattery(BatteryManager.BATTERY_STATUS_DISCHARGING, 90, 100, 0);
+
+		try (MockedStatic<NotificationService> ns = mockStatic(NotificationService.class)) {
+			receive();
+
+			ns.verify(() -> NotificationService.sendNotification(any(Context.class), eq(AlertType.FULL), anyInt(), anyBoolean()), never());
+			ns.verify(() -> NotificationService.clearLevelAlert(any(Context.class)));
 		}
 	}
 
@@ -206,7 +251,7 @@ public class BatteryLevelReceiverTest {
 
 			final InOrder ordered = inOrder(NotificationService.class);
 			ordered.verify(ns, () -> NotificationService.clearLevelAlert(any(Context.class)));
-			ordered.verify(ns, () -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL), anyInt()));
+			ordered.verify(ns, () -> NotificationService.sendNotification(any(Context.class), eq(AlertType.CRITICAL), anyInt(), anyBoolean()));
 		}
 	}
 
@@ -323,6 +368,13 @@ public class BatteryLevelReceiverTest {
 		PreferenceManager.getDefaultSharedPreferences(context)
 				.edit()
 				.putBoolean(context.getString(R.string._pref_key_notify_every_tick), true)
+				.commit();
+	}
+
+	private void setUnplugReminderEnabled(boolean enabled) {
+		PreferenceManager.getDefaultSharedPreferences(context)
+				.edit()
+				.putBoolean(context.getString(R.string._pref_key_notify_unplug_reminder), enabled)
 				.commit();
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/FastDrainDetectorTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/FastDrainDetectorTest.java
@@ -13,7 +13,8 @@ import static org.junit.Assert.assertTrue;
  * Unit tests for the pure fast-drain decision core {@link FastDrainDetector#decide} (issue #109),
  * unchanged as the behaviour contract after the shared engine was extracted (#163): the
  * sustained-streak trigger, the once-vs-reminder split by screen state, the re-arm hysteresis, the
- * observation-gap lapse rule, and the timing-preference clamp.
+ * observation-gap lapse rule. The timing-preference clamp the detector reads its windows through moved to {@code AppPrefsTest} along with
+ * {@link com.almothafar.simplebatterynotifier.util.AppPrefs#clampMinutesToMs}, which every timing preference now shares.
  * Times in millis; limit in %/h. The streak's {@code lastSeen} sits close to "now" where the scenario
  * implies continuous observation — in production every above-limit tick refreshes it.
  */
@@ -178,22 +179,5 @@ public class FastDrainDetectorTest {
 		final Outcome lapsed = FastDrainDetector.decide(
 				state, true, 30, LIMIT, SUSTAINED_MS, REMINDER_MS, LOCKED, atBoundary + 1);
 		assertEquals(atBoundary + 1, lapsed.newState().start()); // restarted
-	}
-
-	// --- timing-preference clamp ----------------------------------------------------------------
-
-	@Test
-	public void clampMinutes_inRangeUnchanged() {
-		assertEquals(5 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(5, 1, 30));
-		assertEquals(1 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(1, 1, 30));   // boundaries kept
-		assertEquals(60 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(60, 5, 60));
-	}
-
-	@Test
-	public void clampMinutes_outOfRangeClamped() {
-		// 0 sustained minutes would fire on the first above-limit tick — the spike alarm the design forbids.
-		assertEquals(1 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(0, 1, 30));
-		assertEquals(1 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(-7, 1, 30));
-		assertEquals(30 * MINUTE_MS, FastDrainDetector.clampMinutesToMs(999, 1, 30));
 	}
 }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -82,7 +83,7 @@ public class NotificationServiceTest {
 
 		@Test
 		public void chargeNotification_doesNotReplaceLevelAlert() {
-			NotificationService.sendNotification(context, AlertType.CRITICAL, 15);
+			NotificationService.sendNotification(context, AlertType.CRITICAL, 15, false);
 			NotificationService.notifyChargeConnected(context, ChargeSpeed.unknown(), false);
 
 			// Distinct IDs: both must be showing, not "Charging started" swallowing the critical alert.
@@ -91,7 +92,7 @@ public class NotificationServiceTest {
 
 		@Test
 		public void clearNotifications_onDisconnect_removesLevelAlertAndChargeNotification() {
-			NotificationService.sendNotification(context, AlertType.CRITICAL, 15);
+			NotificationService.sendNotification(context, AlertType.CRITICAL, 15, false);
 			NotificationService.notifyChargeConnected(context, ChargeSpeed.unknown(), false);
 
 			NotificationService.clearNotifications(context);
@@ -102,7 +103,7 @@ public class NotificationServiceTest {
 
 		@Test
 		public void clearLevelAlert_dismissesOnlyTheLevelAlert() {
-			NotificationService.sendNotification(context, AlertType.CRITICAL, 15);
+			NotificationService.sendNotification(context, AlertType.CRITICAL, 15, false);
 			NotificationService.notifyChargeConnected(context, ChargeSpeed.unknown(), false);
 
 			NotificationService.clearLevelAlert(context);
@@ -138,9 +139,61 @@ public class NotificationServiceTest {
 		public void nullAlertType_postsNothing() {
 			// The old int API's default branch posted a completely BLANK notification for an invalid
 			// type (#160). With the enum, the only invalid value left is null — and it must be a no-op.
-			NotificationService.sendNotification(context, null, 50);
+			NotificationService.sendNotification(context, null, 50, false);
 
 			assertEquals(0, shadowOf(manager).size());
+		}
+	}
+
+	/**
+	 * Which posts are allowed to alert the user again (#264).
+	 * <p>
+	 * The level alerts share one notification ID, so every full-battery post after the first is a re-post of that ID. Android only re-alerts on a re-post when
+	 * {@code FLAG_ONLY_ALERT_ONCE} is absent — which is exactly what separates a reminder the user notices from a shade entry that quietly updates behind
+	 * their back. It is the one property the unplug reminder cannot work without, and nothing above this layer can assert it.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class ReminderAlertsAgain {
+
+		private Context context;
+		private NotificationManager manager;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+			shadowOf((Application) context).grantPermissions(Manifest.permission.POST_NOTIFICATIONS);
+			manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		}
+
+		@Test
+		public void firstFullAlert_updatesQuietlyOnARePost() {
+			NotificationService.sendNotification(context, AlertType.FULL, 90, false);
+
+			assertTrue("the charge session's first full alert should keep setOnlyAlertOnce", onlyAlertsOnce(latestNotification()));
+		}
+
+		@Test
+		public void unplugReminder_alertsAgain() {
+			NotificationService.sendNotification(context, AlertType.FULL, 90, true);
+
+			assertFalse("a reminder that only-alerts-once re-posts in silence, reminding nobody", onlyAlertsOnce(latestNotification()));
+		}
+
+		@Test
+		public void criticalAlert_alertsEveryTimeWithoutBeingAReminder() {
+			// The pre-existing per-type rule, unchanged: the critical alert already re-alerts on every post, so the reminder flag has nothing to add there.
+			NotificationService.sendNotification(context, AlertType.CRITICAL, 15, false);
+
+			assertFalse(onlyAlertsOnce(latestNotification()));
+		}
+
+		private Notification latestNotification() {
+			return shadowOf(manager).getAllNotifications().get(0);
+		}
+
+		private static boolean onlyAlertsOnce(Notification notification) {
+			return (notification.flags & Notification.FLAG_ONLY_ALERT_ONCE) != 0;
 		}
 	}
 

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/util/AppPrefsTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/util/AppPrefsTest.java
@@ -34,8 +34,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for the {@link AppPrefs} facade (#162). The context-backed cases run under Robolectric (typed
  * accessors fall back to the single-owned defaults, read stored values, round-trip writes, and — the
- * drift guard — the XML slider defaults still equal the constants); the pure drain-limit clamp is a
- * plain parameterized test.
+ * drift guard — the XML slider defaults still equal the constants); the pure drain-limit, charge-target and minutes clamps are plain parameterized tests.
  */
 @RunWith(Enclosed.class)
 public class AppPrefsTest {
@@ -119,6 +118,34 @@ public class AppPrefsTest {
 		}
 
 		@Test
+		public void unplugReminder_defaultsOffAndReadsBack() {
+			// Off is the whole point of the default (#264): the alert stays once per charge for everyone who didn't ask to be nagged.
+			assertFalse(AppPrefs.DEFAULT_UNPLUG_REMINDER);
+			assertFalse(AppPrefs.unplugReminderEnabled(context));
+
+			PreferenceManager.getDefaultSharedPreferences(context).edit()
+			                 .putBoolean(context.getString(R.string._pref_key_notify_unplug_reminder), true)
+			                 .apply();
+			assertTrue(AppPrefs.unplugReminderEnabled(context));
+		}
+
+		@Test
+		public void unplugReminderGap_defaultsToTheSliderDefaultAndClampsStoredValues() {
+			assertEquals(AppPrefs.DEFAULT_UNPLUG_REMINDER_MINUTES * 60_000L, AppPrefs.unplugReminderGapMs(context));
+
+			// A 0-minute gap is what a corrupt or downgraded preferences file yields, and it would remind on every battery broadcast.
+			PreferenceManager.getDefaultSharedPreferences(context).edit()
+			                 .putInt(context.getString(R.string._pref_key_unplug_reminder_minutes), 0)
+			                 .apply();
+			assertEquals(AppPrefs.MIN_UNPLUG_REMINDER_MINUTES * 60_000L, AppPrefs.unplugReminderGapMs(context));
+
+			PreferenceManager.getDefaultSharedPreferences(context).edit()
+			                 .putInt(context.getString(R.string._pref_key_unplug_reminder_minutes), 30)
+			                 .apply();
+			assertEquals(30 * 60_000L, AppPrefs.unplugReminderGapMs(context));
+		}
+
+		@Test
 		public void vibrateEnabled_defaultsTrueAndReadsBack() {
 			// Defaults on (matches the switch's android:defaultValue in pref_behaviour.xml).
 			assertTrue(AppPrefs.DEFAULT_VIBRATE);
@@ -172,11 +199,25 @@ public class AppPrefsTest {
 		 */
 		@Test
 		public void chargeTargetSlider_boundsAreTheFacadeConstantsAtRuntime() throws Exception {
-			final SeekBarPreference slider = inflateChargeTargetSlider();
+			final SeekBarPreference slider = inflateSlider(R.string._pref_key_charge_target);
 
 			assertNotNull("charge-target slider missing from pref_alerts.xml", slider);
 			assertEquals(AppPrefs.MIN_CHARGE_TARGET, slider.getMin());
 			assertEquals(AppPrefs.MAX_CHARGE_TARGET, slider.getMax());
+		}
+
+		/**
+		 * The same guard for the unplug-reminder interval (#264), which restates the facade's bounds in XML exactly as the charge target does — including the
+		 * {@code app:min} trap that would otherwise offer gaps down to 0 minutes: a reminder on every broadcast, which is the one behaviour the clamp exists to
+		 * make unreachable.
+		 */
+		@Test
+		public void unplugReminderSlider_boundsAreTheFacadeConstantsAtRuntime() throws Exception {
+			final SeekBarPreference slider = inflateSlider(R.string._pref_key_unplug_reminder_minutes);
+
+			assertNotNull("unplug-reminder slider missing from pref_alerts.xml", slider);
+			assertEquals(AppPrefs.MIN_UNPLUG_REMINDER_MINUTES, slider.getMin());
+			assertEquals(AppPrefs.MAX_UNPLUG_REMINDER_MINUTES, slider.getMax());
 		}
 
 		/**
@@ -185,12 +226,71 @@ public class AppPrefsTest {
 		 */
 		@Test
 		public void xmlChargeTargetDefault_matchesTheFacadeConstant() throws Exception {
-			final XmlResourceParser parser = context.getResources().getXml(R.xml.pref_alerts);
-			Integer xmlDefault = null;
+			final Integer xmlDefault = xmlDefaultOf(R.string._pref_key_charge_target);
 
+			assertNotNull("defaultValue attr missing from the charge-target slider", xmlDefault);
+			assertEquals(AppPrefs.DEFAULT_CHARGE_TARGET, (int) xmlDefault);
+		}
+
+		/**
+		 * The unplug reminder greys out with the alert it repeats, and its interval greys out with the reminder (#264).
+		 * <p>
+		 * The chain is the design decision, not an accident of ordering: there is nothing to repeat when the full-battery alert is off, so leaving these two
+		 * live would offer a user settings that cannot do anything. It is also what separates them from the charge target directly above, which stays live
+		 * precisely because it still governs the Insights temperature range (#260) with the alert switched off.
+		 */
+		@Test
+		public void unplugReminderControls_greyOutWithTheAlertTheyRepeat() throws Exception {
+			assertEquals(R.string._pref_key_notify_for_full_level, xmlDependencyOf(R.string._pref_key_notify_unplug_reminder));
+			assertEquals(R.string._pref_key_notify_unplug_reminder, xmlDependencyOf(R.string._pref_key_unplug_reminder_minutes));
+			// The contrast that makes the rule above a rule rather than a habit.
+			assertEquals("the charge target must stay live with the alert off", 0, xmlDependencyOf(R.string._pref_key_charge_target));
+		}
+
+		@Test
+		public void xmlUnplugReminderDefault_matchesTheFacadeConstant() throws Exception {
+			final Integer xmlDefault = xmlDefaultOf(R.string._pref_key_unplug_reminder_minutes);
+
+			assertNotNull("defaultValue attr missing from the unplug-reminder slider", xmlDefault);
+			assertEquals(AppPrefs.DEFAULT_UNPLUG_REMINDER_MINUTES, (int) xmlDefault);
+		}
+
+		/**
+		 * Builds the charge-target slider from {@code pref_alerts.xml} exactly as the preference framework would, so its bounds are the ones a user's finger
+		 * actually meets.
+		 *
+		 * @param keyRes the slider's preference-key string resource
+	 *
+	 * @return the inflated slider, or {@code null} when the screen no longer declares one
+		 */
+		private SeekBarPreference inflateSlider(int keyRes) throws Exception {
+			final XmlResourceParser parser = context.getResources().getXml(R.xml.pref_alerts);
 			try {
 				for (int event = parser.getEventType(); event != XmlPullParser.END_DOCUMENT; event = parser.next()) {
-					if (event != XmlPullParser.START_TAG || !isChargeTargetSlider(parser)) {
+					if (event == XmlPullParser.START_TAG && hasKey(parser, keyRes)) {
+						return new SeekBarPreference(context, Xml.asAttributeSet(parser));
+					}
+				}
+			} finally {
+				parser.close();
+			}
+			return null;
+		}
+
+		/**
+		 * The {@code android:defaultValue} the framework reads for a slider, straight off the attribute — that <em>is</em> where the framework reads it from,
+		 * so it is the one value {@link AppPrefs} cannot own and the one that has to be compared as text.
+		 *
+		 * @param keyRes the slider's preference-key string resource
+		 *
+		 * @return the declared default, or {@code null} when the slider or its attribute is gone
+		 */
+		private Integer xmlDefaultOf(int keyRes) throws Exception {
+			final XmlResourceParser parser = context.getResources().getXml(R.xml.pref_alerts);
+			Integer xmlDefault = null;
+			try {
+				for (int event = parser.getEventType(); event != XmlPullParser.END_DOCUMENT; event = parser.next()) {
+					if (event != XmlPullParser.START_TAG || !hasKey(parser, keyRes)) {
 						continue;
 					}
 					for (int i = 0; i < parser.getAttributeCount(); i++) {
@@ -202,39 +302,44 @@ public class AppPrefsTest {
 			} finally {
 				parser.close();
 			}
-
-			assertNotNull("defaultValue attr missing from the charge-target slider", xmlDefault);
-			assertEquals(AppPrefs.DEFAULT_CHARGE_TARGET, (int) xmlDefault);
+			return xmlDefault;
 		}
 
 		/**
-		 * Builds the charge-target slider from {@code pref_alerts.xml} exactly as the preference framework would, so its bounds are the ones a user's finger
-		 * actually meets.
+		 * The {@code android:dependency} a preference declares, as the string resource it points at.
 		 *
-		 * @return the inflated slider, or {@code null} when the screen no longer declares one
+		 * @param keyRes the preference's own key string resource
+		 *
+		 * @return the dependency's key resource, or {@code 0} when the preference declares none
 		 */
-		private SeekBarPreference inflateChargeTargetSlider() throws Exception {
+		private int xmlDependencyOf(int keyRes) throws Exception {
 			final XmlResourceParser parser = context.getResources().getXml(R.xml.pref_alerts);
+			int dependency = 0;
 			try {
 				for (int event = parser.getEventType(); event != XmlPullParser.END_DOCUMENT; event = parser.next()) {
-					if (event == XmlPullParser.START_TAG && isChargeTargetSlider(parser)) {
-						return new SeekBarPreference(context, Xml.asAttributeSet(parser));
+					if (event != XmlPullParser.START_TAG || !hasKey(parser, keyRes)) {
+						continue;
+					}
+					for (int i = 0; i < parser.getAttributeCount(); i++) {
+						if (parser.getAttributeNameResource(i) == android.R.attr.dependency) {
+							dependency = parser.getAttributeResourceValue(i, 0);
+						}
 					}
 				}
 			} finally {
 				parser.close();
 			}
-			return null;
+			return dependency;
 		}
 
 		/**
-		 * Whether the tag the parser is on is the charge-target slider, identified by its preference key rather than its position — the screen grows and the
+		 * Whether the tag the parser is on carries the given preference key. Preferences are found by key rather than by position — the screen grows and the
 		 * categories get reordered.
 		 */
-		private boolean isChargeTargetSlider(XmlResourceParser parser) {
+		private boolean hasKey(XmlResourceParser parser, int keyRes) {
 			for (int i = 0; i < parser.getAttributeCount(); i++) {
 				if (parser.getAttributeNameResource(i) == android.R.attr.key
-						&& parser.getAttributeResourceValue(i, 0) == R.string._pref_key_charge_target) {
+						&& parser.getAttributeResourceValue(i, 0) == keyRes) {
 					return true;
 				}
 			}
@@ -269,6 +374,41 @@ public class AppPrefsTest {
 		@Test
 		public void matchesExpected() {
 			assertEquals(expected, AppPrefs.clampChargeTarget(stored));
+		}
+	}
+
+	/**
+	 * {@link AppPrefs#clampMinutesToMs}: the shared guarantee behind every timing preference — the fast-drain window and reminder (#109) and the unplug reminder
+	 * (#264). Moved here with the helper itself, which the sliders' ranges are all enforced through.
+	 */
+	@RunWith(Parameterized.class)
+	public static class ClampMinutesToMs {
+
+		private static final long MINUTE_MS = 60_000L;
+
+		@Parameter(0) public int stored;
+		@Parameter(1) public int minMinutes;
+		@Parameter(2) public int maxMinutes;
+		@Parameter(3) public long expectedMs;
+
+		@Parameters(name = "clampMinutesToMs({0}, {1}, {2}) = {3}ms")
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{
+					{5, 1, 30, 5 * MINUTE_MS},      // in range: unchanged
+					{1, 1, 30, 1 * MINUTE_MS},      // boundaries kept
+					{60, 5, 60, 60 * MINUTE_MS},
+					// 0 sustained minutes would fire on the first above-limit tick — the spike alarm the design forbids; 0 reminder minutes would remind on
+					// every broadcast.
+					{0, 1, 30, 1 * MINUTE_MS},
+					{-7, 1, 30, 1 * MINUTE_MS},
+					{999, 1, 30, 30 * MINUTE_MS},
+					{0, 5, 60, 5 * MINUTE_MS},
+			});
+		}
+
+		@Test
+		public void matchesExpected() {
+			assertEquals(expectedMs, AppPrefs.clampMinutesToMs(stored, minMinutes, maxMinutes));
 		}
 	}
 


### PR DESCRIPTION
Closes #264.

The opt-in repeat of the full-battery alert: while the battery stays on the charger at or above the charge target, the full/almost-full alert is re-posted every N minutes instead of arriving once and being missed. **Off by default.**

## The three questions the issue left open

**Repeat rate — minutes, not percentage points.** The level barely moves near the top of a charge, and on a device parked at an OEM charge cap (Samsung "Protect battery" at 85, Sony/Asus at 80) it does not move at all — a per-% repeat would go silent for exactly the users who asked for this. Minutes also reuse the shape the fast-drain reminder already has. Default 15 min, range 5–60.

**A cap — none.** "Until I unplug" is what the switch says, and a cap silently reintroduces the miss the feature exists to prevent. The interval is the user's dial if the repeats are too frequent for an overnight charge.

**Quiet hours — no special case,** as the issue suggested. The full alert is not the critical alert, so it already resolves to a silent channel inside the quiet window and skips the silent-mode override; a reminder posts silently there for free.

## How it works

The repeat sits **on top of** #263's re-arm guard rather than replacing it. `fullNotified` still bounds the alert to one charge session; a new `fullAlertAt` timestamp on the episode state times the reminders from the last post (not the first, or every broadcast after the first gap would be "overdue"). The re-arm band clears the timestamp with the flag, so a stale clock can't fire an instant reminder at the start of the next charge.

Reminders piggyback the `ACTION_BATTERY_CHANGED` broadcasts — no new alarm, timer or wakelock — so the gap is a **minimum**, not a period.

One thing this needed beyond the decision core: the level alerts share a single notification ID, and every full-battery post after the first is a re-post of it. A re-post keeps `setOnlyAlertOnce`, so it would slide into the shade in silence — a reminder nobody notices. `sendNotification` now takes a `reminder` flag that drops that for the repeat only.

`AppPrefs.unplugReminderEnabled` / `unplugReminderGapMs` own the keys, defaults and clamp, and the minutes clamp itself moves from `FastDrainDetector` to `AppPrefs` now that two features enforce a slider's range the same way.

## Settings

Under **Alerts › Full Battery**, below the charge target: a switch (off) and an interval slider. Both are gated by the full-battery alert switch — there is nothing to repeat when that alert is off — unlike the charge target directly above them, which stays live because it still governs the Insights temperature range (#260). A test pins that contrast so the rule stays a rule.

## Tests

- Decision core: default-off, first-alert-is-not-a-reminder, fires on the gap, quiet before it, spacing from the last post, keeps going at an OEM cap, stops at unplug, stops when the level falls back below the target, and never fires without a recorded alert time (the mid-charge upgrade case).
- End-to-end through the receiver and real preferences: the switch is actually read, a due reminder dispatches flagged as a repeat, and unplug dismisses instead of repeating.
- `NotificationService`: the first full alert keeps `FLAG_ONLY_ALERT_ONCE`, a reminder does not. This is the one property the feature cannot work without and nothing above that layer can see it.
- `AppPrefs`: default/clamp for both new preferences, plus the XML-drift guards (inflated bounds and declared default) the charge-target slider already has.

Ran locally on the CI's own gates: `test`, `lintDebug`, `assembleDebug`, `assembleRelease` — all green.

I also reflowed the issue body on #264 (it was hard-wrapped at ~100 columns).
