### PR TITLE
fix: play the picked notification sound on the alert channels

### DIFF
--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/AlertSounds.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/AlertSounds.java
@@ -9,11 +9,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 /**
  * The alert sound/vibration playback path (issue #166): plays the user's alarm sound (and optionally
  * vibrates) when the phone is silenced but the user opted to override silent/DND mode. In normal ringer
- * mode the high-importance notification channel plays its own sound, so this stays out of the way.
+ * mode the high-importance notification channel plays its own sound — the same pick, resolved through
+ * {@code NotificationChannels.alertSoundUri} — so this stays out of the way.
  * <p>
  * Split out of {@code NotificationService} so it owns its own thread pool. The single-thread executor
  * runs for the app's lifetime and is reclaimed on process death (there is no {@code Application} to hook
@@ -39,12 +41,12 @@ final class AlertSounds {
 	 * Callers must first check that alerts are allowed right now (quiet hours / critical override).
 	 *
 	 * @param context      The application context
-	 * @param soundUriStr  The alarm sound URI string
+	 * @param soundUriStr  The alarm sound URI string, empty when the user picked "Silent"
 	 * @param ignoreSilent Whether the user opted to override silent/DND mode
 	 * @param vibrate      Whether the user enabled vibration
 	 */
 	static void playAlarm(Context context, String soundUriStr, boolean ignoreSilent, boolean vibrate) {
-		final Uri soundUri = Uri.parse(soundUriStr);
+		final Uri soundUri = soundUriOrSilent(soundUriStr);
 		final AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
 		if (isNull(audioManager)) {
 			return;
@@ -54,12 +56,32 @@ final class AlertSounds {
 
 		if (ignoreSilent && isNotNormalRingerMode) {
 			soundExecutor.execute(() -> {
-				SystemService.playSound(context, soundUri);
+				// A "Silent" pick still buzzes if the user asked for vibration, which is how the channel behaves too:
+				// setSound(null, …) alongside enableVibration(true). Silent is a choice about the sound, not about the alert.
+				if (nonNull(soundUri)) {
+					SystemService.playSound(context, soundUri);
+				}
 				if (vibrate) {
 					SystemService.vibratePhone(context);
 				}
 			});
 		}
+	}
+
+	/**
+	 * What a stored sound preference means: the picked sound, or null when the user chose "Silent".
+	 * <p>
+	 * The ringtone picker persists Silent as an empty string, so the empty string is a first-class choice rather than a
+	 * missing value (#286). Both consumers have to read it the same way — the channel expresses it as
+	 * {@code setSound(null, …)} and this class as "nothing to play". Parsing it instead yields an empty {@link Uri} that
+	 * resolves to nothing at post time, which honours the choice by accident rather than on purpose.
+	 *
+	 * @param soundUriStr the persisted sound URI, possibly empty or null
+	 *
+	 * @return the sound to play, or null for no sound
+	 */
+	static Uri soundUriOrSilent(String soundUriStr) {
+		return isNull(soundUriStr) || soundUriStr.isEmpty() ? null : Uri.parse(soundUriStr);
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationChannels.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationChannels.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.media.AudioAttributes;
-import android.net.Uri;
 
 import androidx.preference.PreferenceManager;
 
@@ -14,27 +13,29 @@ import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.util.AppPrefs;
 
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 
 /**
  * The notification-channel registry (issue #166): creates, updates, refreshes and resolves the app's
  * notification channels. Split out of {@code NotificationService} so channel bookkeeping lives in one
  * place.
  * <p>
- * The six alert channels below are <em>base</em> IDs: the actual channel ID carries a version suffix
- * (see {@link #versionedChannelId}) because Android un-deletes a channel recreated under the same ID,
- * restoring its old settings — which made the Vibrate toggle a no-op (issue #153).
- * {@link #refreshAlertChannels} bumps the version so a changed setting really applies.
+ * The six alert channels are listed once, in {@link #alertChannels()}. They used to be spelled out three times over —
+ * created, deleted on refresh, and mapped to a sound — so adding one meant remembering all three, and forgetting the
+ * deletion left an orphan in the user's system settings.
  * <p>
- * From Android 8 the <em>channel</em> owns the alert sound, so the user's per-severity sound picks are applied here
- * as well ({@link #alertSoundUri}). Until they were, every alert channel was created with the framework default and
- * the three pickers on Settings › Alerts saved a choice that changed nothing audible (issue #286). A sound pick is
- * therefore as much a channel setting as the Vibrate toggle, and re-versions the channels the same way — see
- * {@link #affectsAlertChannels}.
+ * Each entry's ID is a <em>base</em> ID: the actual channel ID carries a version suffix (see {@link #versionedChannelId})
+ * because Android un-deletes a channel recreated under the same ID, restoring its old settings — which made the Vibrate
+ * toggle a no-op (issue #153). {@link #refreshAlertChannels} bumps the version so a changed setting really applies, and
+ * {@link #ALERT_CHANNEL_DEFINITION} does the same for installs that never change a setting at all.
+ * <p>
+ * From Android 8 the <em>channel</em> owns the alert sound, so the user's per-severity sound picks are applied here as
+ * well. Until they were, every alert channel was created with the framework default and the three pickers on
+ * Settings › Alerts saved a choice that changed nothing audible (issue #286). A sound pick is therefore as much a
+ * channel setting as the Vibrate toggle — see {@link #affectsAlertChannels}.
  */
 final class NotificationChannels {
 
-	// Alert (audible, high-importance) channels — base IDs, see class javadoc.
+	// Alert (audible, high-importance) channels — base IDs, see class javadoc and alertChannels().
 	static final String CHANNEL_ID_CRITICAL = "battery_critical";
 	static final String CHANNEL_ID_WARNING = "battery_warning";
 	static final String CHANNEL_ID_FULL = "battery_full";
@@ -48,9 +49,24 @@ final class NotificationChannels {
 	static final String CHANNEL_ID_ALERTS_SILENT = "battery_alerts_quiet";
 
 	// Current version of the alert channels' settings, stored in the default SharedPreferences.
-	// Version 1 means the original unsuffixed channel IDs, so existing installs keep their channels
-	// (and any per-channel tweaks) until the user first changes a setting the channels are made of.
+	// Version 1 means the original unsuffixed channel IDs.
 	private static final String PREF_ALERT_CHANNEL_VERSION = "alert_channel_version";
+	// Which generation of the app's channel definitions this install's channels were created from. Absent (0) means they
+	// predate issue #286. Deliberately separate from the version above, which counts the user's own setting changes and
+	// so already reads 2 or more on any install that ever toggled Vibrate.
+	private static final String PREF_ALERT_CHANNEL_DEFINITION = "alert_channel_definition";
+
+	/**
+	 * The generation of channel definitions this build creates. Raising it re-versions every install's alert channels
+	 * once, on the next {@link #ensureChannels} — the only way a change to what the channels are <em>made of</em> reaches
+	 * users who never change a setting themselves.
+	 * <p>
+	 * Generation 1 is issue #286. Everything before it created channels without ever calling {@code setSound}, so an
+	 * install that had already picked a sound would have gone on playing the device default forever: the pick is passed
+	 * on every alert and the system ignores it, and nothing else would ever re-version the channels. That is the exact
+	 * population #286 was filed about, so the fix is inert without this.
+	 */
+	private static final int ALERT_CHANNEL_DEFINITION = 1;
 
 	private NotificationChannels() {
 		// Utility class - prevent instantiation
@@ -69,33 +85,14 @@ final class NotificationChannels {
 		}
 
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-		final boolean vibrate = AppPrefs.vibrateEnabled(context);
-		final int version = alertChannelVersion(prefs);
+		migrateAlertChannels(manager, prefs);
 
-		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_CRITICAL, version),
-				context.getString(R.string.notification_critical_channel_name),
-				context.getString(R.string.notification_critical_channel_description), Color.RED, vibrate,
-				alertSoundUri(context, CHANNEL_ID_CRITICAL));
-		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_WARNING, version),
-				context.getString(R.string.notification_warning_channel_name),
-				context.getString(R.string.notification_warning_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate,
-				alertSoundUri(context, CHANNEL_ID_WARNING));
-		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_FULL, version),
-				context.getString(R.string.notification_full_channel_name),
-				context.getString(R.string.notification_full_channel_description), Color.GREEN, vibrate,
-				alertSoundUri(context, CHANNEL_ID_FULL));
-		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_TEMPERATURE, version),
-				context.getString(R.string.notification_temperature_channel_name),
-				context.getString(R.string.notification_temperature_channel_description), Color.RED, vibrate,
-				alertSoundUri(context, CHANNEL_ID_TEMPERATURE));
-		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_FAST_DRAIN, version),
-				context.getString(R.string.notification_fast_drain_channel_name),
-				context.getString(R.string.notification_fast_drain_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate,
-				alertSoundUri(context, CHANNEL_ID_FAST_DRAIN));
-		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_SLOW_CHARGE, version),
-				context.getString(R.string.notification_slow_charge_channel_name),
-				context.getString(R.string.notification_slow_charge_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate,
-				alertSoundUri(context, CHANNEL_ID_SLOW_CHARGE));
+		final int version = alertChannelVersion(prefs);
+		final boolean vibrate = AppPrefs.vibrateEnabled(context);
+		for (AlertChannel definition : alertChannels()) {
+			manager.createNotificationChannel(definition.toNotificationChannel(context, prefs, version, vibrate));
+		}
+
 		createOrUpdateSilentChannel(manager, CHANNEL_ID_STATUS,
 				context.getString(R.string.notification_status_channel_name),
 				context.getString(R.string.notification_status_channel_description));
