### PR TITLE
build: bump androidx.appcompat to 1.8.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,8 +86,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'androidx.core:core:1.18.0'                 // held at 1.18.0; core 1.19.0 requires AGP 9.1+ (see #81)
+    implementation 'androidx.appcompat:appcompat:1.8.0'
+    implementation 'androidx.core:core:1.18.0'                 // held at 1.18.0; core 1.19.0 requires AGP 9.1+ and compileSdk 37 (see #81)
     implementation 'com.google.android.material:material:1.14.0'
 
     implementation 'androidx.preference:preference:1.2.1'     // AndroidX settings UI


### PR DESCRIPTION
Closes #284.

`androidx.appcompat:appcompat` 1.7.1 → **1.8.0** (released 2026-08-12). This is the only app dependency that was behind; everything else in `app/build.gradle` is already on its latest stable, and the build-tooling bumps (AGP 9, Gradle 9.6+) stay blocked by #81.

### It does not drag #81 forward

Checked against the artifact, not the release notes — `appcompat-1.8.0.aar`'s `META-INF/…/aar-metadata.properties` reads:

```
minCompileSdk=34
minAndroidGradlePluginVersion=8.1.1
```

We're on compileSdk 36 / AGP 8.13.2. Its `androidx.core` constraint is still 1.13.0, so it doesn't pull `core` past the 1.18.0 hold either. Library `minSdk` moved 21 → 23 (ours is 26) and it wants Activity 1.8.0 (we're on 1.13.0).

### What's actually in it, for the device retest

- **Toolbar height now includes title/subtitle vertical margins** — the one change here that can visibly move pixels, so the main screen's toolbar is worth a look.
- `AlertDialog` window title is set for accessibility, so TalkBack announces dialogs properly.
- `AppCompatActivity` dispatches configuration changes to the view tree.
- `fontVariationSettings` applied correctly from `textAppearance`.

### Verification

| Check | Result |
|---|---|
| `./gradlew test` | ✅ |
| `./gradlew :app:lintDebug` | ✅ zero issues |
| `./gradlew assembleDebug assembleRelease` | ✅ (R8 minify) |
| Release APK size | 2,995,166 B vs 2,995,222 B on master — **56 bytes smaller** |

The size line matters because 1.8.0 transitively bumps `kotlin-stdlib` 1.8.22 → 2.1.20 and adds `org.jspecify:jspecify`. Neither survives R8 in a Java-only module, which the measurement confirms.

**On-device retest pending** — mainly the toolbar.

### Also in this diff

One comment, one line below the bump: the `core` hold said "requires AGP 9.1+", but per the closed #85 it also requires compileSdk 37. Corrected so nobody retries it thinking AGP alone unblocks it.