### PR TITLE
ci: add a Dependabot config for Gradle and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+# Dependabot — automated dependency PRs for the two ecosystems this repo actually has.
+#
+# PR titles are gated: the `PR Title` workflow runs a Conventional Commits check on every PR, including
+# Dependabot's, so `commit-message.prefix` below is what keeps these PRs mergeable. `build` and `ci` are
+# both non-bumping types, so a dependency PR never makes release-please cut a version.
+#
+# `google()` is declared in settings.gradle's dependencyResolutionManagement block. Dependabot only
+# learned to read that block in Feb 2026 (dependabot-core#3286) — if AndroidX bumps ever stop showing
+# up, that regression is the first thing to check, and the fix is a `registries:` entry pointing at
+# https://dl.google.com/dl/android/maven2/.
+version: 2
+
+updates:
+  # app/build.gradle dependencies, the AGP plugin version in the root build.gradle, and the Gradle wrapper.
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Asia/Amman
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: build
+      include: scope
+    # Let a release settle before opening a PR for it — AndroidX and AGP both ship same-week respins.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+    groups:
+      # Minor/patch bumps of the UI stack move together and are reviewed as one change. Major bumps are
+      # deliberately left out of every group so each one arrives as its own PR with its own CI run.
+      androidx:
+        patterns:
+          - androidx.*
+          - com.google.android.material:material
+        exclude-patterns:
+          - androidx.test*
+        update-types:
+          - minor
+          - patch
+      test-libraries:
+        patterns:
+          - androidx.test*
+          - junit:junit
+          - org.mockito:*
+          - org.robolectric:*
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Held at 1.18.0 until the AGP 9 upgrade in #81 — core 1.19.0 requires AGP 9.1+, so a bump PR
+      # would just fail CI every week. Remove this entry when #81 lands.
+      - dependency-name: androidx.core:core
+        versions:
+          - ">= 1.19.0"
+
+  # The actions used by android-ci.yml, pr-title-lint.yml and release-please.yml. All are pinned to a
+  # major tag, so this only fires on a new major — monthly is often enough.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      timezone: Asia/Amman
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,10 @@ updates:
   - package-ecosystem: gradle
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: "weekly"
+      day: "saturday"
       time: "06:00"
-      timezone: Asia/Amman
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     commit-message:
       prefix: build
@@ -48,20 +48,28 @@ updates:
         update-types:
           - minor
           - patch
+    # Both holds below exist because this project is deliberately still on the AGP 8 line (#81). Without
+    # them Dependabot would re-open the same red PR every week. Remove both when #81 lands.
     ignore:
-      # Held at 1.18.0 until the AGP 9 upgrade in #81 — core 1.19.0 requires AGP 9.1+, so a bump PR
-      # would just fail CI every week. Remove this entry when #81 lands.
+      # core 1.19.0 requires AGP 9.1+ and compileSdk 37 (see the closed attempt in #85).
       - dependency-name: androidx.core:core
         versions:
           - ">= 1.19.0"
+      # Gradle 9.6.0 removed the internal InternalProblems API that AGP 8 calls, so AGP 8.x refuses to
+      # load on 9.6+ ("relies on an API that was removed in Gradle 9.6.0"). 9.5.1 is the ceiling here.
+      - dependency-name: gradle-wrapper
+        versions:
+          - ">= 9.6.0"
 
   # The actions used by android-ci.yml, pr-title-lint.yml and release-please.yml. All are pinned to a
-  # major tag, so this only fires on a new major — monthly is often enough.
+  # major tag, so this only fires on a new major.
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
-      timezone: Asia/Amman
+      interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 5
     commit-message:
       prefix: ci


### PR DESCRIPTION
Closes #280.

Adds `.github/dependabot.yml` covering the two ecosystems this repo actually has: `gradle` (the `app/build.gradle` dependencies, the AGP plugin version in the root `build.gradle`, and the Gradle wrapper) and `github-actions` (the six actions across the three workflows). Both run weekly, Saturday 06:00 UTC.

### The parts that aren't boilerplate

- **`commit-message.prefix`** — `build` for Gradle, `ci` for Actions. Without it Dependabot titles its PRs "Bump x from a to b", which the `PR Title` check rejects, so every dependency PR would sit blocked. Both types are non-bumping, so a dependency PR never makes release-please cut a version.
- **Groups are minor/patch only.** AndroidX + Material move together in one PR, the test libraries in another. Major bumps are deliberately in no group, so each one lands as its own PR with its own CI run — which is what you want for something like AGP 9.
- **Two `ignore` holds, both because we're deliberately still on AGP 8** (#81). `androidx.core:core >= 1.19.0` needs AGP 9.1+ and compileSdk 37 — that is what the closed #85 was. `gradle-wrapper >= 9.6.0` is the one from #87: Gradle 9.6.0 removed the internal `InternalProblems` API that AGP 8 calls, so AGP 8.x refuses to load on it, and 9.5.1 is the ceiling. Without these two entries Dependabot re-opens the same red PR every Saturday. Both comments say to delete them when #81 lands.
- **`cooldown`** (5 days, 14 for majors) keeps day-of-release respins out of the queue.
- The header comment records that `google()` lives in `settings.gradle`'s `dependencyResolutionManagement` block, which Dependabot only learned to read in Feb 2026 — if AndroidX bumps ever stop appearing, that's the first thing to check, and the workaround is a `registries:` entry for `https://dl.google.com/dl/android/maven2/`.

### Verification

No code change, so no build impact. The YAML was parsed and its shape checked against the documented option schema locally; GitHub validates it for real once this is on `master` (Insights → Dependency graph → Dependabot). The `gradle-wrapper` dependency name is the one Dependabot itself uses (`file_parser/distributions_finder.rb`, and real PR titles read `build(deps): bump gradle-wrapper from 9.6.1 to 9.7.0`).

### What it will open first

`androidx.appcompat` 1.7.1 → 1.8.0 is the only app dependency behind and the only PR expected on the first run. AGP 8.13.2 → 9.x will also come through as its own major PR, which overlaps #81 — expect to close it in favour of the tracked upgrade, or use it as the starting diff.