@@ -122,26 +119,19 @@ final class NotificationChannels {
 		}
 
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-		final int oldVersion = alertChannelVersion(prefs);
-		manager.deleteNotificationChannel(versionedChannelId(CHANNEL_ID_CRITICAL, oldVersion));
-		manager.deleteNotificationChannel(versionedChannelId(CHANNEL_ID_WARNING, oldVersion));
-		manager.deleteNotificationChannel(versionedChannelId(CHANNEL_ID_FULL, oldVersion));
-		manager.deleteNotificationChannel(versionedChannelId(CHANNEL_ID_TEMPERATURE, oldVersion));
-		manager.deleteNotificationChannel(versionedChannelId(CHANNEL_ID_FAST_DRAIN, oldVersion));
-		manager.deleteNotificationChannel(versionedChannelId(CHANNEL_ID_SLOW_CHARGE, oldVersion));
-
-		prefs.edit().putInt(PREF_ALERT_CHANNEL_VERSION, oldVersion + 1).apply();
+		reVersionAlertChannels(manager, prefs);
 		ensureChannels(context);
 	}
 
 	/**
 	 * Whether a changed preference is one the alert channels are built from, so the channels have to be re-created
-	 * for it to take effect: the "Vibrate" toggle (issue #153) and the three per-severity sound picks (issue #286).
+	 * for it to take effect: the "Vibrate" toggle (issue #153) and the per-severity sound picks (issue #286).
 	 * <p>
 	 * Android freezes a channel's sound and vibration at creation, so a setting that never reaches
 	 * {@link #refreshAlertChannels} is simply ignored — which is what made both of these look like they worked and
-	 * not. Kept here, next to the channels themselves, so the settings screen doesn't accumulate its own list of
-	 * which preferences happen to be channel settings.
+	 * not. The sound keys come from {@link #alertChannels()} rather than being listed again here: a picker added
+	 * without a matching entry in the membership test would save a choice that never re-versions anything, which is
+	 * #286 all over again.
 	 *
 	 * @param context The application context
 	 * @param prefKey the preference key that changed, or null
@@ -149,40 +139,41 @@ final class NotificationChannels {
 	 * @return true when the alert channels have to be re-created under a new version
 	 */
 	static boolean affectsAlertChannels(Context context, String prefKey) {
-		return nonNull(prefKey) && (prefKey.equals(context.getString(R.string._pref_key_notifications_vibrate))
-				|| prefKey.equals(context.getString(R.string._pref_key_notifications_alert_sound_ringtone))
-				|| prefKey.equals(context.getString(R.string._pref_key_notifications_warning_sound_ringtone))
-				|| prefKey.equals(context.getString(R.string._pref_key_notifications_full_sound_ringtone)));
+		if (isNull(prefKey)) {
+			return false;
+		}
+		if (prefKey.equals(context.getString(R.string._pref_key_notifications_vibrate))) {
+			return true;
+		}
+		for (AlertChannel definition : alertChannels()) {
+			if (prefKey.equals(context.getString(definition.soundKeyRes()))) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
 	 * The sound an alert channel plays: the URI the user picked for the severity bucket that channel belongs to.
 	 * <p>
 	 * Three pickers cover six channels, so the two rate alerts and the overheat alert — which have no picker of their
-	 * own — need a bucket that is chosen rather than the critical pref they reached by accident (issue #286). The
-	 * mapping is the one #223 designs its bundled sounds around: the critical level and overheating are the same
-	 * "act now" severity, while low battery, fast drain and slow charge are all "something is off, look at it".
+	 * own — take a bucket that is chosen rather than the critical pref they reached by accident (issue #286). The
+	 * buckets are the ones #223 designs its bundled sounds around and are recorded per channel in
+	 * {@link #alertChannels()}: the critical level and overheating are the same "act now" severity, while low battery,
+	 * fast drain and slow charge are all "something is off, look at it".
 	 * <p>
-	 * The same resolution feeds the channel and {@link AlertSounds#playAlarm}, so the sound a user hears can't depend
-	 * on which of the two paths delivered the alert.
-	 * <p>
-	 * An empty result is a real answer, not a missing one: it is what the picker's "Silent" option persists.
+	 * The same resolution feeds the channel and {@link AlertSounds#playAlarm}, so the sound a user hears can't depend on
+	 * which of the two paths delivered the alert. An empty result is a real answer, not a missing one: it is what the
+	 * picker's "Silent" option persists, and {@link AlertSounds#soundUriOrSilent} is how both paths read it.
 	 *
 	 * @param context       The application context
+	 * @param prefs         the default SharedPreferences, already held by every caller
 	 * @param baseChannelId the unversioned channel ID whose sound is wanted
 	 *
 	 * @return the picked sound URI, empty when the user chose Silent, or the device's default notification sound
 	 */
-	static String alertSoundUri(Context context, String baseChannelId) {
-		final int soundKeyRes = switch (baseChannelId) {
-			case CHANNEL_ID_FULL -> R.string._pref_key_notifications_full_sound_ringtone;
-			case CHANNEL_ID_WARNING, CHANNEL_ID_FAST_DRAIN, CHANNEL_ID_SLOW_CHARGE -> R.string._pref_key_notifications_warning_sound_ringtone;
-			// The critical bucket takes the overheat alert and, deliberately, anything added later without a bucket of
-			// its own: an alert on a neighbouring severity's sound is a far smaller failure than one that loses its sound.
-			default -> R.string._pref_key_notifications_alert_sound_ringtone;
-		};
-		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-		return prefs.getString(context.getString(soundKeyRes), context.getString(R.string._default_notification_sound_uri));
+	static String alertSoundUri(Context context, SharedPreferences prefs, String baseChannelId) {
+		return prefs.getString(context.getString(soundKeyFor(baseChannelId)), context.getString(R.string._default_notification_sound_uri));
 	}
 
 	/**
@@ -218,11 +209,122 @@ final class NotificationChannels {
 	}
 
 	/**
+	 * The six alert channels, each with everything about it that doesn't change between versions: its base ID, its
+	 * translated name and description, its LED colour, and the sound preference whose severity bucket it belongs to.
+	 * <p>
+	 * Built per call rather than held in a static field so nothing in {@code android.graphics} is touched at class-init
+	 * time, which would throw {@code Stub!} in the plain-JUnit tests that use this class's pure channel-ID helpers.
+	 *
+	 * @return the alert-channel definitions, in creation order
+	 */
+	private static AlertChannel[] alertChannels() {
+		// The amber both rate alerts and the low-battery alert light up in.
+		final int amber = Color.rgb(0xff, 0x66, 0x00);
+		return new AlertChannel[]{
+				new AlertChannel(CHANNEL_ID_CRITICAL,
+						R.string.notification_critical_channel_name,
+						R.string.notification_critical_channel_description,
+						Color.RED,
+						R.string._pref_key_notifications_alert_sound_ringtone),
+				new AlertChannel(CHANNEL_ID_WARNING,
+						R.string.notification_warning_channel_name,
+						R.string.notification_warning_channel_description,
+						amber,
+						R.string._pref_key_notifications_warning_sound_ringtone),
+				new AlertChannel(CHANNEL_ID_FULL,
+						R.string.notification_full_channel_name,
+						R.string.notification_full_channel_description,
+						Color.GREEN,
+						R.string._pref_key_notifications_full_sound_ringtone),
+				new AlertChannel(CHANNEL_ID_TEMPERATURE,
+						R.string.notification_temperature_channel_name,
+						R.string.notification_temperature_channel_description,
+						Color.RED,
+						R.string._pref_key_notifications_alert_sound_ringtone),
+				new AlertChannel(CHANNEL_ID_FAST_DRAIN,
+						R.string.notification_fast_drain_channel_name,
+						R.string.notification_fast_drain_channel_description,
+						amber,
+						R.string._pref_key_notifications_warning_sound_ringtone),
+				new AlertChannel(CHANNEL_ID_SLOW_CHARGE,
+						R.string.notification_slow_charge_channel_name,
+						R.string.notification_slow_charge_channel_description,
+						amber,
+						R.string._pref_key_notifications_warning_sound_ringtone),
+		};
+	}
+
+	/**
+	 * The sound preference a base channel ID takes its pick from.
+	 *
+	 * @param baseChannelId the unversioned channel ID
+	 *
+	 * @return that channel's sound preference key resource
+	 */
+	private static int soundKeyFor(String baseChannelId) {
+		for (AlertChannel definition : alertChannels()) {
+			if (definition.baseId().equals(baseChannelId)) {
+				return definition.soundKeyRes();
+			}
+		}
+		// Deliberately the critical bucket rather than nothing, for a channel added without an entry above: an alert on a
+		// neighbouring severity's sound is a far smaller failure than one that loses its sound.
+		return R.string._pref_key_notifications_alert_sound_ringtone;
+	}
+
+	/**
+	 * Re-version the alert channels once when this build's {@link #ALERT_CHANNEL_DEFINITION} is newer than the one the
+	 * install's channels were created from.
+	 * <p>
+	 * Runs before the channels are created, so the same {@link #ensureChannels} call that migrates also creates the
+	 * replacements. Keyed on the definition generation rather than on the settings version, because the version counts
+	 * the user's own changes: an install that toggled Vibrate once is already on version 2, and a migration that tested
+	 * "version below 2" would skip precisely the long-standing installs it exists for.
+	 * <p>
+	 * A fresh install has no channels to replace and still passes through here, so it starts one version up. That costs
+	 * nothing — the version only names the channel IDs — and it beats testing "is this install new?", which the version
+	 * preference cannot answer: an install that never changed a setting has never written it either.
+	 *
+	 * @param manager The NotificationManager
+	 * @param prefs   the default SharedPreferences
+	 */
+	private static void migrateAlertChannels(NotificationManager manager, SharedPreferences prefs) {
+		if (prefs.getInt(PREF_ALERT_CHANNEL_DEFINITION, 0) >= ALERT_CHANNEL_DEFINITION) {
+			return;
+		}
+		reVersionAlertChannels(manager, prefs);
+	}
+
+	/**
+	 * Delete the alert channels at the version the install is on and move it to the next one, so the channels
+	 * {@link #ensureChannels} creates next are ones the system sees as brand new rather than un-deleting with their old
+	 * settings (issue #153). Deleting first keeps the user's system settings free of orphans.
+	 * <p>
+	 * The single home of the re-version, shared by the user-driven {@link #refreshAlertChannels} and the one-time
+	 * definition migration, so the two can't disagree about what re-versioning means. Recording the definition
+	 * generation here is what stops the migration re-firing on every alert.
+	 *
+	 * @param manager The NotificationManager
+	 * @param prefs   the default SharedPreferences
+	 */
+	private static void reVersionAlertChannels(NotificationManager manager, SharedPreferences prefs) {
+		final int oldVersion = alertChannelVersion(prefs);
+		for (AlertChannel definition : alertChannels()) {
+			manager.deleteNotificationChannel(versionedChannelId(definition.baseId(), oldVersion));
+		}
+		prefs.edit()
+		     .putInt(PREF_ALERT_CHANNEL_VERSION, oldVersion + 1)
+		     .putInt(PREF_ALERT_CHANNEL_DEFINITION, ALERT_CHANNEL_DEFINITION)
+		     .apply();
+	}
+
+	/**
 	 * The current alert-channel settings version, bumped by {@link #refreshAlertChannels(Context)}
-	 * whenever one of the {@link #affectsAlertChannels} preferences changes.
+	 * whenever one of the {@link #affectsAlertChannels} preferences changes, and once more when this build's
+	 * {@link #ALERT_CHANNEL_DEFINITION} is newer than the one the install's channels were created from.
 	 *
 	 * @param prefs the default SharedPreferences
-	 * @return the current version, 1 for installs that never changed one of those preferences
+	 * @return the current version, 1 for installs still on the original unsuffixed channels
 	 */
 	private static int alertChannelVersion(SharedPreferences prefs) {
 		return prefs.getInt(PREF_ALERT_CHANNEL_VERSION, 1);
@@ -254,79 +356,66 @@ final class NotificationChannels {
 	}
 
 	/**
-	 * Create an alert channel, or update its name/description if it already exists.
-	 * <p>
-	 * Re-calling {@code createNotificationChannel} with an existing ID updates only the name,
-	 * description and group — Android ignores importance, vibration, lights and sound so the user's
-	 * (and the versioned #153) settings are preserved. This is how translated channel names reach
-	 * <em>upgraded</em> installs, not just fresh ones (#165): the channel already exists, so we still
-	 * re-apply the current locale's name and description.
-	 *
-	 * @param manager     The NotificationManager
-	 * @param channelId   The channel ID
-	 * @param name        The channel name
-	 * @param description The channel description
-	 * @param ledColor    The LED color for notifications
-	 * @param vibrate     Whether the channel should vibrate (from the user's Vibrate preference)
-	 * @param soundUri    The sound to play, from the user's pick for this channel's severity bucket (#286)
-	 */
-	private static void createOrUpdateAlertChannel(NotificationManager manager,
-	                                               String channelId,
-	                                               String name,
-	                                               String description,
-	                                               int ledColor,
-	                                               boolean vibrate,
-	                                               String soundUri) {
-		final NotificationChannel channel = new NotificationChannel(channelId, name, NotificationManager.IMPORTANCE_HIGH);
-		channel.setDescription(description);
-		channel.enableLights(true);
-		channel.setLightColor(ledColor);
-		channel.enableVibration(vibrate);
-		if (vibrate) {
-			channel.setVibrationPattern(SystemService.VIBRATION_PATTERN);
-		}
-		// Set at creation and frozen there by the system, which is why a changed pick comes back through
-		// refreshAlertChannels rather than being re-applied on the next ensureChannels (#286).
-		channel.setSound(soundUriOrSilent(soundUri), alertAudioAttributes());
-		manager.createNotificationChannel(channel);
-	}
-
-	/**
-	 * The picked sound as a {@link Uri}, or null for the picker's "Silent" choice.
-	 * <p>
-	 * {@code RingtonePreference} persists Silent as an empty string, and {@code setSound(null, …)} is how a channel
-	 * says "no sound" — so the empty string has to be translated into that null rather than parsed into an empty
-	 * {@code Uri} that resolves to nothing at post time.
-	 *
-	 * @param soundUri the persisted sound URI, possibly empty
-	 *
-	 * @return the sound to set on the channel, or null for no sound
-	 */
-	private static Uri soundUriOrSilent(String soundUri) {
-		return isNull(soundUri) || soundUri.isEmpty() ? null : Uri.parse(soundUri);
-	}
-
-	/**
 	 * The attributes an alert channel's sound plays under: a notification, so it follows the notification stream's
 	 * volume and the system's Do Not Disturb rules.
 	 * <p>
-	 * Deliberately not the {@code USAGE_ALARM} that {@link AlertSounds} plays under. That path exists to be heard when
-	 * notifications are silenced, and this one is suppressed in exactly those conditions, so the channel sound and the
-	 * override-silent sound can never double up (issue #286).
-	 * <p>
-	 * Built per call rather than held in a static field: a static initializer touching {@code android.media} would
-	 * throw {@code Stub!} in the plain-JUnit tests that use this class's pure channel-ID helpers.
+	 * Deliberately not the {@code USAGE_ALARM} that {@link AlertSounds} plays under. That path only runs when the ringer
+	 * is silenced or DND is on, and those are exactly the conditions in which a {@code USAGE_NOTIFICATION} sound is
+	 * suppressed — so in normal ringer mode, silent mode and DND alike, one of the two plays and never both (issue #286,
+	 * requirement 4). The one case the split does not cover is a user who has explicitly allowed this app's channel
+	 * through Do Not Disturb in system settings: the channel then sounds under a priority filter that {@code AlertSounds}
+	 * still reads as DND, and both play. The app cannot take that override back — it is the user's setting, and
+	 * {@code setBypassDnd(false)} here would only restate the default the channel already has.
 	 *
 	 * @return the audio attributes for an alert channel's sound
 	 */
 	private static AudioAttributes alertAudioAttributes() {
-		return new AudioAttributes.Builder()
-				.setUsage(AudioAttributes.USAGE_NOTIFICATION)
-				.setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-				.build();
+		return new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_NOTIFICATION).setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION).build();
 	}
 
 	private static NotificationManager getManager(Context context) {
 		return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+	}
+
+	/**
+	 * One alert channel's definition — the part of it that is the same at every settings version.
+	 *
+	 * @param baseId         the unversioned channel ID
+	 * @param nameRes        the translated channel name
+	 * @param descriptionRes the translated channel description
+	 * @param ledColor       the LED colour for this channel's notifications
+	 * @param soundKeyRes    the preference key holding the sound pick for this channel's severity bucket (#286)
+	 */
+	private record AlertChannel(String baseId, int nameRes, int descriptionRes, int ledColor, int soundKeyRes) {
+
+		/**
+		 * This channel as the system object to create, at a given settings version.
+		 * <p>
+		 * Re-calling {@code createNotificationChannel} with an existing ID updates only the name, description and group —
+		 * Android ignores importance, vibration, lights and sound, so the user's (and the versioned #153) settings are
+		 * preserved. That is how translated channel names reach <em>upgraded</em> installs, not just fresh ones (#165),
+		 * and equally why a changed sound has to come back through {@link NotificationChannels#refreshAlertChannels}
+		 * instead of being re-applied here on the next alert.
+		 *
+		 * @param context The application context
+		 * @param prefs   the default SharedPreferences
+		 * @param version the alert-channel settings version to create at
+		 * @param vibrate whether the channel should vibrate (from the user's Vibrate preference)
+		 *
+		 * @return the channel to hand to {@code NotificationManager.createNotificationChannel}
+		 */
+		NotificationChannel toNotificationChannel(Context context, SharedPreferences prefs, int version, boolean vibrate) {
+			final NotificationChannel channel = new NotificationChannel(versionedChannelId(baseId, version),
+					context.getString(nameRes), NotificationManager.IMPORTANCE_HIGH);
+			channel.setDescription(context.getString(descriptionRes));
+			channel.enableLights(true);
+			channel.setLightColor(ledColor);
+			channel.enableVibration(vibrate);
+			if (vibrate) {
+				channel.setVibrationPattern(SystemService.VIBRATION_PATTERN);
+			}
+			channel.setSound(AlertSounds.soundUriOrSilent(alertSoundUri(context, prefs, baseId)), alertAudioAttributes());
+			return channel;
+		}
 	}
 }

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationChannels.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationChannels.java
@@ -5,6 +5,8 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.media.AudioAttributes;
+import android.net.Uri;
 
 import androidx.preference.PreferenceManager;
 
@@ -12,6 +14,7 @@ import com.almothafar.simplebatterynotifier.R;
 import com.almothafar.simplebatterynotifier.util.AppPrefs;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 /**
  * The notification-channel registry (issue #166): creates, updates, refreshes and resolves the app's
@@ -22,6 +25,12 @@ import static java.util.Objects.isNull;
  * (see {@link #versionedChannelId}) because Android un-deletes a channel recreated under the same ID,
  * restoring its old settings — which made the Vibrate toggle a no-op (issue #153).
  * {@link #refreshAlertChannels} bumps the version so a changed setting really applies.
+ * <p>
+ * From Android 8 the <em>channel</em> owns the alert sound, so the user's per-severity sound picks are applied here
+ * as well ({@link #alertSoundUri}). Until they were, every alert channel was created with the framework default and
+ * the three pickers on Settings › Alerts saved a choice that changed nothing audible (issue #286). A sound pick is
+ * therefore as much a channel setting as the Vibrate toggle, and re-versions the channels the same way — see
+ * {@link #affectsAlertChannels}.
  */
 final class NotificationChannels {
 
@@ -40,7 +49,7 @@ final class NotificationChannels {
 
 	// Current version of the alert channels' settings, stored in the default SharedPreferences.
 	// Version 1 means the original unsuffixed channel IDs, so existing installs keep their channels
-	// (and any per-channel tweaks) until the user first changes the Vibrate preference.
+	// (and any per-channel tweaks) until the user first changes a setting the channels are made of.
 	private static final String PREF_ALERT_CHANNEL_VERSION = "alert_channel_version";
 
 	private NotificationChannels() {
@@ -65,22 +74,28 @@ final class NotificationChannels {
 
 		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_CRITICAL, version),
 				context.getString(R.string.notification_critical_channel_name),
-				context.getString(R.string.notification_critical_channel_description), Color.RED, vibrate);
+				context.getString(R.string.notification_critical_channel_description), Color.RED, vibrate,
+				alertSoundUri(context, CHANNEL_ID_CRITICAL));
 		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_WARNING, version),
 				context.getString(R.string.notification_warning_channel_name),
-				context.getString(R.string.notification_warning_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
+				context.getString(R.string.notification_warning_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate,
+				alertSoundUri(context, CHANNEL_ID_WARNING));
 		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_FULL, version),
 				context.getString(R.string.notification_full_channel_name),
-				context.getString(R.string.notification_full_channel_description), Color.GREEN, vibrate);
+				context.getString(R.string.notification_full_channel_description), Color.GREEN, vibrate,
+				alertSoundUri(context, CHANNEL_ID_FULL));
 		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_TEMPERATURE, version),
 				context.getString(R.string.notification_temperature_channel_name),
-				context.getString(R.string.notification_temperature_channel_description), Color.RED, vibrate);
+				context.getString(R.string.notification_temperature_channel_description), Color.RED, vibrate,
+				alertSoundUri(context, CHANNEL_ID_TEMPERATURE));
 		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_FAST_DRAIN, version),
 				context.getString(R.string.notification_fast_drain_channel_name),
