### PR TITLE
refactor: move the fast-drain timing preferences behind AppPrefs

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/FastDrainDetector.java
@@ -13,6 +13,7 @@ import com.almothafar.simplebatterynotifier.service.SustainedConditionTracker.St
 import com.almothafar.simplebatterynotifier.util.AppPrefs;
 
 import static java.util.Objects.isNull;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * Warns when the battery drains abnormally fast for a <em>sustained</em> time (issue #109).
@@ -41,17 +42,6 @@ public final class FastDrainDetector {
 
 	private static final StreakStore STORE =
 			new StreakStore(PREF_STREAK_START, PREF_ALERTED, PREF_LAST_SEEN_ABOVE, PREF_LAST_REMINDER);
-
-	// Defaults and accepted ranges (user-tunable), matching the settings XML min/max — enforced when the
-	// preferences are read, so a corrupt/out-of-range value can't turn this into a spike alarm.
-	static final int DEFAULT_SUSTAINED_MINUTES = 5;
-	static final int MIN_SUSTAINED_MINUTES = 1;
-	static final int MAX_SUSTAINED_MINUTES = 30;
-	static final int DEFAULT_REMINDER_MINUTES = 15;
-	static final int MIN_REMINDER_MINUTES = 5;
-	static final int MAX_REMINDER_MINUTES = 60;
-
-	private static final long MS_PER_MINUTE = 60_000L;
 
 	private FastDrainDetector() {
 		// Utility class - prevent instantiation
@@ -92,10 +82,8 @@ public final class FastDrainDetector {
 		}
 
 		final int limit = AppPrefs.drainLimitPph(context);
-		final long sustainedMs = minutesPref(prefs, context, R.string._pref_key_fast_drain_sustained_minutes,
-				DEFAULT_SUSTAINED_MINUTES, MIN_SUSTAINED_MINUTES, MAX_SUSTAINED_MINUTES);
-		final long reminderGapMs = minutesPref(prefs, context, R.string._pref_key_fast_drain_reminder_minutes,
-				DEFAULT_REMINDER_MINUTES, MIN_REMINDER_MINUTES, MAX_REMINDER_MINUTES);
+		final long sustainedMs = AppPrefs.fastDrainSustainedMs(context);
+		final long reminderGapMs = AppPrefs.fastDrainReminderGapMs(context);
 		final boolean activelyUsed = SystemService.isActivelyUsed(context);
 		final long now = System.currentTimeMillis();
 
@@ -104,7 +92,7 @@ public final class FastDrainDetector {
 
 		STORE.saveIfChanged(transientPrefs, decision.newState());
 		if (decision.shouldNotify()) {
-			final int elapsedMinutes = Math.max(1, Math.round(decision.elapsedMs() / (float) MS_PER_MINUTE));
+			final int elapsedMinutes = Math.max(1, Math.round(decision.elapsedMs() / (float) MINUTES.toMillis(1)));
 			NotificationService.sendFastDrainNotification(context, rate.percentPerHour(), limit, elapsedMinutes);
 		} else if (previous.alerted() && !decision.newState().alerted()) {
 			// The episode ended: the drain calmed back below the limit (hysteresis re-arm), or a long
@@ -160,14 +148,5 @@ public final class FastDrainDetector {
 		final SustainedConditionTracker.RepeatPolicy policy =
 				SustainedConditionTracker.withReminders(activelyUsed, reminderGapMs);
 		return SustainedConditionTracker.decide(state, rateAvailable, conditionActive, sustainedMs, nowMillis, policy);
-	}
-
-	private static long minutesPref(SharedPreferences prefs,
-	                                Context context,
-	                                int keyRes,
-	                                int defaultMinutes,
-	                                int minMinutes,
-	                                int maxMinutes) {
-		return AppPrefs.clampMinutesToMs(prefs.getInt(context.getString(keyRes), defaultMinutes), minMinutes, maxMinutes);
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/util/AppPrefs.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/util/AppPrefs.java
@@ -25,7 +25,10 @@ import com.almothafar.simplebatterynotifier.model.LevelThresholds;
  *       value can't defeat the feature" lives in one place;</li>
  *   <li>the "Vibrate" flag ({@link #vibrateEnabled}) — previously re-read with an inline {@code true}
  *       default in three spots (channel creation, the level-alert config and the manual override path),
- *       which meant the alert channels and the silent-mode buzz could drift apart.</li>
+ *       which meant the alert channels and the silent-mode buzz could drift apart;</li>
+ *   <li>the fast-drain timing pair (#109) — the sustained window and the reminder gap ({@link #fastDrainSustainedMs} + {@link #fastDrainReminderGapMs}), whose
+ *       six bounds moved here from {@code FastDrainDetector} so they sit beside the {@link #clampMinutesToMs} that enforces them, like every other timing
+ *       preference.</li>
  * </ul>
  * The one restatement that remains is each slider's XML-declared default in {@code pref_alerts.xml}, which the framework instantiates from XML and so cannot
  * share a constant with — a comment ties each pair, and {@code AppPrefsTest} asserts they stay equal. Remaining settings migrate incrementally; new ones (the
@@ -82,9 +85,27 @@ public final class AppPrefs {
 	/** Highest accepted drain limit in %/h; mirrors the slider's {@code android:max} in pref_alerts.xml. */
 	public static final int MAX_DRAIN_LIMIT_PPH = 60;
 
+	/**
+	 * Default fast-drain window in minutes (#109) — how long the rate must hold at/above the limit before the alert fires. Mirrors the slider's
+	 * {@code android:defaultValue} in pref_alerts.xml.
+	 */
+	public static final int DEFAULT_FAST_DRAIN_SUSTAINED_MINUTES = 5;
+	/** Shortest accepted fast-drain window; mirrors the slider's {@code app:min} in pref_alerts.xml. */
+	public static final int MIN_FAST_DRAIN_SUSTAINED_MINUTES = 1;
+	/** Longest accepted fast-drain window; mirrors the slider's {@code android:max} in pref_alerts.xml. */
+	public static final int MAX_FAST_DRAIN_SUSTAINED_MINUTES = 30;
+
+	/** Default gap between fast-drain reminders, in minutes (#109) — mirrors the slider's {@code android:defaultValue} in pref_alerts.xml. */
+	public static final int DEFAULT_FAST_DRAIN_REMINDER_MINUTES = 15;
+	/** Shortest accepted fast-drain reminder gap; mirrors the slider's {@code app:min} in pref_alerts.xml. */
+	public static final int MIN_FAST_DRAIN_REMINDER_MINUTES = 5;
+	/** Longest accepted fast-drain reminder gap; mirrors the slider's {@code android:max} in pref_alerts.xml. */
+	public static final int MAX_FAST_DRAIN_REMINDER_MINUTES = 60;
+
 	/** Default for the "Vibrate" preference — mirrors the switch's {@code android:defaultValue} in pref_behaviour.xml. */
 	public static final boolean DEFAULT_VIBRATE = true;
 
+	/** Milliseconds in a minute — the conversion between the minutes every timing slider speaks in and the millis the decision cores measure in. */
 	private static final long MS_PER_MINUTE = 60_000L;
 
 	private AppPrefs() {
@@ -234,6 +255,37 @@ public final class AppPrefs {
 	 */
 	public static long clampMinutesToMs(int storedMinutes, int minMinutes, int maxMinutes) {
 		return Math.max(minMinutes, Math.min(maxMinutes, storedMinutes)) * MS_PER_MINUTE;
+	}
+
+	/**
+	 * How long the drain rate must hold at/above the limit before the fast-drain alert fires (#109), in milliseconds. Reads
+	 * {@link #DEFAULT_FAST_DRAIN_SUSTAINED_MINUTES} when unset and always clamps, so a corrupt preference (a 0-minute window, say) can't turn a sustained-drain
+	 * warning into a spike alarm.
+	 *
+	 * @param context Application context
+	 *
+	 * @return the configured window in milliseconds
+	 */
+	public static long fastDrainSustainedMs(Context context) {
+		return clampMinutesToMs(
+				prefs(context).getInt(context.getString(R.string._pref_key_fast_drain_sustained_minutes), DEFAULT_FAST_DRAIN_SUSTAINED_MINUTES),
+				MIN_FAST_DRAIN_SUSTAINED_MINUTES,
+				MAX_FAST_DRAIN_SUSTAINED_MINUTES);
+	}
+
+	/**
+	 * The minimum gap between fast-drain reminders while the screen is off or locked (#109), in milliseconds. Reads
+	 * {@link #DEFAULT_FAST_DRAIN_REMINDER_MINUTES} when unset and always clamps, for the same reason as every other timing preference here.
+	 *
+	 * @param context Application context
+	 *
+	 * @return the configured reminder gap in milliseconds
+	 */
+	public static long fastDrainReminderGapMs(Context context) {
+		return clampMinutesToMs(
+				prefs(context).getInt(context.getString(R.string._pref_key_fast_drain_reminder_minutes), DEFAULT_FAST_DRAIN_REMINDER_MINUTES),
+				MIN_FAST_DRAIN_REMINDER_MINUTES,
+				MAX_FAST_DRAIN_REMINDER_MINUTES);
 	}
 
 	/**

--- a/app/src/main/res/xml/pref_alerts.xml
+++ b/app/src/main/res/xml/pref_alerts.xml
@@ -218,9 +218,9 @@
             app:adjustable="true"
             app:iconSpaceReserved="false" />
 
-        <!-- defaultValue/min/max of both timing sliders must match FastDrainDetector's
-             DEFAULT/MIN/MAX_SUSTAINED_MINUTES and DEFAULT/MIN/MAX_REMINDER_MINUTES, which clamp
-             the stored values when they are read (#109). app:min for the same reason as above. -->
+        <!-- defaultValue/min/max of both timing sliders must match AppPrefs'
+             DEFAULT/MIN/MAX_FAST_DRAIN_SUSTAINED_MINUTES and DEFAULT/MIN/MAX_FAST_DRAIN_REMINDER_MINUTES,
+             which clamp the stored values when they are read (#109). app:min for the same reason as above. -->
         <SeekBarPreference
             android:defaultValue="5"
             android:dependency="@string/_pref_key_notify_fast_drain"

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/receiver/BatteryLevelReceiverDecisionTest.java
@@ -77,14 +77,37 @@ public class BatteryLevelReceiverDecisionTest {
 	 * fixed for the whole suite, so only what a case actually varies is named at the call site.
 	 */
 	private static LevelAlertConfig config(int chargeTarget, boolean warningEnabled, boolean fullNotifyEnabled, boolean alertEveryTick) {
-		return new LevelAlertConfig(CRITICAL, WARNING, chargeTarget, warningEnabled, fullNotifyEnabled, alertEveryTick, false, REMINDER_GAP_MS);
+		return config(chargeTarget, warningEnabled, fullNotifyEnabled, alertEveryTick, false);
+	}
+
+	/**
+	 * The same with the unplug reminder (#264) named too. The one place the record is constructed, so a component added to it lands here rather than in every
+	 * shape the suite happens to need — and no case has to spell out eight positional arguments to reach the combination it is about.
+	 */
+	private static LevelAlertConfig config(
+			int chargeTarget,
+			boolean warningEnabled,
+			boolean fullNotifyEnabled,
+			boolean alertEveryTick,
+			boolean unplugReminderEnabled) {
+		return new LevelAlertConfig(
+				CRITICAL, WARNING, chargeTarget, warningEnabled, fullNotifyEnabled, alertEveryTick, unplugReminderEnabled, REMINDER_GAP_MS);
 	}
 
 	/**
 	 * A config with the unplug reminder on (#264), at the given charge target. Everything else matches {@link #config}.
 	 */
 	private static LevelAlertConfig remindingAt(int chargeTarget) {
-		return new LevelAlertConfig(CRITICAL, WARNING, chargeTarget, true, true, false, true, REMINDER_GAP_MS);
+		return config(chargeTarget, true, true, false, true);
+	}
+
+	/**
+	 * The same, but with the full-battery alert the reminder repeats switched off — the one combination {@link #remindingAt} cannot express, and the premise of
+	 * the case proving the reminder does not outlive the alert it exists to repeat. Named rather than spelled out, because the two booleans that disagree are
+	 * the whole point and a positional list is where that reads as a typo.
+	 */
+	private static LevelAlertConfig remindingWithTheFullAlertOff(int chargeTarget) {
+		return config(chargeTarget, true, false, false, true);
 	}
 
 	/**
@@ -536,10 +559,8 @@ public class BatteryLevelReceiverDecisionTest {
 	@Test
 	public void unplugReminder_withTheFullAlertSwitchedOff_saysNothing() {
 		// The reminder repeats the full-battery alert; with that alert off there is nothing to repeat, whatever this switch says.
-		final LevelAlertConfig noFullButReminding =
-				new LevelAlertConfig(CRITICAL, WARNING, TARGET_90, true, false, false, true, REMINDER_GAP_MS);
 		final LevelAlertDecision d = BatteryLevelReceiver.decideLevelAlert(
-				fullAlertShowing(90, NOW), 90, CHARGING, noFullButReminding, NOW + 10 * REMINDER_GAP_MS);
+				fullAlertShowing(90, NOW), 90, CHARGING, remindingWithTheFullAlertOff(TARGET_90), NOW + 10 * REMINDER_GAP_MS);
 
 		assertNull(d.notifyType());
 	}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/util/AppPrefsTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/util/AppPrefsTest.java
@@ -145,6 +145,40 @@ public class AppPrefsTest {
 			assertEquals(30 * 60_000L, AppPrefs.unplugReminderGapMs(context));
 		}
 
+		/**
+		 * The fast-drain window (#109), now that the facade owns it. A 0-minute window is the corrupt-preference case that matters: it would fire on the first
+		 * broadcast above the limit, turning the sustained-drain warning into the spike alarm the window exists to prevent.
+		 */
+		@Test
+		public void fastDrainSustained_defaultsToTheSliderDefaultAndClampsStoredValues() {
+			assertEquals(AppPrefs.DEFAULT_FAST_DRAIN_SUSTAINED_MINUTES * 60_000L, AppPrefs.fastDrainSustainedMs(context));
+
+			PreferenceManager.getDefaultSharedPreferences(context).edit()
+			                 .putInt(context.getString(R.string._pref_key_fast_drain_sustained_minutes), 0)
+			                 .apply();
+			assertEquals(AppPrefs.MIN_FAST_DRAIN_SUSTAINED_MINUTES * 60_000L, AppPrefs.fastDrainSustainedMs(context));
+
+			PreferenceManager.getDefaultSharedPreferences(context).edit()
+			                 .putInt(context.getString(R.string._pref_key_fast_drain_sustained_minutes), 999)
+			                 .apply();
+			assertEquals(AppPrefs.MAX_FAST_DRAIN_SUSTAINED_MINUTES * 60_000L, AppPrefs.fastDrainSustainedMs(context));
+		}
+
+		@Test
+		public void fastDrainReminderGap_defaultsToTheSliderDefaultAndClampsStoredValues() {
+			assertEquals(AppPrefs.DEFAULT_FAST_DRAIN_REMINDER_MINUTES * 60_000L, AppPrefs.fastDrainReminderGapMs(context));
+
+			PreferenceManager.getDefaultSharedPreferences(context).edit()
+			                 .putInt(context.getString(R.string._pref_key_fast_drain_reminder_minutes), 0)
+			                 .apply();
+			assertEquals(AppPrefs.MIN_FAST_DRAIN_REMINDER_MINUTES * 60_000L, AppPrefs.fastDrainReminderGapMs(context));
+
+			PreferenceManager.getDefaultSharedPreferences(context).edit()
+			                 .putInt(context.getString(R.string._pref_key_fast_drain_reminder_minutes), 30)
+			                 .apply();
+			assertEquals(30 * 60_000L, AppPrefs.fastDrainReminderGapMs(context));
+		}
+
 		@Test
 		public void vibrateEnabled_defaultsTrueAndReadsBack() {
 			// Defaults on (matches the switch's android:defaultValue in pref_behaviour.xml).
@@ -256,12 +290,58 @@ public class AppPrefsTest {
 		}
 
 		/**
-		 * Builds the charge-target slider from {@code pref_alerts.xml} exactly as the preference framework would, so its bounds are the ones a user's finger
-		 * actually meets.
+		 * The same guard for the two fast-drain timing sliders (#109), whose bounds moved into this facade so that "the slider range is also the enforced
+		 * range" is stated once. Until now that pairing was only a comment in {@code pref_alerts.xml}; these are the assertions that make it a rule.
+		 * <p>
+		 * The sustained window is the one where the {@code app:min} trap bites hardest: a slider bottoming out at 0 offers a zero-minute window, which is the
+		 * spike alarm the whole "sustained, not spikes" design exists to rule out.
+		 */
+		@Test
+		public void fastDrainSustainedSlider_boundsAreTheFacadeConstantsAtRuntime() throws Exception {
+			final SeekBarPreference slider = inflateSlider(R.string._pref_key_fast_drain_sustained_minutes);
+
+			assertNotNull("fast-drain sustained slider missing from pref_alerts.xml", slider);
+			assertEquals(AppPrefs.MIN_FAST_DRAIN_SUSTAINED_MINUTES, slider.getMin());
+			assertEquals(AppPrefs.MAX_FAST_DRAIN_SUSTAINED_MINUTES, slider.getMax());
+		}
+
+		@Test
+		public void fastDrainReminderSlider_boundsAreTheFacadeConstantsAtRuntime() throws Exception {
+			final SeekBarPreference slider = inflateSlider(R.string._pref_key_fast_drain_reminder_minutes);
+
+			assertNotNull("fast-drain reminder slider missing from pref_alerts.xml", slider);
+			assertEquals(AppPrefs.MIN_FAST_DRAIN_REMINDER_MINUTES, slider.getMin());
+			assertEquals(AppPrefs.MAX_FAST_DRAIN_REMINDER_MINUTES, slider.getMax());
+		}
+
+		@Test
+		public void xmlFastDrainDefaults_matchTheFacadeConstants() throws Exception {
+			final Integer xmlSustained = xmlDefaultOf(R.string._pref_key_fast_drain_sustained_minutes);
+			final Integer xmlReminder = xmlDefaultOf(R.string._pref_key_fast_drain_reminder_minutes);
+
+			assertNotNull("defaultValue attr missing from the fast-drain sustained slider", xmlSustained);
+			assertNotNull("defaultValue attr missing from the fast-drain reminder slider", xmlReminder);
+			assertEquals(AppPrefs.DEFAULT_FAST_DRAIN_SUSTAINED_MINUTES, (int) xmlSustained);
+			assertEquals(AppPrefs.DEFAULT_FAST_DRAIN_REMINDER_MINUTES, (int) xmlReminder);
+		}
+
+		/**
+		 * Both fast-drain timing sliders grey out with the fast-drain alert itself — the same "no settings that cannot do anything" rule the unplug reminder
+		 * follows, and the reason neither slider needs a separate enabled check when it is read.
+		 */
+		@Test
+		public void fastDrainTimingControls_greyOutWithTheAlertTheyTune() throws Exception {
+			assertEquals(R.string._pref_key_notify_fast_drain, xmlDependencyOf(R.string._pref_key_fast_drain_sustained_minutes));
+			assertEquals(R.string._pref_key_notify_fast_drain, xmlDependencyOf(R.string._pref_key_fast_drain_reminder_minutes));
+		}
+
+		/**
+		 * Builds a slider from {@code pref_alerts.xml}, by preference key, exactly as the preference framework would — so its bounds are the ones a user's
+		 * finger actually meets.
 		 *
 		 * @param keyRes the slider's preference-key string resource
-	 *
-	 * @return the inflated slider, or {@code null} when the screen no longer declares one
+		 *
+		 * @return the inflated slider, or {@code null} when the screen no longer declares one
 		 */
 		private SeekBarPreference inflateSlider(int keyRes) throws Exception {
 			final XmlResourceParser parser = context.getResources().getXml(R.xml.pref_alerts);
@@ -286,23 +366,7 @@ public class AppPrefsTest {
 		 * @return the declared default, or {@code null} when the slider or its attribute is gone
 		 */
 		private Integer xmlDefaultOf(int keyRes) throws Exception {
-			final XmlResourceParser parser = context.getResources().getXml(R.xml.pref_alerts);
-			Integer xmlDefault = null;
-			try {
-				for (int event = parser.getEventType(); event != XmlPullParser.END_DOCUMENT; event = parser.next()) {
-					if (event != XmlPullParser.START_TAG || !hasKey(parser, keyRes)) {
-						continue;
-					}
-					for (int i = 0; i < parser.getAttributeCount(); i++) {
-						if (parser.getAttributeNameResource(i) == android.R.attr.defaultValue) {
-							xmlDefault = parser.getAttributeIntValue(i, Integer.MIN_VALUE);
-						}
-					}
-				}
-			} finally {
-				parser.close();
-			}
-			return xmlDefault;
+			return attrOf(keyRes, android.R.attr.defaultValue, (parser, i) -> parser.getAttributeIntValue(i, Integer.MIN_VALUE), null);
 		}
 
 		/**
@@ -313,23 +377,41 @@ public class AppPrefsTest {
 		 * @return the dependency's key resource, or {@code 0} when the preference declares none
 		 */
 		private int xmlDependencyOf(int keyRes) throws Exception {
+			return attrOf(keyRes, android.R.attr.dependency, (parser, i) -> parser.getAttributeResourceValue(i, 0), 0);
+		}
+
+		/**
+		 * One attribute off the preference declared with {@code keyRes}, read straight from {@code pref_alerts.xml}. The typed readers above differ only in
+		 * which attribute they want and how it is decoded, so the walk itself lives here once.
+		 * <p>
+		 * The first tag carrying the key wins, matching {@link #inflateSlider}: a key declared twice is a bug in the screen, not a value to pick between.
+		 *
+		 * @param keyRes  the preference's own key string resource
+		 * @param attrRes the {@code android.R.attr} constant to look for
+		 * @param reader  decodes the attribute at the given index off the positioned parser
+		 * @param absent  what the preference or the attribute being undeclared reads as
+		 * @param <T>     the decoded attribute type
+		 *
+		 * @return the decoded attribute, or {@code absent}
+		 */
+		private <T> T attrOf(int keyRes, int attrRes, AttrReader<T> reader, T absent) throws Exception {
 			final XmlResourceParser parser = context.getResources().getXml(R.xml.pref_alerts);
-			int dependency = 0;
 			try {
 				for (int event = parser.getEventType(); event != XmlPullParser.END_DOCUMENT; event = parser.next()) {
 					if (event != XmlPullParser.START_TAG || !hasKey(parser, keyRes)) {
 						continue;
 					}
 					for (int i = 0; i < parser.getAttributeCount(); i++) {
-						if (parser.getAttributeNameResource(i) == android.R.attr.dependency) {
-							dependency = parser.getAttributeResourceValue(i, 0);
+						if (parser.getAttributeNameResource(i) == attrRes) {
+							return reader.read(parser, i);
 						}
 					}
+					return absent;
 				}
 			} finally {
 				parser.close();
 			}
-			return dependency;
+			return absent;
 		}
 
 		/**
@@ -344,6 +426,12 @@ public class AppPrefsTest {
 				}
 			}
 			return false;
+		}
+
+		/** Decodes one attribute off a parser already positioned on the tag that declares it. */
+		private interface AttrReader<T> {
+
+			T read(XmlResourceParser parser, int index);
 		}
 	}
 


### PR DESCRIPTION
Follow-up cleanups from the code review of #277, now that it has merged, plus the findings from the review of this branch. Rebased onto `master`.

**No behaviour change:** same keys, same defaults, same clamped ranges.

## Production

**The minutes clamp finished its move.** #277 moved `clampMinutesToMs` into `AppPrefs` so that "the slider range is also the enforced range" is stated once — but it left `FastDrainDetector` reading its own two windows by hand, so the fast-drain sliders were the last timing preferences outside the facade. Their six bounds move across beside the clamp that enforces them, and two accessors (`fastDrainSustainedMs`, `fastDrainReminderGapMs`) replace `minutesPref`, which had become a six-parameter wrapper around a single call. The constants pick up a `FAST_DRAIN` prefix on the way, since `DEFAULT_REMINDER_MINUTES` next to `DEFAULT_UNPLUG_REMINDER_MINUTES` would be a coin toss. `AppPrefs`' class javadoc records them in its "migrated so far" list, which had not learned about this commit.

**`MS_PER_MINUTE` is declared once, and stays private.** The move had left a copy in each of the two classes, neither aware of the other. `AppPrefs` owns it now — but `FastDrainDetector`'s only use of it is a millis→minutes conversion for display, which is not a preference concern, so it reads `TimeUnit.MINUTES.toMillis(1)` rather than the facade widening a constant to `public` for it.

The `pref_alerts.xml` comment tying both sliders to those bounds follows them to their new home — it still named `FastDrainDetector`.

## Tests

**The comment that tied the sliders to the constants is now an assertion.** That pairing had never been enforced for the fast-drain sliders — only written down. Both now get the three guards the charge-target and unplug-reminder sliders already had: inflated bounds (the `app:min` trap, where androidx reads `min` from its own namespace and an `android:min` leaves the slider silently bottoming out at 0 — on the sustained window that means a zero-minute window, the spike alarm the whole "sustained, not spikes" design exists to rule out), the declared `defaultValue`, and the dependency that greys both out with the alert they tune. The two new accessors also pick up the default/clamp pair every other accessor in `AppPrefsTest` has; they had landed in the facade with no test of their own.

**One walk over `pref_alerts.xml` instead of three.** `xmlDefaultOf` and `xmlDependencyOf` were the same parser walk written twice — same open, same `hasKey` scan, same attribute loop, same `finally` — differing only in which attribute they wanted and how it was decoded. Both now sit on one `attrOf` helper with a small `AttrReader` on top. It takes the **first** tag carrying the key, which matches `inflateSlider`; the two of them previously scanned on and kept the last, so the three helpers disagreed about a key declared twice.

**One way to build a `LevelAlertConfig`.** The decision suite had three: the `config(...)` helper, `remindingAt(...)` restating its body with one flag flipped, and a raw eight-argument literal for the one combination neither covered — six consecutive booleans and ints, which is the transposition hazard the helpers existed to remove, in the test whose whole point is that two of those booleans disagree. `config(...)` is now the single construction site, and that last combination is reached through a named `remindingWithTheFullAlertOff(...)` rather than a positional list of five arguments, four of them booleans.

**`inflateSlider`'s javadoc** no longer says "Builds the charge-target slider" — it serves five sliders now. Its `@param`/`@return` block had also lost an indent level.

## Testing

Ran locally on the CI's own gates: `test`, `lintDebug`, `assembleDebug`, `assembleRelease` — all green, no failures. The six new tests are confirmed present in the results XML rather than silently filtered out.

The drift guards were also negative-checked, since a guard that cannot fail is not a guard: flipping `MIN_FAST_DRAIN_SUSTAINED_MINUTES` from 1 to 2 fails `fastDrainSustainedSlider_boundsAreTheFacadeConstantsAtRuntime`, and the constant was restored afterwards.

No existing test assertion was changed. The only test-behaviour change is `attrOf`'s first-match rule, which the current XML cannot distinguish from last-match — all 17 `android:key` values in `pref_alerts.xml` are unique.