-				context.getString(R.string.notification_fast_drain_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
+				context.getString(R.string.notification_fast_drain_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate,
+				alertSoundUri(context, CHANNEL_ID_FAST_DRAIN));
 		createOrUpdateAlertChannel(manager, versionedChannelId(CHANNEL_ID_SLOW_CHARGE, version),
 				context.getString(R.string.notification_slow_charge_channel_name),
-				context.getString(R.string.notification_slow_charge_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate);
+				context.getString(R.string.notification_slow_charge_channel_description), Color.rgb(0xff, 0x66, 0x00), vibrate,
+				alertSoundUri(context, CHANNEL_ID_SLOW_CHARGE));
 		createOrUpdateSilentChannel(manager, CHANNEL_ID_STATUS,
 				context.getString(R.string.notification_status_channel_name),
 				context.getString(R.string.notification_status_channel_description));
@@ -90,13 +105,13 @@ final class NotificationChannels {
 	}
 
 	/**
-	 * Re-create the alert channels so a changed "Vibrate" preference takes effect.
+	 * Re-create the alert channels so a changed "Vibrate" or sound preference takes effect.
 	 * <p>
 	 * Deleting and recreating a channel under the same ID is not enough: Android un-deletes it with
 	 * its old settings (issue #153). So the old-version channels are deleted (keeping system
 	 * settings free of orphans) and the channels are recreated under the next version's IDs, which
-	 * the system treats as brand-new channels with the new vibration setting. The silent channels
-	 * are untouched.
+	 * the system treats as brand-new channels with the new settings. The silent channels are
+	 * untouched.
 	 *
 	 * @param context The application context
 	 */
@@ -117,6 +132,57 @@ final class NotificationChannels {
 
 		prefs.edit().putInt(PREF_ALERT_CHANNEL_VERSION, oldVersion + 1).apply();
 		ensureChannels(context);
+	}
+
+	/**
+	 * Whether a changed preference is one the alert channels are built from, so the channels have to be re-created
+	 * for it to take effect: the "Vibrate" toggle (issue #153) and the three per-severity sound picks (issue #286).
+	 * <p>
+	 * Android freezes a channel's sound and vibration at creation, so a setting that never reaches
+	 * {@link #refreshAlertChannels} is simply ignored — which is what made both of these look like they worked and
+	 * not. Kept here, next to the channels themselves, so the settings screen doesn't accumulate its own list of
+	 * which preferences happen to be channel settings.
+	 *
+	 * @param context The application context
+	 * @param prefKey the preference key that changed, or null
+	 *
+	 * @return true when the alert channels have to be re-created under a new version
+	 */
+	static boolean affectsAlertChannels(Context context, String prefKey) {
+		return nonNull(prefKey) && (prefKey.equals(context.getString(R.string._pref_key_notifications_vibrate))
+				|| prefKey.equals(context.getString(R.string._pref_key_notifications_alert_sound_ringtone))
+				|| prefKey.equals(context.getString(R.string._pref_key_notifications_warning_sound_ringtone))
+				|| prefKey.equals(context.getString(R.string._pref_key_notifications_full_sound_ringtone)));
+	}
+
+	/**
+	 * The sound an alert channel plays: the URI the user picked for the severity bucket that channel belongs to.
+	 * <p>
+	 * Three pickers cover six channels, so the two rate alerts and the overheat alert — which have no picker of their
+	 * own — need a bucket that is chosen rather than the critical pref they reached by accident (issue #286). The
+	 * mapping is the one #223 designs its bundled sounds around: the critical level and overheating are the same
+	 * "act now" severity, while low battery, fast drain and slow charge are all "something is off, look at it".
+	 * <p>
+	 * The same resolution feeds the channel and {@link AlertSounds#playAlarm}, so the sound a user hears can't depend
+	 * on which of the two paths delivered the alert.
+	 * <p>
+	 * An empty result is a real answer, not a missing one: it is what the picker's "Silent" option persists.
+	 *
+	 * @param context       The application context
+	 * @param baseChannelId the unversioned channel ID whose sound is wanted
+	 *
+	 * @return the picked sound URI, empty when the user chose Silent, or the device's default notification sound
+	 */
+	static String alertSoundUri(Context context, String baseChannelId) {
+		final int soundKeyRes = switch (baseChannelId) {
+			case CHANNEL_ID_FULL -> R.string._pref_key_notifications_full_sound_ringtone;
+			case CHANNEL_ID_WARNING, CHANNEL_ID_FAST_DRAIN, CHANNEL_ID_SLOW_CHARGE -> R.string._pref_key_notifications_warning_sound_ringtone;
+			// The critical bucket takes the overheat alert and, deliberately, anything added later without a bucket of
+			// its own: an alert on a neighbouring severity's sound is a far smaller failure than one that loses its sound.
+			default -> R.string._pref_key_notifications_alert_sound_ringtone;
+		};
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		return prefs.getString(context.getString(soundKeyRes), context.getString(R.string._default_notification_sound_uri));
 	}
 
 	/**
@@ -153,10 +219,10 @@ final class NotificationChannels {
 
 	/**
 	 * The current alert-channel settings version, bumped by {@link #refreshAlertChannels(Context)}
-	 * whenever the Vibrate preference changes.
+	 * whenever one of the {@link #affectsAlertChannels} preferences changes.
 	 *
 	 * @param prefs the default SharedPreferences
-	 * @return the current version, 1 for installs that never changed the Vibrate preference
+	 * @return the current version, 1 for installs that never changed one of those preferences
 	 */
 	private static int alertChannelVersion(SharedPreferences prefs) {
 		return prefs.getInt(PREF_ALERT_CHANNEL_VERSION, 1);
@@ -202,9 +268,15 @@ final class NotificationChannels {
 	 * @param description The channel description
 	 * @param ledColor    The LED color for notifications
 	 * @param vibrate     Whether the channel should vibrate (from the user's Vibrate preference)
+	 * @param soundUri    The sound to play, from the user's pick for this channel's severity bucket (#286)
 	 */
-	private static void createOrUpdateAlertChannel(NotificationManager manager, String channelId, String name, String description,
-	                                               int ledColor, boolean vibrate) {
+	private static void createOrUpdateAlertChannel(NotificationManager manager,
+	                                               String channelId,
+	                                               String name,
+	                                               String description,
+	                                               int ledColor,
+	                                               boolean vibrate,
+	                                               String soundUri) {
 		final NotificationChannel channel = new NotificationChannel(channelId, name, NotificationManager.IMPORTANCE_HIGH);
 		channel.setDescription(description);
 		channel.enableLights(true);
@@ -213,7 +285,45 @@ final class NotificationChannels {
 		if (vibrate) {
 			channel.setVibrationPattern(SystemService.VIBRATION_PATTERN);
 		}
+		// Set at creation and frozen there by the system, which is why a changed pick comes back through
+		// refreshAlertChannels rather than being re-applied on the next ensureChannels (#286).
+		channel.setSound(soundUriOrSilent(soundUri), alertAudioAttributes());
 		manager.createNotificationChannel(channel);
+	}
+
+	/**
+	 * The picked sound as a {@link Uri}, or null for the picker's "Silent" choice.
+	 * <p>
+	 * {@code RingtonePreference} persists Silent as an empty string, and {@code setSound(null, …)} is how a channel
+	 * says "no sound" — so the empty string has to be translated into that null rather than parsed into an empty
+	 * {@code Uri} that resolves to nothing at post time.
+	 *
+	 * @param soundUri the persisted sound URI, possibly empty
+	 *
+	 * @return the sound to set on the channel, or null for no sound
+	 */
+	private static Uri soundUriOrSilent(String soundUri) {
+		return isNull(soundUri) || soundUri.isEmpty() ? null : Uri.parse(soundUri);
+	}
+
+	/**
+	 * The attributes an alert channel's sound plays under: a notification, so it follows the notification stream's
+	 * volume and the system's Do Not Disturb rules.
+	 * <p>
+	 * Deliberately not the {@code USAGE_ALARM} that {@link AlertSounds} plays under. That path exists to be heard when
+	 * notifications are silenced, and this one is suppressed in exactly those conditions, so the channel sound and the
+	 * override-silent sound can never double up (issue #286).
+	 * <p>
+	 * Built per call rather than held in a static field: a static initializer touching {@code android.media} would
+	 * throw {@code Stub!} in the plain-JUnit tests that use this class's pure channel-ID helpers.
+	 *
+	 * @return the audio attributes for an alert channel's sound
+	 */
+	private static AudioAttributes alertAudioAttributes() {
+		return new AudioAttributes.Builder()
+				.setUsage(AudioAttributes.USAGE_NOTIFICATION)
+				.setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+				.build();
 	}
 
 	private static NotificationManager getManager(Context context) {

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationConfig.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationConfig.java
@@ -50,8 +50,6 @@ final class NotificationConfig {
 		this.ignoreSilent = QuietHours.shouldIgnoreSilentMode(context, prefs);
 		this.vibrate = AppPrefs.vibrateEnabled(context);
 
-		final String defaultSound = context.getString(R.string._default_notification_sound_uri);
-
 		// A switch EXPRESSION over the enum is exhaustive at compile time — the old int switch
 		// needed a default branch, which posted a completely blank notification on any invalid
 		// type value (issue #160). That branch can no longer exist.
@@ -59,13 +57,15 @@ final class NotificationConfig {
 		// Each branch reads only its own threshold, so the full-battery alert — the one that fires at the end of every charge — does no preference lookups for
 		// levels it never names.
 		final AlertStyle style = switch (type) {
-			case CRITICAL -> criticalAlertStyle(context, prefs, defaultSound);
-			case WARNING -> warningAlertStyle(context, prefs, defaultSound);
-			case FULL -> fullAlertStyle(context, prefs, defaultSound, levelPercent);
+			case CRITICAL -> criticalAlertStyle(context);
+			case WARNING -> warningAlertStyle(context);
+			case FULL -> fullAlertStyle(context, levelPercent);
 		};
 		this.channelId = style.channelId();
 		this.iconRes = style.iconRes();
-		this.alarmSound = style.alarmSound();
+		// The channel this alert posts on is what decides which sound pick applies, so the override-silent playback below can't
+		// end up on a different sound from the one the channel itself plays (#286).
+		this.alarmSound = NotificationChannels.alertSoundUri(context, this.channelId);
 		this.ticker = style.ticker();
 		this.title = style.title();
 		this.content = style.content();
@@ -82,18 +82,15 @@ final class NotificationConfig {
 	 * That sign is why the level is isolated before it goes into the copy (#275): every string below sets it against Arabic prose, where a bare {@code "20%"}
 	 * renders {@code %20}. Isolating the formatted level — not the digits alone — keeps the sign on the number it belongs to.
 	 *
-	 * @param context      The application context
-	 * @param prefs        SharedPreferences containing user settings
-	 * @param defaultSound the fallback alarm sound URI
+	 * @param context The application context
 	 *
 	 * @return the copy and channel for this alert
 	 */
-	private static AlertStyle criticalAlertStyle(Context context, SharedPreferences prefs, String defaultSound) {
+	private static AlertStyle criticalAlertStyle(Context context) {
 		final String levelText = isolate(BatteryPercentFormatter.formatWhole(AppPrefs.criticalLevel(context)));
 		return new AlertStyle(
 				NotificationChannels.CHANNEL_ID_CRITICAL,
 				R.drawable.ic_stat_battery_alert,
-				prefs.getString(context.getString(R.string._pref_key_notifications_alert_sound_ringtone), defaultSound),
 				context.getString(R.string.notification_critical_ticker, levelText),
 				context.getString(R.string.notification_critical_title),
 				context.getString(R.string.notification_critical_content, levelText),
@@ -103,18 +100,15 @@ final class NotificationConfig {
 	/**
 	 * The warning alert's presentation — the critical alert's shape one threshold up, on its own channel and sound.
 	 *
-	 * @param context      The application context
-	 * @param prefs        SharedPreferences containing user settings
-	 * @param defaultSound the fallback alarm sound URI
+	 * @param context The application context
 	 *
 	 * @return the copy and channel for this alert
 	 */
-	private static AlertStyle warningAlertStyle(Context context, SharedPreferences prefs, String defaultSound) {
+	private static AlertStyle warningAlertStyle(Context context) {
 		final String levelText = isolate(BatteryPercentFormatter.formatWhole(AppPrefs.warningLevel(context)));
 		return new AlertStyle(
 				NotificationChannels.CHANNEL_ID_WARNING,
 				R.drawable.ic_stat_battery_low,
-				prefs.getString(context.getString(R.string._pref_key_notifications_warning_sound_ringtone), defaultSound),
 				context.getString(R.string.notification_warning_ticker, levelText),
 				context.getString(R.string.notification_warning_title),
 				context.getString(R.string.notification_warning_content, levelText),
@@ -134,13 +128,11 @@ final class NotificationConfig {
 	 * rather than one parameterised one — the messages differ in more than a number.
 	 *
 	 * @param context      The application context
-	 * @param prefs        SharedPreferences containing user settings
-	 * @param defaultSound the fallback alarm sound URI
 	 * @param levelPercent the battery level the alert fired at
 	 *
 	 * @return the copy and channel for this alert
 	 */
-	private static AlertStyle fullAlertStyle(Context context, SharedPreferences prefs, String defaultSound, int levelPercent) {
+	private static AlertStyle fullAlertStyle(Context context, int levelPercent) {
 		final int target = AppPrefs.chargeTarget(context);
 		// Below the target the only way here is a charge the battery reported as complete.
 		final boolean chargeIsComplete = AppPrefs.targetIsAFullCharge(target) || levelPercent < target;
@@ -173,7 +165,6 @@ final class NotificationConfig {
 		return new AlertStyle(
 				NotificationChannels.CHANNEL_ID_FULL,
 				R.drawable.ic_stat_battery_full,
-				prefs.getString(context.getString(R.string._pref_key_notifications_full_sound_ringtone), defaultSound),
 				ticker,
 				title,
 				content,
@@ -198,7 +189,6 @@ final class NotificationConfig {
 	 *
 	 * @param channelId  the audible base channel ID for this type
 	 * @param iconRes    the small-icon resource
-	 * @param alarmSound the user's chosen alarm sound for this type
 	 * @param ticker     the ticker text
 	 * @param title      the notification title
 	 * @param content    the collapsed content line
@@ -207,7 +197,6 @@ final class NotificationConfig {
 	private record AlertStyle(
 			String channelId,
 			int iconRes,
-			String alarmSound,
 			String ticker,
 			String title,
 			String content,

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationConfig.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationConfig.java
@@ -65,7 +65,7 @@ final class NotificationConfig {
 		this.iconRes = style.iconRes();
 		// The channel this alert posts on is what decides which sound pick applies, so the override-silent playback below can't
 		// end up on a different sound from the one the channel itself plays (#286).
-		this.alarmSound = NotificationChannels.alertSoundUri(context, this.channelId);
+		this.alarmSound = NotificationChannels.alertSoundUri(context, prefs, this.channelId);
 		this.ticker = style.ticker();
 		this.title = style.title();
 		this.content = style.content();

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -301,27 +301,25 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Re-create the alert channels so a changed "Vibrate" (issue #153) or sound (issue #286) preference takes effect.
-	 * Delegates to {@link NotificationChannels#refreshAlertChannels(Context)}.
-	 *
-	 * @param context The application context
-	 */
-	public static void refreshAlertChannels(Context context) {
-		NotificationChannels.refreshAlertChannels(context);
-	}
-
-	/**
-	 * Whether a changed preference is one the alert channels are built from, so {@link #refreshAlertChannels} has to
-	 * run for it to take effect. Delegates to {@link NotificationChannels#affectsAlertChannels(Context, String)}, so
-	 * the settings screen asks which preferences those are instead of keeping its own list of them.
+	 * Re-create the alert channels if the preference that just changed is one they are built from — the "Vibrate"
+	 * toggle (issue #153) or a per-severity sound pick (issue #286).
+	 * <p>
+	 * The test and the effect are one call rather than two, and both live behind this class rather than in the settings
+	 * screen. Split up, each half can be right while the pair does nothing: a picker added to the screen without being
+	 * added to the test saves a choice that never re-versions anything, which is #286 again, and nothing fails. Joined,
+	 * the settings screen has no decision left to get wrong and the whole path is exercised by one test.
 	 *
 	 * @param context The application context
 	 * @param prefKey the preference key that changed, or null
 	 *
-	 * @return true when the alert channels have to be re-created
+	 * @return true when the alert channels were re-created
 	 */
-	public static boolean affectsAlertChannels(Context context, String prefKey) {
-		return NotificationChannels.affectsAlertChannels(context, prefKey);
+	public static boolean refreshAlertChannelsIfAffected(Context context, String prefKey) {
+		if (!NotificationChannels.affectsAlertChannels(context, prefKey)) {
+			return false;
+		}
+		NotificationChannels.refreshAlertChannels(context);
+		return true;
 	}
 
 	/**
@@ -426,7 +424,7 @@ public final class NotificationService {
 
 		if (routing.withinWindow()) {
 			final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-			final String sound = NotificationChannels.alertSoundUri(context, spec.audibleChannelId());
+			final String sound = NotificationChannels.alertSoundUri(context, prefs, spec.audibleChannelId());
 			AlertSounds.playAlarm(context, sound, QuietHours.shouldIgnoreSilentMode(context, prefs), AppPrefs.vibrateEnabled(context));
 		}
 	}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/service/NotificationService.java
@@ -301,13 +301,27 @@ public final class NotificationService {
 	}
 
 	/**
-	 * Re-create the alert channels so a changed "Vibrate" preference takes effect (issue #153).
+	 * Re-create the alert channels so a changed "Vibrate" (issue #153) or sound (issue #286) preference takes effect.
 	 * Delegates to {@link NotificationChannels#refreshAlertChannels(Context)}.
 	 *
 	 * @param context The application context
 	 */
 	public static void refreshAlertChannels(Context context) {
 		NotificationChannels.refreshAlertChannels(context);
+	}
+
+	/**
+	 * Whether a changed preference is one the alert channels are built from, so {@link #refreshAlertChannels} has to
+	 * run for it to take effect. Delegates to {@link NotificationChannels#affectsAlertChannels(Context, String)}, so
+	 * the settings screen asks which preferences those are instead of keeping its own list of them.
+	 *
+	 * @param context The application context
+	 * @param prefKey the preference key that changed, or null
+	 *
+	 * @return true when the alert channels have to be re-created
+	 */
+	public static boolean affectsAlertChannels(Context context, String prefKey) {
+		return NotificationChannels.affectsAlertChannels(context, prefKey);
 	}
 
 	/**
@@ -393,7 +407,11 @@ public final class NotificationService {
 	 * The single home of the quiet-hours dance shared by the temperature (#18/#111), fast-drain (#109)
 	 * and slow-charge (#123) alerts: rerouting to the silent channel outside the notification window,
 	 * and gating the alarm sound/vibration on the window — so a quiet-hours fix can't be applied to one
-	 * alert and missed on another. All reuse the critical-alert ringtone preference, as before.
+	 * alert and missed on another.
+	 * <p>
+	 * None of the three has a sound picker of its own, so the sound comes from the severity bucket its channel belongs to
+	 * ({@link NotificationChannels#alertSoundUri}) — the same resolution the channel itself was created with, rather than
+	 * the critical pref all three used to reach for regardless of severity (#286).
 	 *
 	 * @param context The application context
 	 * @param spec    What to show: channel, id, icon and text content
@@ -408,9 +426,7 @@ public final class NotificationService {
 
 		if (routing.withinWindow()) {
 			final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-			final String sound = prefs.getString(
-					context.getString(R.string._pref_key_notifications_alert_sound_ringtone),
-					context.getString(R.string._default_notification_sound_uri));
+			final String sound = NotificationChannels.alertSoundUri(context, spec.audibleChannelId());
 			AlertSounds.playAlarm(context, sound, QuietHours.shouldIgnoreSilentMode(context, prefs), AppPrefs.vibrateEnabled(context));
 		}
 	}

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
@@ -284,17 +284,15 @@ public class GenericPreferenceFragment extends CardPreferenceFragment
 	 * @param key               The key of the preference that was changed
 	 */
 	@Override
-	public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, final String key) {
+	public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
 		// Update summary when preference changes
 		final Preference pref = findPreference(key);
 		updatePreferencesSummary(sharedPreferences, pref);
 
-		// The Vibrate toggle and the three per-severity sound picks are baked into the alert channels, which Android
-		// caches; recreate the channels under new versioned IDs so the new setting takes effect (#153, #286). Which
-		// preferences those are is the channel registry's to know, not this screen's.
-		if (NotificationService.affectsAlertChannels(requireContext(), key)) {
-			NotificationService.refreshAlertChannels(requireContext());
-		}
+		// The Vibrate toggle and the per-severity sound picks are baked into the alert channels, which Android caches, so
+		// a change to one has to recreate them under new versioned IDs to take effect (#153, #286). Which preferences
+		// those are, and the recreation itself, both belong to the channel registry — this screen only reports the change.
+		NotificationService.refreshAlertChannelsIfAffected(requireContext(), key);
 	}
 
 	/**

--- a/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
+++ b/app/src/main/java/com/almothafar/simplebatterynotifier/ui/fragment/GenericPreferenceFragment.java
@@ -289,9 +289,10 @@ public class GenericPreferenceFragment extends CardPreferenceFragment
 		final Preference pref = findPreference(key);
 		updatePreferencesSummary(sharedPreferences, pref);
 
-		// The Vibrate toggle changes channel settings, which Android caches; recreate the alert
-		// channels under new versioned IDs so the new setting takes effect (#153).
-		if (nonNull(key) && key.equals(getString(R.string._pref_key_notifications_vibrate))) {
+		// The Vibrate toggle and the three per-severity sound picks are baked into the alert channels, which Android
+		// caches; recreate the channels under new versioned IDs so the new setting takes effect (#153, #286). Which
+		// preferences those are is the channel registry's to know, not this screen's.
+		if (NotificationService.affectsAlertChannels(requireContext(), key)) {
 			NotificationService.refreshAlertChannels(requireContext());
 		}
 	}

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationChannelsTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationChannelsTest.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -41,6 +41,19 @@ public class NotificationChannelsTest {
 	private static final String PICKED_CRITICAL = "content://media/internal/audio/media/101";
 	private static final String PICKED_WARNING = "content://media/internal/audio/media/202";
 	private static final String PICKED_FULL = "content://media/internal/audio/media/303";
+
+	/**
+	 * The six alert channels, restated rather than read from the production table on purpose: a test that enumerated the
+	 * same list the code iterates could not notice a channel dropping out of it.
+	 */
+	private static final String[] BASE_CHANNEL_IDS = {
+			NotificationChannels.CHANNEL_ID_CRITICAL,
+			NotificationChannels.CHANNEL_ID_WARNING,
+			NotificationChannels.CHANNEL_ID_FULL,
+			NotificationChannels.CHANNEL_ID_TEMPERATURE,
+			NotificationChannels.CHANNEL_ID_FAST_DRAIN,
+			NotificationChannels.CHANNEL_ID_SLOW_CHARGE,
+	};
 
 	/**
 	 * {@link NotificationChannels#versionedChannelId(String, int)} — versioned alert-channel IDs so a changed setting
@@ -186,16 +199,21 @@ public class NotificationChannelsTest {
 		}
 
 		private NotificationChannel channel(String baseChannelId) {
-			return manager.getNotificationChannel(NotificationChannels.channelFor(context, true, baseChannelId));
+			return currentChannel(context, manager, baseChannelId);
 		}
 	}
 
 	/**
-	 * A changed pick has to re-version the channels to take effect (#153/#286).
+	 * A changed setting has to re-version the channels to take effect, and an install on an older definition has to be
+	 * re-versioned without changing any setting at all (#153/#286).
 	 * <p>
 	 * A channel's sound is fixed when it is created, and Android un-deletes a channel recreated under the same ID with
-	 * its old settings — so without the version bump the new pick is stored, shown in the summary, and ignored. That is
-	 * how the Vibrate toggle failed before #153, and how a sound pick would fail with the wiring alone.
+	 * its old settings — so without a version bump the new pick is stored, shown in the summary, and ignored. That is how
+	 * the Vibrate toggle failed before #153, and how a sound pick would fail with the wiring alone.
+	 * <p>
+	 * The re-version is driven through {@link NotificationService#refreshAlertChannelsIfAffected}, which is the single
+	 * call the settings screen makes: testing the predicate and the recreation separately leaves the join untested, and
+	 * the join is the part both #153 and #286 got wrong.
 	 */
 	@RunWith(RobolectricTestRunner.class)
 	@Config(sdk = 34)
@@ -214,56 +232,209 @@ public class NotificationChannelsTest {
 
 		@Test
 		public void changedPick_bumpsTheChannelVersion() {
+			final int before = channelVersion(context);
 			pickSound(context, R.string._pref_key_notifications_alert_sound_ringtone, PICKED_CRITICAL);
 
-			NotificationChannels.refreshAlertChannels(context);
+			assertTrue(NotificationService.refreshAlertChannelsIfAffected(context, key(R.string._pref_key_notifications_alert_sound_ringtone)));
 
-			assertEquals(2, PreferenceManager.getDefaultSharedPreferences(context).getInt("alert_channel_version", 1));
+			// Asserted as a move rather than against a literal, so raising the definition version doesn't rewrite this test.
+			assertTrue("a changed pick that leaves the version alone is a pick the system will ignore", channelVersion(context) > before);
 		}
 
 		@Test
-		public void changedPick_recreatesTheChannelsUnderTheNewIds() {
-			pickSound(context, R.string._pref_key_notifications_alert_sound_ringtone, PICKED_CRITICAL);
+		public void changedPick_recreatesEveryChannelUnderTheNewIds() {
+			pickSound(context, R.string._pref_key_notifications_warning_sound_ringtone, PICKED_WARNING);
 
-			NotificationChannels.refreshAlertChannels(context);
+			NotificationService.refreshAlertChannelsIfAffected(context, key(R.string._pref_key_notifications_warning_sound_ringtone));
 
-			final String newId = NotificationChannels.channelFor(context, true, NotificationChannels.CHANNEL_ID_CRITICAL);
-			assertNotEquals("the alert must move off the ID whose settings the system froze", NotificationChannels.CHANNEL_ID_CRITICAL, newId);
-			assertEquals(Uri.parse(PICKED_CRITICAL), manager.getNotificationChannel(newId).getSound());
+			for (String baseId : BASE_CHANNEL_IDS) {
+				assertNotNull(baseId + " went missing across the re-version", currentChannel(context, manager, baseId));
+			}
+			assertEquals(Uri.parse(PICKED_WARNING), currentChannel(context, manager, NotificationChannels.CHANNEL_ID_FAST_DRAIN).getSound());
 		}
 
 		@Test
 		public void changedPick_leavesNoOrphanBehindInSystemSettings() {
+			final String[] oldIds = currentChannelIds(context);
 			pickSound(context, R.string._pref_key_notifications_alert_sound_ringtone, PICKED_CRITICAL);
 
-			NotificationChannels.refreshAlertChannels(context);
+			NotificationService.refreshAlertChannelsIfAffected(context, key(R.string._pref_key_notifications_alert_sound_ringtone));
 
-			assertNull(manager.getNotificationChannel(NotificationChannels.CHANNEL_ID_CRITICAL));
+			// Every one of the six, not just the first: an orphan is a per-channel failure, so a channel missed out of the
+			// deletion list leaves a stale entry the user sees in system settings and a single-channel assertion passes.
+			for (String oldId : oldIds) {
+				assertNull(oldId + " was left behind in system settings", manager.getNotificationChannel(oldId));
+			}
 		}
 
 		@Test
-		public void everySoundPickIsAChannelSetting() {
-			assertTrue(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_notifications_alert_sound_ringtone)));
-			assertTrue(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_notifications_warning_sound_ringtone)));
-			assertTrue(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_notifications_full_sound_ringtone)));
+		public void theVibrateToggleStillReVersions() {
+			final int before = channelVersion(context);
+
+			assertTrue(NotificationService.refreshAlertChannelsIfAffected(context, key(R.string._pref_key_notifications_vibrate)));
+			assertTrue(channelVersion(context) > before);
 		}
 
 		@Test
-		public void theVibrateToggleIsStillAChannelSetting() {
-			assertTrue(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_notifications_vibrate)));
+		public void everySoundPickReVersions() {
+			assertReVersions(R.string._pref_key_notifications_alert_sound_ringtone);
+			assertReVersions(R.string._pref_key_notifications_warning_sound_ringtone);
+			assertReVersions(R.string._pref_key_notifications_full_sound_ringtone);
 		}
 
 		@Test
-		public void anUnrelatedPreferenceIsNot() {
-			// Every preference change on the screen comes through here, so a re-version for one that changes nothing about
+		public void anUnrelatedPreferenceDoesNot() {
+			// Every preference change on the screen comes through here, so re-versioning for one that changes nothing about
 			// the channels would reset the user's per-channel tweaks for nothing.
-			assertFalse(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_charge_target)));
-			assertFalse(NotificationChannels.affectsAlertChannels(context, null));
+			final int before = channelVersion(context);
+
+			assertFalse(NotificationService.refreshAlertChannelsIfAffected(context, key(R.string._pref_key_charge_target)));
+			assertFalse(NotificationService.refreshAlertChannelsIfAffected(context, null));
+			assertEquals(before, channelVersion(context));
+		}
+
+		private void assertReVersions(int keyRes) {
+			final int before = channelVersion(context);
+			assertTrue(key(keyRes) + " must re-version the channels", NotificationService.refreshAlertChannelsIfAffected(context, key(keyRes)));
+			assertTrue(key(keyRes) + " must re-version the channels", channelVersion(context) > before);
 		}
 
 		private String key(int keyRes) {
 			return context.getString(keyRes);
 		}
+	}
+
+	/**
+	 * An install that predates #286 has to start playing its pick without touching a setting.
+	 * <p>
+	 * This is the population #286 was filed about: the pick was saved long ago, the channels were created by code that
+	 * never called {@code setSound}, and the user has no reason to go back and pick again. Passing the URI on every alert
+	 * changes nothing there — Android froze the channel's sound when it was created — so unless the app re-versions the
+	 * channels on its own, the fix reaches everyone except the people who reported it.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class DefinitionVersionMigration {
+
+		private Context context;
+		private NotificationManager manager;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+			manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+			pickSound(context, R.string._pref_key_notifications_alert_sound_ringtone, PICKED_CRITICAL);
+		}
+
+		@Test
+		public void theOldPick_becomesAudibleWithoutTheUserRePicking() {
+			seedPre286Install(1);
+
+			NotificationChannels.ensureChannels(context);
+
+			assertEquals(Uri.parse(PICKED_CRITICAL), currentChannel(context, manager, NotificationChannels.CHANNEL_ID_CRITICAL).getSound());
+		}
+
+		@Test
+		public void theOldChannels_areNotLeftBehind() {
+			seedPre286Install(1);
+
+			NotificationChannels.ensureChannels(context);
+
+			// versionedChannelId(base, 1) is the bare base ID, so this is the pre-#286 channel itself.
+			assertNull(manager.getNotificationChannel(NotificationChannels.CHANNEL_ID_CRITICAL));
+		}
+
+		@Test
+		public void anInstallThatHadAlreadyChangedASetting_isMigratedToo() {
+			// The settings version counts the user's own changes, so a long-standing install sits at 2 or higher while its
+			// channels still predate #286. Keying the migration on that version instead of on the definition generation
+			// would skip exactly these installs — the oldest ones, and the likeliest to have picked a sound years ago.
+			seedPre286Install(4);
+
+			NotificationChannels.ensureChannels(context);
+
+			assertEquals(Uri.parse(PICKED_CRITICAL), currentChannel(context, manager, NotificationChannels.CHANNEL_ID_CRITICAL).getSound());
+			assertNull(manager.getNotificationChannel(NotificationChannels.versionedChannelId(NotificationChannels.CHANNEL_ID_CRITICAL, 4)));
+			assertTrue(channelVersion(context) > 4);
+		}
+
+		@Test
+		public void theMigration_runsOnceAndThenLeavesTheVersionAlone() {
+			seedPre286Install(1);
+
+			NotificationChannels.ensureChannels(context);
+			final int afterMigration = channelVersion(context);
+			NotificationChannels.ensureChannels(context);
+			NotificationChannels.ensureChannels(context);
+
+			// ensureChannels runs on every alert. A migration that re-fired would throw away the user's per-channel tweaks
+			// over and over, which is worse than the bug it exists to fix.
+			assertTrue(afterMigration > 1);
+			assertEquals(afterMigration, channelVersion(context));
+		}
+
+		/**
+		 * Put the install in the state this migration exists for: channels created before #286 (so carrying no sound of
+		 * their own) at a given settings version, and no record of which definition generation made them.
+		 *
+		 * @param version the settings version the install's channels live at
+		 */
+		private void seedPre286Install(int version) {
+			setChannelVersion(context, version);
+			manager.createNotificationChannel(new NotificationChannel(
+					NotificationChannels.versionedChannelId(NotificationChannels.CHANNEL_ID_CRITICAL, version),
+					"Critical", NotificationManager.IMPORTANCE_HIGH));
+		}
+	}
+
+	/**
+	 * The channel whose ID a base ID currently resolves to, at whatever settings version the install is on.
+	 *
+	 * @param context the test's application context
+	 * @param manager the notification manager to read from
+	 * @param baseId  the unversioned channel ID
+	 *
+	 * @return the live channel for that base ID
+	 */
+	private static NotificationChannel currentChannel(Context context, NotificationManager manager, String baseId) {
+		return manager.getNotificationChannel(NotificationChannels.channelFor(context, true, baseId));
+	}
+
+	/**
+	 * The versioned IDs the six alert channels currently live under.
+	 *
+	 * @param context the test's application context
+	 *
+	 * @return the current channel IDs, in the order of {@link #BASE_CHANNEL_IDS}
+	 */
+	private static String[] currentChannelIds(Context context) {
+		final String[] ids = new String[BASE_CHANNEL_IDS.length];
+		for (int i = 0; i < BASE_CHANNEL_IDS.length; i++) {
+			ids[i] = NotificationChannels.channelFor(context, true, BASE_CHANNEL_IDS[i]);
+		}
+		return ids;
+	}
+
+	/**
+	 * The stored alert-channel settings version. Read by its literal key, which is what the persisted state actually is.
+	 *
+	 * @param context the test's application context
+	 *
+	 * @return the current version
+	 */
+	private static int channelVersion(Context context) {
+		return PreferenceManager.getDefaultSharedPreferences(context).getInt("alert_channel_version", 1);
+	}
+
+	/**
+	 * Put the install on a given alert-channel settings version.
+	 *
+	 * @param context the test's application context
+	 * @param version the version to store
+	 */
+	private static void setChannelVersion(Context context, int version) {
+		PreferenceManager.getDefaultSharedPreferences(context).edit().putInt("alert_channel_version", version).commit();
 	}
 
 	/**

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationChannelsTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationChannelsTest.java
@@ -1,43 +1,307 @@
 package com.almothafar.simplebatterynotifier.service;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.media.AudioAttributes;
+import android.net.Uri;
+
+import androidx.preference.PreferenceManager;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.almothafar.simplebatterynotifier.R;
+
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
- * {@link NotificationChannels#versionedChannelId(String, int)} — versioned alert-channel IDs so a
- * Vibrate change creates genuinely new channels instead of un-deleting old ones (issue #153).
- * Version 1 must stay the original unsuffixed ID so existing installs keep their channels.
+ * {@link NotificationChannels} — the channel registry's two settings-driven behaviours: the versioned IDs that let a
+ * changed setting apply at all (issue #153), and the per-severity sound each alert channel is created with (#286).
  */
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class NotificationChannelsTest {
 
-	@Parameter(0) public String label;
-	@Parameter(1) public String baseId;
-	@Parameter(2) public int version;
-	@Parameter(3) public String expected;
+	/** A picked sound that is nothing like the device default, so "the pick applied" can't pass by coincidence. */
+	private static final String PICKED_CRITICAL = "content://media/internal/audio/media/101";
+	private static final String PICKED_WARNING = "content://media/internal/audio/media/202";
+	private static final String PICKED_FULL = "content://media/internal/audio/media/303";
 
-	@Parameters(name = "{0}")
-	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][]{
-				{"version 1 keeps the legacy unsuffixed ID", "battery_critical", 1, "battery_critical"},
-				{"version 2 appends _v2", "battery_critical", 2, "battery_critical_v2"},
-				{"later versions keep counting", "battery_warning", 7, "battery_warning_v7"},
-				{"different base IDs stay distinct", "battery_full", 2, "battery_full_v2"},
-				{"defensive: version 0 treated as legacy", "battery_critical", 0, "battery_critical"},
-				{"defensive: negative version treated as legacy", "battery_critical", -3, "battery_critical"},
-		});
+	/**
+	 * {@link NotificationChannels#versionedChannelId(String, int)} — versioned alert-channel IDs so a changed setting
+	 * creates genuinely new channels instead of un-deleting old ones (issue #153). Version 1 must stay the original
+	 * unsuffixed ID so existing installs keep their channels.
+	 */
+	@RunWith(Parameterized.class)
+	public static class VersionedIds {
+
+		@Parameter(0) public String label;
+		@Parameter(1) public String baseId;
+		@Parameter(2) public int version;
+		@Parameter(3) public String expected;
+
+		@Parameters(name = "{0}")
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{
+					{"version 1 keeps the legacy unsuffixed ID", "battery_critical", 1, "battery_critical"},
+					{"version 2 appends _v2", "battery_critical", 2, "battery_critical_v2"},
+					{"later versions keep counting", "battery_warning", 7, "battery_warning_v7"},
+					{"different base IDs stay distinct", "battery_full", 2, "battery_full_v2"},
+					{"defensive: version 0 treated as legacy", "battery_critical", 0, "battery_critical"},
+					{"defensive: negative version treated as legacy", "battery_critical", -3, "battery_critical"},
+			});
+		}
+
+		@Test
+		public void matchesExpected() {
+			assertEquals(label, expected, NotificationChannels.versionedChannelId(baseId, version));
+		}
 	}
 
-	@Test
-	public void matchesExpected() {
-		assertEquals(label, expected, NotificationChannels.versionedChannelId(baseId, version));
+	/**
+	 * The sound each alert channel is created with (#286).
+	 * <p>
+	 * On Android 8+ the channel owns the sound, and {@code createOrUpdateAlertChannel} never set one — so the three
+	 * pickers on Settings › Alerts saved a choice and every alert went on playing the framework default. These pin
+	 * that the pick reaches the channel, and which of the three picks each of the six channels takes.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class ChannelSounds {
+
+		private Context context;
+		private NotificationManager manager;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+			manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+			pickSounds(context, PICKED_CRITICAL, PICKED_WARNING, PICKED_FULL);
+		}
+
+		@Test
+		public void criticalChannel_playsTheCriticalPick() {
+			NotificationChannels.ensureChannels(context);
+
+			assertEquals(Uri.parse(PICKED_CRITICAL), soundOf(NotificationChannels.CHANNEL_ID_CRITICAL));
+		}
+
+		@Test
+		public void warningChannel_playsTheWarningPick() {
+			NotificationChannels.ensureChannels(context);
+
+			assertEquals(Uri.parse(PICKED_WARNING), soundOf(NotificationChannels.CHANNEL_ID_WARNING));
+		}
+
+		@Test
+		public void fullChannel_playsTheFullPick() {
+			NotificationChannels.ensureChannels(context);
+
+			assertEquals(Uri.parse(PICKED_FULL), soundOf(NotificationChannels.CHANNEL_ID_FULL));
+		}
+
+		@Test
+		public void temperatureChannel_sharesTheCriticalPick() {
+			NotificationChannels.ensureChannels(context);
+
+			// Overheating is the critical bucket's second member (#223): "act now", same as a critically low battery.
+			assertEquals(Uri.parse(PICKED_CRITICAL), soundOf(NotificationChannels.CHANNEL_ID_TEMPERATURE));
+		}
+
+		@Test
+		public void fastDrainChannel_sharesTheWarningPick() {
+			NotificationChannels.ensureChannels(context);
+
+			// The two rate alerts belong to the warning bucket. They reached the critical pref by accident before, which
+			// is the half of #286 that was a mapping bug rather than missing wiring.
+			assertEquals(Uri.parse(PICKED_WARNING), soundOf(NotificationChannels.CHANNEL_ID_FAST_DRAIN));
+		}
+
+		@Test
+		public void slowChargeChannel_sharesTheWarningPick() {
+			NotificationChannels.ensureChannels(context);
+
+			assertEquals(Uri.parse(PICKED_WARNING), soundOf(NotificationChannels.CHANNEL_ID_SLOW_CHARGE));
+		}
+
+		@Test
+		public void silentPick_leavesTheChannelWithNoSound() {
+			// The picker's "Silent" option persists an empty string, which is a choice and not an unset value: parsed
+			// rather than translated it becomes an empty Uri that resolves to nothing at post time.
+			pickSound(context, R.string._pref_key_notifications_full_sound_ringtone, "");
+
+			NotificationChannels.ensureChannels(context);
+
+			assertNull(soundOf(NotificationChannels.CHANNEL_ID_FULL));
+		}
+
+		@Test
+		public void unpickedSound_fallsBackToTheDeviceDefault() {
+			clearSounds(context);
+
+			NotificationChannels.ensureChannels(context);
+
+			final Uri deviceDefault = Uri.parse(context.getString(R.string._default_notification_sound_uri));
+			assertEquals(deviceDefault, soundOf(NotificationChannels.CHANNEL_ID_CRITICAL));
+		}
+
+		@Test
+		public void alertSound_playsUnderNotificationUsage() {
+			NotificationChannels.ensureChannels(context);
+
+			// USAGE_NOTIFICATION, not USAGE_ALARM: the channel's sound has to be the one the system silences in DND and
+			// silent mode, because that is exactly when AlertSounds' override-silent path takes over. Both firing at once
+			// is the double-up #286 has to avoid.
+			final AudioAttributes attributes = channel(NotificationChannels.CHANNEL_ID_CRITICAL).getAudioAttributes();
+			assertEquals(AudioAttributes.USAGE_NOTIFICATION, attributes.getUsage());
+			assertEquals(AudioAttributes.CONTENT_TYPE_SONIFICATION, attributes.getContentType());
+		}
+
+		@Test
+		public void quietHoursChannel_staysSilentWhateverIsPicked() {
+			NotificationChannels.ensureChannels(context);
+
+			// The quiet-hours channel is where an alert is rerouted outside the notification window (#111). A sound pick
+			// must not follow it there.
+			assertNull(manager.getNotificationChannel(NotificationChannels.CHANNEL_ID_ALERTS_SILENT).getSound());
+		}
+
+		private Uri soundOf(String baseChannelId) {
+			return channel(baseChannelId).getSound();
+		}
+
+		private NotificationChannel channel(String baseChannelId) {
+			return manager.getNotificationChannel(NotificationChannels.channelFor(context, true, baseChannelId));
+		}
+	}
+
+	/**
+	 * A changed pick has to re-version the channels to take effect (#153/#286).
+	 * <p>
+	 * A channel's sound is fixed when it is created, and Android un-deletes a channel recreated under the same ID with
+	 * its old settings — so without the version bump the new pick is stored, shown in the summary, and ignored. That is
+	 * how the Vibrate toggle failed before #153, and how a sound pick would fail with the wiring alone.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class SettingChangesReVersion {
+
+		private Context context;
+		private NotificationManager manager;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+			manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+			clearSounds(context);
+			NotificationChannels.ensureChannels(context);
+		}
+
+		@Test
+		public void changedPick_bumpsTheChannelVersion() {
+			pickSound(context, R.string._pref_key_notifications_alert_sound_ringtone, PICKED_CRITICAL);
+
+			NotificationChannels.refreshAlertChannels(context);
+
+			assertEquals(2, PreferenceManager.getDefaultSharedPreferences(context).getInt("alert_channel_version", 1));
+		}
+
+		@Test
+		public void changedPick_recreatesTheChannelsUnderTheNewIds() {
+			pickSound(context, R.string._pref_key_notifications_alert_sound_ringtone, PICKED_CRITICAL);
+
+			NotificationChannels.refreshAlertChannels(context);
+
+			final String newId = NotificationChannels.channelFor(context, true, NotificationChannels.CHANNEL_ID_CRITICAL);
+			assertNotEquals("the alert must move off the ID whose settings the system froze", NotificationChannels.CHANNEL_ID_CRITICAL, newId);
+			assertEquals(Uri.parse(PICKED_CRITICAL), manager.getNotificationChannel(newId).getSound());
+		}
+
+		@Test
+		public void changedPick_leavesNoOrphanBehindInSystemSettings() {
+			pickSound(context, R.string._pref_key_notifications_alert_sound_ringtone, PICKED_CRITICAL);
+
+			NotificationChannels.refreshAlertChannels(context);
+
+			assertNull(manager.getNotificationChannel(NotificationChannels.CHANNEL_ID_CRITICAL));
+		}
+
+		@Test
+		public void everySoundPickIsAChannelSetting() {
+			assertTrue(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_notifications_alert_sound_ringtone)));
+			assertTrue(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_notifications_warning_sound_ringtone)));
+			assertTrue(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_notifications_full_sound_ringtone)));
+		}
+
+		@Test
+		public void theVibrateToggleIsStillAChannelSetting() {
+			assertTrue(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_notifications_vibrate)));
+		}
+
+		@Test
+		public void anUnrelatedPreferenceIsNot() {
+			// Every preference change on the screen comes through here, so a re-version for one that changes nothing about
+			// the channels would reset the user's per-channel tweaks for nothing.
+			assertFalse(NotificationChannels.affectsAlertChannels(context, key(R.string._pref_key_charge_target)));
+			assertFalse(NotificationChannels.affectsAlertChannels(context, null));
+		}
+
+		private String key(int keyRes) {
+			return context.getString(keyRes);
+		}
+	}
+
+	/**
+	 * Store all three sound picks.
+	 *
+	 * @param context  the test's application context
+	 * @param critical the critical bucket's pick
+	 * @param warning  the warning bucket's pick
+	 * @param full     the full-charge bucket's pick
+	 */
+	private static void pickSounds(Context context, String critical, String warning, String full) {
+		pickSound(context, R.string._pref_key_notifications_alert_sound_ringtone, critical);
+		pickSound(context, R.string._pref_key_notifications_warning_sound_ringtone, warning);
+		pickSound(context, R.string._pref_key_notifications_full_sound_ringtone, full);
+	}
+
+	/**
+	 * Store one sound pick, the way the ringtone picker does.
+	 *
+	 * @param context  the test's application context
+	 * @param keyRes   the pick's preference key
+	 * @param soundUri the URI to store; empty for the picker's "Silent" option
+	 */
+	private static void pickSound(Context context, int keyRes, String soundUri) {
+		PreferenceManager.getDefaultSharedPreferences(context).edit().putString(context.getString(keyRes), soundUri).commit();
+	}
+
+	/**
+	 * Leave every sound unpicked, as on a fresh install.
+	 *
+	 * @param context the test's application context
+	 */
+	private static void clearSounds(Context context) {
+		PreferenceManager.getDefaultSharedPreferences(context)
+		                 .edit()
+		                 .remove(context.getString(R.string._pref_key_notifications_alert_sound_ringtone))
+		                 .remove(context.getString(R.string._pref_key_notifications_warning_sound_ringtone))
+		                 .remove(context.getString(R.string._pref_key_notifications_full_sound_ringtone))
+		                 .commit();
 	}
 }

--- a/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/almothafar/simplebatterynotifier/service/NotificationServiceTest.java
@@ -22,12 +22,14 @@ import org.junit.runners.Parameterized.Parameters;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -225,6 +227,62 @@ public class NotificationServiceTest {
 			assertTrue(text, text.contains("واط"));
 			assertTrue(text, text.contains("18"));
 			assertTrue("Eastern digits leaked into the charge-connected message: " + text, !text.contains("١٨"));
+		}
+	}
+
+	/**
+	 * Quiet hours still swallow the sound, whatever the user picked (#111/#286).
+	 * <p>
+	 * The picks reach the alert channels now, while outside the notification window an alert is rerouted to the shared
+	 * silent channel instead — so a pick has to stay behind on the channel it was set on. One that followed the alert
+	 * onto the quiet-hours channel would ding at 3am on exactly the alerts quiet hours exist to silence.
+	 */
+	@RunWith(RobolectricTestRunner.class)
+	@Config(sdk = 34)
+	public static class QuietHoursRouting {
+
+		private Context context;
+		private NotificationManager manager;
+
+		@Before
+		public void setUp() {
+			context = ApplicationProvider.getApplicationContext();
+			shadowOf((Application) context).grantPermissions(Manifest.permission.POST_NOTIFICATIONS);
+			manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+			// A loud pick, and a one-minute notification window starting two minutes from now — so "now" is outside it
+			// whatever time of day the suite runs at, without the test having to freeze the clock.
+			final LocalTime windowStart = LocalTime.now().plusMinutes(2);
+			PreferenceManager.getDefaultSharedPreferences(context)
+					.edit()
+					.putString(context.getString(R.string._pref_key_notifications_alert_sound_ringtone), "content://media/internal/audio/media/101")
+					.putBoolean(context.getString(R.string._pref_key_notifications_time_range), true)
+					.putString(context.getString(R.string._pref_key_notifications_time_range_start), asHourMinute(windowStart))
+					.putString(context.getString(R.string._pref_key_notifications_time_range_end), asHourMinute(windowStart.plusMinutes(1)))
+					.commit();
+		}
+
+		@Test
+		public void alertOutsideTheWindow_postsOnTheSilentChannel() {
+			NotificationService.sendTemperatureNotification(context, 460);
+
+			assertEquals(NotificationChannels.CHANNEL_ID_ALERTS_SILENT, postedChannelId());
+		}
+
+		@Test
+		public void theChannelItLandsOn_playsNothing() {
+			NotificationService.sendTemperatureNotification(context, 460);
+
+			assertNull("a sound pick must not follow an alert onto the quiet-hours channel",
+					manager.getNotificationChannel(postedChannelId()).getSound());
+		}
+
+		private String postedChannelId() {
+			return shadowOf(manager).getAllNotifications().get(0).getChannelId();
+		}
+
+		private static String asHourMinute(LocalTime time) {
+			return String.format(Locale.ROOT, "%02d:%02d", time.getHour(), time.getMinute());
 		}
 	}
 


### PR DESCRIPTION
Closes #286.

## What was wrong

`createOrUpdateAlertChannel` never called `setSound()`, so all six alert channels were created with the framework default and the three per-severity pickers on **Settings › Alerts** saved a choice that changed nothing audible. The saved URI *was* read, but only ever reached `AlertSounds.playAlarm`, which plays under `ignoreSilent && (ringer != RINGER_MODE_NORMAL || DND)` — the narrow override-silent path. In normal ringer mode, the ordinary case, `playAlarm` returns without playing and the channel's default sound is what the user hears.

## The fix

**1. The channels carry the pick.** Each channel is created with `setSound(uri, attrs)` under `USAGE_NOTIFICATION` + `CONTENT_TYPE_SONIFICATION`. That usage is the point, not a detail: `playAlarm` only runs when the ringer is silenced or DND is on, and those are exactly the conditions in which a `USAGE_NOTIFICATION` sound is suppressed — so in normal ringer mode, silent mode and DND alike, one of the two plays and never both.

**2. A changed pick re-versions the channels.** A channel's sound is frozen at creation and Android un-deletes a same-ID channel with its old settings, which is why #153 versions the IDs. Sound picks route through the same re-version as the Vibrate toggle, via `NotificationService.refreshAlertChannelsIfAffected` — one call, so the settings screen has no decision left to get wrong and the whole path is covered by one test.

**3. Installs that predate the wiring are re-versioned once.** Without this the fix is inert for exactly the population #286 describes: their channels were created before the code called `setSound` at all, and a user who already picked a sound has no reason to pick again. The channels carry a *definition generation* alongside the settings version, and `ensureChannels` re-versions once when this build's generation is newer. It is a separate preference deliberately — the settings version counts the user's own changes, so a long-standing install already reads 2 or more and a "version below 2" test would skip the oldest installs, which are the likeliest to have picked a sound years ago. The cost is one re-version on upgrade, which resets any per-channel tweaks made in system settings.

**4. The picker-less alerts get a defined bucket.** Temperature, fast-drain and slow-charge reached the critical pref by accident. They now take the severity buckets #223 designs its bundled sounds around: overheating joins the critical level, the two rate alerts join low battery.

**5. "Silent" means the same thing on both paths.** The picker persists it as an empty string; `AlertSounds.soundUriOrSilent` is what both the channel and `playAlarm` read it through, so it becomes `setSound(null, …)` on one side and "nothing to play" on the other rather than an empty `Uri` that resolves to nothing at post time. A Silent pick still vibrates when the user asked for vibration, matching `enableVibration(true)` on a soundless channel.

The six channels are one table of `(base id, name, description, LED colour, sound bucket)` iterated everywhere they are needed. They used to be spelled out three times over — created, deleted on refresh, and mapped to a sound — so adding one meant remembering all three, and forgetting the deletion left an orphan in the user's system settings.

## Tests

- Each of the six channels is created carrying the pick from its own bucket, under `USAGE_NOTIFICATION`.
- "Silent" leaves the channel with no sound; an unpicked sound falls back to the device default.
- A pre-#286 install starts playing its existing pick without touching a setting, its old channels are not left behind, and the migration runs once rather than on every alert — including for an install already on a higher settings version from an earlier Vibrate toggle.
- A changed pick re-versions the channels through the one call the settings screen makes, recreates all six, and leaves no orphan among any of them; an unrelated preference leaves the version alone.
- An alert outside the notification window still lands on the silent quiet-hours channel, and no pick follows it there.

## Known limit

The channel/`playAlarm` split covers normal ringer mode, silent mode and DND. A user who has explicitly allowed this app's channel through Do Not Disturb in system settings can still get both at once: the channel sounds under a priority filter that `AlertSounds` reads as DND. The app cannot take that override back — it is the user's setting, and `setBypassDnd(false)` would only restate the default the channel already has.

## Left for #223

The picker labels still read "Critical / Warning / Full Level Sound" while three of them now also govern temperature, fast-drain and slow-charge. #223 owns the picker UI and collapses the six channels into three labelled buckets; renaming them here would mean new strings and Arabic copy for a screen that is about to be replaced.

## Verification

Unit tests, lint and both APK builds are green in CI for the first commit; the review follow-up is running now. Nothing was run locally — this container has no Android SDK and JDK 21 rather than 25 — so CI is the only execution these changes have had.
